### PR TITLE
Překlad pomocí XeTeX nonstopmode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - "pip install -r requirements.txt"
   - "sudo apt-get install texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-xetex"
   - "sudo ln -s /usr/share/i18n/SUPPORTED /var/lib/locales/supported.d/all"
-  - "sudo locale-gen"
+  - "sudo locale-gen cs_CZ.UTF-8"
 script:
   - "snakemake -p -s Snakefile.test"
   - "snakemake -p -s Snakefile.2pedro"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# Použití:
+#   make ... přeloží všechny zpěvníky (sériově)
+#   make test ... přeloží Snakefile.test
+#   make TP2011 TP2012 ... přeloží TP2011 a TP2012
+#   make clean ... smaže všechny vygenerované soubory
+
+Zpevniky = $(patsubst Snakefile.%,%,$(wildcard Snakefile.*))
+
+.PHONY:	all clean cleanall $(Zpevniky)
+
+all:	$(Zpevniky)
+
+$(Zpevniky):
+	snakemake -s Snakefile.$@ --cores
+
+clean:
+	git clean -fxd .

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -121,9 +121,6 @@ rule main_pdf:
 		[sc_tex(x) for x in songs_dict.keys()],
 		workflow.snakefile,
 	run:
-		volat_xelatex_dvakrat=False
-		xelatex_zavolan=0
-
 		if not os.path.isfile(ind_pisne()) or not os.path.isfile(ind_interpreti()):
 			call_xelatex(input[0])
 			udelejRejstrik(idx_pisne(),ind_pisne()); 
@@ -168,11 +165,10 @@ rule main_tex:
 				os.linesep.join(["\\def\\{}{{}}".format(x) for x in options]) \
 				+ r"""
 				\usepackage[czech]{babel}
-				\usepackage{pdfpages}
+				\usepackage{calc}
 				\usepackage{fancyhdr}
 				\usepackage{fontspec}
 				\usepackage[chordbk]{songbook}
-				\usepackage{refcount}
 				\usepackage[xetex,pdfpagelabels=false]{hyperref}
 				\usepackage{forloop}
 

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -46,14 +46,14 @@ def idx_interpreti():
 
 def call_xelatex(xelatex_file):
 	if platform.system()=="Windows":
-		xelatex_command = """xelatex -include-directory "{dir}" -aux-directory "{dir}" -output-directory "{dir}" "{texfile}" """.format(
+		xelatex_command = """xelatex -interaction nonstopmode -include-directory "{dir}" -aux-directory "{dir}" -output-directory "{dir}" "{texfile}" """.format(
 				dir=os.path.basedir(xelatex_file),
 				texfile=xelatex_file,
 			)
 	else:
 		xelatex_command = """
 			cd "{dir}"
-			xelatex "{texfile}"
+			xelatex -interaction nonstopmode "{texfile}"
 			""".format(
 				dir=os.path.dirname(xelatex_file),
 				texfile=os.path.basename(xelatex_file),


### PR DESCRIPTION
Snakemake podle jeho autora není připravený pro vstup z terminálu. Proto je potřeba volat TeX tak, aby se na chybách nezastavoval. Při překladu jednotlivých souborů to fungovalo, ale ve smyslu úvodní věty je to nejspíš nějaká shoda okolností a tudíž časovaná bomba. Snakemake vypíše při chybě hromadu informací, ale mezi nimi, aby se člověk podíval nahoru. Což když udělá, najde tam TeX chybu poměrně snadno, například:

```
! 

**Chyby zarovnání dvoustran u písní:**
  Muzeum

Překlad nyní skončí chybou. Opravte konflikty a spusťte znovu, případně,
jestliže chcete tuto kontrolu vypnout, přidejte options = [ "ONESIDE" ]
nebo options = [ "SKIPCHECK" ].
l.142 }

(./_muj_novy_zpevnik.aux)

LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right.

 )
(see the transcript file for additional information)
Output written on _muj_novy_zpevnik.pdf (6 pages).
Transcript written on _muj_novy_zpevnik.log.
Error in job main_pdf while creating output files _muj_novy_zpevnik.pdf, cache.muj_novy_zpevnik/_muj_novy_zpevnik.ind_pisne, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_pisne, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_pisne.old, cache.muj_novy_zpevnik/_muj_novy_zpevnik.ind_interpreti, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_interpreti.
RuleException:
CalledProcessError in line 61 of /home/vasek/misc/zpevniky/tp/pisnicky/tpcb/snake_incl.py:
Command '
            cd "cache.muj_novy_zpevnik"
            xelatex -interaction nonstopmode "_muj_novy_zpevnik.tex"
            ' returned non-zero exit status 1
  File "/home/vasek/misc/zpevniky/tp/pisnicky/tpcb/snake_incl.py", line 134, in __main_pdf
  File "/home/vasek/misc/zpevniky/tp/pisnicky/tpcb/snake_incl.py", line 61, in call_xelatex
Removing output files of failed job main_pdf since they might be corrupted:
_muj_novy_zpevnik.pdf, cache.muj_novy_zpevnik/_muj_novy_zpevnik.ind_pisne, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_pisne, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_pisne.old, cache.muj_novy_zpevnik/_muj_novy_zpevnik.ind_interpreti, cache.muj_novy_zpevnik/_muj_novy_zpevnik.idx_interpreti
Will exit after finishing currently running jobs.
Exiting because a job execution failed. Look above for error message
```

Vrátil jsem hlavní `Snakefile`, protože tím pádem je v pořádku. V `Readme.md` jsem jím nahradil stávající instrukci na `zkompiluj_vse_seriove.sh`. Pro svoje účely jsem taky udělal „normální“ `Makefile` – nikde se o něm nezmiňuji, ale nevidím důvod, proč se nepodělit.
