### PR TITLE
Možnost překladu not pomocí lilypond-book (fixes #38)

### DIFF
--- a/Snakefile.test
+++ b/Snakefile.test
@@ -6,9 +6,14 @@ chordbook="muj_novy_zpevnik"
 #cover_front="obalka_predni.pdf"
 #cover_back="obalka_zadni.pdf"
 
+# Takto lze přidávat volby (ONESIDE, NOHEADER, SKIPCHECK, TPBAND, MUSIC).
+# Odstraňte # před následující řádkou, jestli chcete, aby se u Love me do zobrazily (pokusné) noty.
+
+#options=["MUSIC"]
+
 songs=[
     ("./tp-songs/03_zahranicni/Beatles____Let_it_be.tex", 5), # 5 = transpozice o 5 půltónů nahoru
-    "./tp-songs/03_zahranicni/Beatles____Love_me_do.tex",
+    "./tp-songs/03_zahranicni/Beatles____Love_me_do.lytex",
 ]
 
 include:"tpcb/snake_incl.py"

--- a/tp-songs/03_zahranicni/Beatles____Love_me_do.lytex
+++ b/tp-songs/03_zahranicni/Beatles____Love_me_do.lytex
@@ -1,0 +1,63 @@
+% -*-coding: utf-8 -*-
+
+\zp{Love me do}{Beatles}
+
+\begin{lilypond}
+\relative c' {c d e}
+\end{lilypond}
+
+\zs
+
+\Ch{G}{Love}, love me \Ch{C}{do},
+you \Ch{G}{know} I love \Ch{C}{you}
+
+I'll \Ch{G}{always} be \Ch{C}{true,}
+so \Ch{C}{pleeeeee}\Ch{C/G}{ase}...
+
+Love me \Ch{G}{do}
+\ks
+
+\zs
+Love, love me do,
+you know I love you
+
+I'll always be true,
+so pleeeeeease...
+
+Love me do
+\ks
+\zr
+
+\Ch{D}{Someone} to love, \Ch{C}{some}\Ch{F}{body} \Ch{G}{new}
+
+\Ch{D}{Someone} to love, \Ch{C}{some}\Ch{F}{one} like \Ch{G}{you}
+\kr
+\zs
+Love, love me do,
+you know I love you
+
+I'll always be true,
+so pleeeeeease...
+
+Love me do
+\ks
+\zs
+Love, love me do,
+you know I love you
+
+I'll always be true,
+so pleeeeeease...
+
+Love me do
+\ks
+
+
+\Ch{G}{Love} me \Ch{C}{do}, yeah, \Ch{G}{love} me \Ch{C}{do,}
+yeah, \Ch{G}{love} me \Ch{C}{do}...
+
+\kp
+
+
+
+
+

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -34,6 +34,8 @@ def cb_ind():
 def sc_tex(song):
 	return os.path.join(cache_dir(),"0_{}.tex".format(song))
 
+def sc_lytex(song):
+	return os.path.join(cache_dir(),"0_{}.lytex".format(song))
 
 def ind_pisne():
 	return cb_ind()+"_pisne"
@@ -88,14 +90,14 @@ for x in songs:
 		songs_prop.append((
 			x,
 			0,
-			os.path.basename(x).replace(".tex","")
+			os.path.basename(x).replace(".tex","").replace(".lytex","")
 		))
 	# transposition ... must be a list
 	else:
 		songs_prop.append((
 			x[0],
 			int(x[1]),
-			os.path.basename(x[0]).replace(".tex","")
+			os.path.basename(x[0]).replace(".tex","").replace(".lytex","")
 		))
 
 songs_dict = OrderedDict(
@@ -109,6 +111,11 @@ songs_dict_transp = OrderedDict(
 					(x[2],x[1]) for x in songs_prop
 				]
 			)
+
+# Jestli jsou požadovány noty, zkontrolovat, zda máme lilypond-book
+if "MUSIC" in options:
+	if None == shutil.which("lilypond-book"):
+		raise Exception("lilypond-book není na vašem systému nainstalován, noty nelze překládat!")
 
 # zpevnik.tex => zpevnik.pdf
 rule main_pdf:
@@ -186,8 +193,8 @@ rule main_tex:
 		shutil.copyfile(os.path.join("tpcb","template.tex"),os.path.join(cache_dir(),"template.tex"))
 		shutil.copyfile(os.path.join("tpcb","songbook.sty"),os.path.join(cache_dir(),"songbook.sty"))
 
-# o1/pisen.tex   =>  cache/pisen.tex
-# o2/pisen2.tex  =>  cache/pisen2.tex
+# o1/pisen.(ly)tex   =>  cache/pisen.tex
+# o2/pisen2.(ly)tex  =>  cache/pisen2.tex
 rule song_tex:
 	output:
 		sc_tex("{song}"),
@@ -195,10 +202,13 @@ rule song_tex:
 		lambda wildcards: songs_dict[wildcards.song],
 		workflow.snakefile
 	run:
-		song=""
-		song2=""
 		with open(input[0],"r",encoding="utf-8") as f:
 			song=f.read()
 			song2=transposition_song(song,songs_dict_transp[wildcards.song])
-		with open(output[0],"w+",encoding="utf-8") as f:
-			f.write(song2)
+		if ".lytex" in input[0] and "MUSIC" in options:
+			with open(sc_lytex(wildcards.song),"w+",encoding="utf-8") as f:
+				f.write(song2)
+			shell("lilypond-book --format=latex --output="+cache_dir()+" "+sc_lytex(wildcards.song))
+		else:
+			with open(output[0],"w+",encoding="utf-8") as f:
+				f.write(song2)

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -10,6 +10,7 @@
 \usepackage[chordbk]{songbook}
 \usepackage[xetex,pdfpagelabels=false,pdfborder={0 0 0}]{hyperref}
 \usepackage{forloop}
+\usepackage{verbatim}
 
 \newindex[cisloPisne]{default}{idx_pisne}{ind_pisne}{Rejstřík písní}
 \newindex[cisloPisne]{interpreti}{idx_interpreti}{ind_interpreti}{Rejstřík interpretů}
@@ -98,6 +99,8 @@
 }
 
 \newcommand\emptyPage{\shipout\vbox to \vsize{\hbox to \hsize{\hss}\vss}\stepcounter{page}}
+
+\newenvironment{lilypond}{\comment}{\endcomment} % Ignorovat lilypond, pokud zbude v .tex
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
`options = [ "MUSIC" ]` zapne možnost vkládání not pomocí `lilypond-book`. Jestliže program není nainstalovaný, Snakemake to hned ze začátku oznámí a skončí. V případě absence `MUSIC` se bloky `lilypond` ignorují. Překlad probíhá u souborů, které mají příponu `lytex`.

Ve `Snakefile.test` je příklad. K "Love me do" jsem pokusně přidal noty _C-D-E_ (v novém souboru `Beatles____Love_me_do.lytex`, existující jsem neměnil). Překlad ostatních zpěvníků to neovlivní. Postupem času se může nahradit nějakým smysluplnějším příkladem.
