### PR TITLE
Drobné opravy v tpcb

### DIFF
--- a/tpcb/index.py
+++ b/tpcb/index.py
@@ -64,7 +64,7 @@ def udelejRejstrik(vstup, vystup):
 			strana = strana.replace("}","")
 			zac = rozp[0] 
 		
-			zac = zac.replace("\\indexentry {","")
+			zac = zac.replace("\\indexentry {","").replace("|hyperpage","")
 			
 			zac = zac.split("!")
 			

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -2,15 +2,15 @@
   \ifdefined\ONESIDE,oneside\fi%
 ]{book}
 
-\usepackage[czech]{babel}
+\usepackage{fontspec}
+\usepackage{index}
 \usepackage{calc}
 \usepackage{fancyhdr}
-\usepackage{fontspec}
+\usepackage[czech]{babel}
 \usepackage[chordbk]{songbook}
-\usepackage[xetex,pdfpagelabels=false]{hyperref}
+\usepackage[xetex,pdfpagelabels=false,pdfborder={0 0 0}]{hyperref}
 \usepackage{forloop}
 
-\usepackage{index}
 \newindex[cisloPisne]{default}{idx_pisne}{ind_pisne}{Rejstřík písní}
 \newindex[cisloPisne]{interpreti}{idx_interpreti}{ind_interpreti}{Rejstřík interpretů}
 
@@ -97,7 +97,7 @@
   \fi
 }
 
-\newcommand\emptyPage{\shipout\vbox to \vsize{\hbox to \hsize{}}\stepcounter{page}}
+\newcommand\emptyPage{\shipout\vbox to \vsize{\hbox to \hsize{\hss}\vss}\stepcounter{page}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -134,6 +134,10 @@
 % Kontrola dvojstránek probíhá v rámci \zs, takže pro poslední písničku ji 
 % musíme zavolat ručně
 \twopagecheck
+
+% Hot Fix: přebít \thispagestyle{plain} z index.sty, způsobuje čísla stránek
+% na první stránce rejstříku
+\renewcommand\thispagestyle[1]{}
 
 % Rejstřík podle interpretů
 \fancyfoot{}


### PR DESCRIPTION
1) vypnout čísla stránek _opravdu_ všude (fixes #41)
2) přeházeno pořadí balíčků a jeden nový (fixes "Command \markright has
changed", "Command \markboth has changed" apod.)
3) vypnout škaredé červené okraje kolem položek v rejstříku (nebude nijak
označené, že to jsou odkazy, ale fungují pořád)
4) upraveno \emptypage (fixes "Underfull \vbox (badness 10000) detected at
line ...")
