### PR TITLE
Nový formát akordů

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -164,10 +164,10 @@ Dodržujte, prosím, logiku celého zpěvníku:
 * ```\kr``` - konec refrénu
 * ```\zs``` - začátek sloky
 * ```\ks``` - konec sloky
-* ```\Ch{Dmi}{Text, nad kterým bude akord}``` - akord
+* ```<Dmi>Text, nad kterým bude akord``` - akord
 
 ### Poznámky
 
 * Používejte evropskou hudební notaci (*B* = *A#*).
 * Pro mollové akordy používejte *mi*, tedy např. *Ami*.
-* Do jedné značky ```\Ch``` vkládejte právě jeden akordy (pokud jich tam bude více, program ohlásí neznámý formát akordové značky).
+* Do jedné značky ```<...>``` vkládejte právě jeden akordy (pokud jich tam bude více, program ohlásí neznámý formát akordové značky).

--- a/Snakefile.2pedro
+++ b/Snakefile.2pedro
@@ -62,7 +62,7 @@ songs=[
 	"./tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Cukrářská_bossanova.tex",
-	#"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macbre.tex",
+	#"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Divoké_koně.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Hlídač_krav.tex",

--- a/Snakefile.TP2012
+++ b/Snakefile.TP2012
@@ -49,7 +49,7 @@ songs=[
 	"./tp-songs/01_folk/Jarek_Nohavica____Osmá_barva_duhy.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex",
-	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macbre.tex",
+	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Jdou_po_mně_jdou.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Kometa.tex",

--- a/Snakefile.TP2013
+++ b/Snakefile.TP2013
@@ -42,7 +42,7 @@ songs=[
 	"./tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Cukrářská_bossanova.tex",
-	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macbre.tex",
+	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Jdou_po_mně_jdou.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Kometa.tex",

--- a/Snakefile.TP2015
+++ b/Snakefile.TP2015
@@ -45,7 +45,7 @@ songs=[
 	"./tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Cukrářská_bossanova.tex",
-	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macbre.tex",
+	"./tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Jdou_po_mně_jdou.tex",
 	"./tp-songs/01_folk/Jarek_Nohavica____Kometa.tex",

--- a/konverze.sed
+++ b/konverze.sed
@@ -1,0 +1,22 @@
+# Jestli řádek končí neuzavřenou {, schováme si ho a přidáme před zpracováním k dalšímu řádku.
+# Znak konce řádku zůstane zachovaný. Pak se skript resetuje a načte další řádku.
+/{[^}]*/H
+/{[^}]*/d
+# Jestli jsme došli sem, jsme balancovaní. I nová řádka se přidá k bufferu...
+H
+# ...a celý buffer vezmeme za vstup.
+g
+# Hlavní náhrada \Ch{a}{b} -> [a]b
+s/\\Ch\s*{\([^}]*\)}\s*{\([^}]*\)}/<\1>\2/g
+s/\\Ch\s*{\([^}]*\)}/<\1>/g
+# Několik mezer -> jedna mezera
+s/ \{2,\}/ /g
+# Odstraníme případný znak konce řádku na jeho začátku a vypíšeme.
+s/^\n//
+p
+# Buffer vyprázdníme. Tohle způsobí, že před další načtenou řádkou bude řádka 
+# prázdná, ale o to je postaráno o dva příkazy výš.
+s/.*//g
+h
+# Všechno smazat a hurá zpátky na začátek.
+d

--- a/tp-songs/01_folk/Argema____Jarošovský_pivovar.tex
+++ b/tp-songs/01_folk/Argema____Jarošovský_pivovar.tex
@@ -3,23 +3,23 @@
 \zp{Jarošovský pivovar}{Argema}
 
 \zs
-\Ch{E}{Léta} tam \Ch{H}{stál,} \Ch{A}{stojí} tam \Ch{E}{dál,}
+<E>Léta tam <H>stál, <A>stojí tam <E>dál,
 
-pivovar \Ch{H}{u cesty,} \Ch{A}{každý} ho \Ch{H}{znal.}
+pivovar <H>u cesty, <A>každý ho <H>znal.
 
-\Ch{E}{Léta} tam \Ch{H}{stál}, \Ch{A}{stát} bude \Ch{E}{dál,}
+<E>Léta tam <H>stál, <A>stát bude <E>dál,
 
-ten, kdo zná \Ch{H}{Jar}ošov, \Ch{A}{zná} pi\Ch{H}{vov}\Ch{E}{ar.}
+ten, kdo zná <H>Jarošov, <A>zná pi<H>vov<E>ar.
 \ks
 
 \zr
-\Ch{A}{Bílá} \Ch{H}{pěna,} \Ch{E}{láhev} oro\Ch{C#mi}{sená,}
+<A>Bílá <H>pěna, <E>láhev oro<C#mi>sená,
 
-\Ch{A}{chme}lový \Ch{H}{nekt}ar já \Ch{E}{znám,}
+<A>chmelový <H>nektar já <E>znám,
 
-\Ch{A}{jen} jsem to \Ch{H}{zkusil} a \Ch{E}{jednou} se \Ch{C#mi}{napil,}
+<A>jen jsem to <H>zkusil a <E>jednou se <C#mi>napil,
 
-\Ch{A}{od} těch dob \Ch{H}{žízeň} \Ch{E}{mám.}
+<A>od těch dob <H>žízeň <E>mám.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Asonance____Čarodějnice_z_Amesbury.tex
+++ b/tp-songs/01_folk/Asonance____Čarodějnice_z_Amesbury.tex
@@ -3,13 +3,13 @@
 \zp{Čarodějnice z Amesbury}{Asonance}
 
 \zs
-Zuzana \Ch{Dmi}{byla} dívka, \Ch{C}{která} žila v \Ch{Dmi}{Amesbury},
+Zuzana <Dmi>byla dívka, <C>která žila v <Dmi>Amesbury,
 
-s jasnýma \Ch{F}{očima} a \Ch{C}{řečmi} pánům \Ch{Dmi}{navzdory},
+s jasnýma <F>očima a <C>řečmi pánům <Dmi>navzdory,
 
-souse\Ch{F}{dé} o ní \Ch{C}{říkali}, že \Ch{Dmi}{temná} kouzla \Ch{Ami}{zná}
+souse<F>dé o ní <C>říkali, že <Dmi>temná kouzla <Ami>zná
 
-a \Ch{B}{že} se lidem \Ch{Ami}{vyhýbá} a s \Ch{B}{ďáblem} \Ch{C}{pletky} \Ch{Dmi}{má.}
+a <B>že se lidem <Ami>vyhýbá a s <B>ďáblem <C>pletky <Dmi>má.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Bratři_Ebenové____Folklóreček.tex
+++ b/tp-songs/01_folk/Bratři_Ebenové____Folklóreček.tex
@@ -5,9 +5,9 @@
 Zahrajte mi muzikanti zvesela, zvesela!
 
 \zs
-\Ch{D}{Slunečko} vychází nad vysokú \Ch{C}{horú},
+<D>Slunečko vychází nad vysokú <C>horú,
 
-\Ch{G}{počítám,} že \Ch{Emi}{večer} \Ch{G}{pude} zase \Ch{A}{do}-\Ch{D}{lu.}
+<G>počítám, že <Emi>večer <G>pude zase <A>do-<D>lu.
 
 Večer pude dolu, zitra pujde znovu,
 
@@ -15,9 +15,9 @@ takhle tu pisničku máme hned hotovú.
 \ks
 
 \zr
-\Ch{A}{Nejvíc} mě ten folkloreček {do}{jí}\Ch{C}{má,}
+<A>Nejvíc mě ten folkloreček {do}{jí}<C>má,
 
-\Ch{G}{když} se hraje \Ch{Emi}{elektricky,} \Ch{G}{elektricky} s \Ch{Emi}{bi-}\Ch{A}{cí}-\Ch{D}{ma}.
+<G>když se hraje <Emi>elektricky, <G>elektricky s <Emi>bi-<A>cí-<D>ma.
 \kr
 
 \zs
@@ -30,7 +30,7 @@ Jede na koničku, jede do vesničky,
 za klobúčkem perko a v ruce husličky.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Zahraj mi Janičku, zahraj na húsličky,
@@ -43,7 +43,7 @@ hned z toho natočil dvě pěkné destičky.
 
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Kdo si to cedečko doma vypaluje,
@@ -55,6 +55,6 @@ Komu tu cedečku najdu na pisičku,
 tomu svu šavličku useknu ručičku.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Bratři_Ebenové____Folklóreček.tex
+++ b/tp-songs/01_folk/Bratři_Ebenové____Folklóreček.tex
@@ -17,7 +17,7 @@ takhle tu pisničku máme hned hotovú.
 \zr
 <A>Nejvíc mě ten folkloreček {do}{jí}<C>má,
 
-<G>když se hraje <Emi>elektricky, <G>elektricky s <Emi>bi-<A>cí-<D>ma.
+<G>když se hraje <Emi>elektricky, <G>elektricky s <Emi>bi<A>cí<D>ma.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Bratři_Ebenové____Nikdo_to_nebere.tex
+++ b/tp-songs/01_folk/Bratři_Ebenové____Nikdo_to_nebere.tex
@@ -2,17 +2,17 @@
 
 \zp{Nikdo to nebere}{Bratři Ebenové}
 
-\Ch{Emi7}{}
-\Ch{A}{}
+<Emi7>
+<A>
 
 \zs
-Ještě se \Ch{D}{svítí} a ještě \Ch{C}{teče} vo\Ch{G}{da,}
+Ještě se <D>svítí a ještě <C>teče vo<G>da,
 
-kdo odpo\Ch{D}{ví} ti a kdo ti \Ch{C}{ruku} po\Ch{G}{dá?}
+kdo odpo<D>ví ti a kdo ti <C>ruku po<G>dá?
 
-Ještě se \Ch{Emi}{vaří} a zdá se, že \Ch{A}{nám} chut\Ch{D}{ná,}
+Ještě se <Emi>vaří a zdá se, že <A>nám chut<D>ná,
 
-\Ch{G}{volaná} \Ch{C}{srdce} jsou dočasně nedo\Ch{D}{stupná.}
+<G>volaná <C>srdce jsou dočasně nedo<D>stupná.
 \ks
 
 \zs
@@ -26,7 +26,7 @@ volaná srdce jsou dočasně nedostupná.
 \ks
 
 \zr
-\Ch{Emi7}{Zvon}\Ch{A}{í to,}   \Ch{Emi7}{~}vyz\Ch{A}{vání}, \Ch{Emi7}{a} \Ch{A}{běda:}    \Ch{Emi7}{~} \Ch{A}{~}
+<Emi7>Zvon<A>í to, <Emi7>~vyz<A>vání, <Emi7>a <A>běda: <Emi7>~ <A>~
 
 nikdo to nebere,
 nikdo se nehlásí,

--- a/tp-songs/01_folk/Bratři_Ebenové____Stýskání.tex
+++ b/tp-songs/01_folk/Bratři_Ebenové____Stýskání.tex
@@ -3,13 +3,13 @@
 \zp{Stýskání}{Bratři Ebenové}
 
 \zs
-\Ch{A}{Stý}ská \Ch{Dmi}{se,} \Ch{Emi}{čern}ovlás\Ch{Hmi}{ko,}
+<A>Stýská <Dmi>se, <Emi>černovlás<Hmi>ko,
 
-\Ch{F#mi}{po lo}uče\Ch{Hmi}{ní,} \Ch{G}{kdy} jsi se \Ch{Ami}{}
+<F#mi>po louče<Hmi>ní, <G>kdy jsi se <Ami>
 
-\Ch{F#mi}{na ram}e\Ch{Hmi}{ni} \Ch{G}{vypl}aka\Ch{C}{la,}
+<F#mi>na rame<Hmi>ni <G>vyplaka<C>la,
 
-\Ch{C}{čern}ovlás\Ch{A}{ko.}\Ch{Emi7}{} \Ch{A}{}
+<C>černovlás<A>ko.<Emi7> <A>
 \ks
 
 \zs
@@ -19,15 +19,15 @@ něžně smála, rozespalá, černovlásko.
 \ks
 
 \zr
-\Ch{Hmi}{Stýs}ká -- \Ch{G}{šest} písmen \Ch{D}{mís}to tvé \Ch{A}{lás}ky,
+<Hmi>Stýská -- <G>šest písmen <D>místo tvé <A>lásky,
 
-\Ch{Emi}{stýs}ká -- \Ch{F#mi}{pláčou} dlou\Ch{Hmi}{hé sa}mo\Ch{F#mi}{hlásky,}
+<Emi>stýská -- <F#mi>pláčou dlou<Hmi>hé samo<F#mi>hlásky,
 
-\Ch{Hmi}{stýs}ká -- \Ch{G}{zůst}ala \Ch{D}{jsi} mi pod \Ch{A}{víčky,}
+<Hmi>stýská -- <G>zůstala <D>jsi mi pod <A>víčky,
 
-\Ch{Hmi}{doho}řel knot svíčky, \Ch{Gmaj7}{uschly} tvé slzičky
+<Hmi>dohořel knot svíčky, <Gmaj7>uschly tvé slzičky
 
-\Ch{Emi7}{a dveří} skřípání nese mi \Ch{A}{stýs}kání.
+<Emi7>a dveří skřípání nese mi <A>stýskání.
 \kr
 
 \zs
@@ -61,9 +61,9 @@ inventura milování, černovlásko.
 \zr \kr
 
 \zr
-\Ch{A}{Stýs}ká se, \Ch{Dmi}{} \Ch{Emi}{}hm, \Ch{Hmi}{}
+<A>Stýská se, <Dmi> <Emi>hm, <Hmi>
 
-\Ch{F#mi}{stýská} se \Ch{Hmi}{mi,} \Ch{G}{hm.} \Ch{A4sus}{}
+<F#mi>stýská se <Hmi>mi, <G>hm. <A4sus>
 \kr
 
 \kp

--- a/tp-songs/01_folk/Bratři_Ebenové____Trampská.tex
+++ b/tp-songs/01_folk/Bratři_Ebenové____Trampská.tex
@@ -3,27 +3,27 @@
 \zp{Trampská}{Bratři Ebenové}
 
 \zs
-\Ch{Dmi}{Mlhavým} ránem bose jdou, kanady vržou na nohou
+<Dmi>Mlhavým ránem bose jdou, kanady vržou na nohou
 
-a dálka tolik vzdále\Ch{G}{ná} je \Ch{Dmi}{blízká},
+a dálka tolik vzdále<G>ná je <Dmi>blízká,
 
 město jsi nechal za zády, zajíci dělaj' rošády
 
-a v křoví někdo tiše \Ch{G}{Vlajku} \Ch{Dmi}{píská},
+a v křoví někdo tiše <G>Vlajku <Dmi>píská,
 
-\Ch{G}{najednou} připadáš si ňák príma, svobodnej a tak,
+<G>najednou připadáš si ňák príma, svobodnej a tak,
 
-prostě \Ch{Dmi}{tak,} tak \Ch{G}{ňák}, ňák \Ch{Dmi}{tak.}
+prostě <Dmi>tak, tak <G>ňák, ňák <Dmi>tak.
 \ks
 
 \zr
-Pojď \Ch{F}{dál}, s náma se nenudíš, pojď dál, ráno se probudíš
+Pojď <F>dál, s náma se nenudíš, pojď dál, ráno se probudíš
 
-a vedle sebe máš o šišku \Ch{Dmi}{víc,}
+a vedle sebe máš o šišku <Dmi>víc,
 
-pojď \Ch{F}{dál}, pod sebou pevnou zem, pojď dál, a Číro s Melounem,
+pojď <F>dál, pod sebou pevnou zem, pojď dál, a Číro s Melounem,
 
-a Meky, Miky, Vrt -- a dál už \Ch{G}{nic}, dál už \Ch{Dmi}{nic.}
+a Meky, Miky, Vrt -- a dál už <G>nic, dál už <Dmi>nic.
 \kr
 
 \zs
@@ -40,7 +40,7 @@ důležitý je to, co jseš, odkud jsi přišel a kam jdeš,
 co jseš, kam jdeš, co jseš.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Brontosauři____Franky_Dlouhán.tex
+++ b/tp-songs/01_folk/Brontosauři____Franky_Dlouhán.tex
@@ -3,10 +3,10 @@
 \zp{Franky Dlouhán}{Brontosauři}
 
 \zs
-\Ch{C}{Kolik} je smutného,
-když \Ch{F}{mraky} černé \Ch{C}{jdou}
+<C>Kolik je smutného,
+když <F>mraky černé <C>jdou
 
-lidem nad \Ch{G}{hlavou,} \Ch{F}{smu}tnou dála\Ch{C}{vou.}
+lidem nad <G>hlavou, <F>smutnou dála<C>vou.
 
 Já slyšel příběh, který velkou pravdu měl,
 
@@ -14,18 +14,18 @@ za čas odletěl, každý zapomněl.
 \ks
 
 \zr
-\Ch{C}{Měl} kapsu \Ch{G}{prázdnou} Franky Dlouhán,
+<C>Měl kapsu <G>prázdnou Franky Dlouhán,
 
-po Státech \Ch{F}{toulal} se jen \Ch{C}{sám}
+po Státech <F>toulal se jen <C>sám
 
-a že byl \Ch{F}{veselej,} tak \Ch{C}{každej} měl ho \Ch{G7}{rád}.
+a že byl <F>veselej, tak <C>každej měl ho <G7>rád.
 
-Tam ruce k \Ch{F}{dílu} mlčky přiloží
-a \Ch{C}{zase}
-jede \Ch{Ami}{dál.}
+Tam ruce k <F>dílu mlčky přiloží
+a <C>zase
+jede <Ami>dál.
 
-A \Ch{F}{kaž}dej, kdo s ním
-\Ch{G}{chvilku} byl, tak \Ch{F}{dlou}ho \Ch{G7}{se pak} \Ch{C}{smál}.
+A <F>každej, kdo s ním
+<G>chvilku byl, tak <F>dlouho <G7>se pak <C>smál.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Hejna_včel.tex
+++ b/tp-songs/01_folk/Brontosauři____Hejna_včel.tex
@@ -3,11 +3,11 @@
 \zp{Hejna včel}{Brontosauři}
 
 \zs
-\Ch{Bmi}{Nějak umírá} nám \Ch{Bmi/Ab}{láska,}
+<Bmi>Nějak umírá nám <Bmi/Ab>láska,
 
-my jako \Ch{Bmi/Gb}{hejna divejch} \Ch{Bmi/F}{včel}
+my jako <Bmi/Gb>hejna divejch <Bmi/F>včel
 
-jdeme \Ch{Bmi}{dál.} \Ch{Bmi/Ab}{} \Ch{Bmi/Gb}{} \Ch{Bmi/F}{}
+jdeme <Bmi>dál. <Bmi/Ab> <Bmi/Gb> <Bmi/F>
 
 Každej vztah je vlastně sázka,
 

--- a/tp-songs/01_folk/Brontosauři____Hráz.tex
+++ b/tp-songs/01_folk/Brontosauři____Hráz.tex
@@ -3,21 +3,21 @@
 \zp{Hráz}{Brontosauři}
 
 \zs
-\Ch{G}{Stál} tam na stráni \Ch{Gmaj7}{dům, v něm} židle a \Ch{G6}{stůl,}
+<G>Stál tam na stráni <Gmaj7>dům, v něm židle a <G6>stůl,
 
-pár kůží a \Ch{G}{krb,} co dřevo z něj \Ch{Ami}{voní,} \Ch{Ami7}{}
+pár kůží a <G>krb, co dřevo z něj <Ami>voní, <Ami7>
 
-s \Ch{D}{jarem,} když máj rozdá barvy svý,
+s <D>jarem, když máj rozdá barvy svý,
 
-tu \Ch{D7}{sosna krásná} nad chajdou se \Ch{G}{skloní}
+tu <D7>sosna krásná nad chajdou se <G>skloní
 
-a \Ch{G}{říčka,} když stříbrným \Ch{Gmaj7}{hávem se přikryje} s \Ch{G6}{ránem,}
+a <G>říčka, když stříbrným <Gmaj7>hávem se přikryje s <G6>ránem,
 
-svý \uv{ahoj} jí \Ch{G}{dáš a pak je tu} \Ch{E}{den.}
+svý \uv{ahoj} jí <G>dáš a pak je tu <E>den.
 
-\Ch{C}{Zazní} údolím kytara tvá, ta \Ch{Emi}{píseň ráno} uvítá,
+<C>Zazní údolím kytara tvá, ta <Emi>píseň ráno uvítá,
 
-svět s \Ch{D7}{ním, svět} s \Ch{G}{ním.}
+svět s <D7>ním, svět s <G>ním.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Jarní_tání.tex
+++ b/tp-songs/01_folk/Brontosauři____Jarní_tání.tex
@@ -3,25 +3,25 @@
 \zp{Jarní tání}{Brontosauři}
 
 \zs
-Když první \Ch{Ami}{tání} \Ch{Dmi}{cestu} sněhu \Ch{C}{zkříží}
+Když první <Ami>tání <Dmi>cestu sněhu <C>zkříží
 
-\Ch{F}{a nad} le\Ch{Dmi}{dem} se \Ch{E7}{voda} obje\Ch{Ami}{ví,}
+<F>a nad le<Dmi>dem se <E7>voda obje<Ami>ví,
 
-voňavá zem se \Ch{Dmi}{sněhem} tiše \Ch{C}{plíží,}
+voňavá zem se <Dmi>sněhem tiše <C>plíží,
 
-\Ch{F}{tak} nějak \Ch{Dmi}{líp si} \Ch{E7}{balím,} proč, Bůh \Ch{Ami}{ví.}
+<F>tak nějak <Dmi>líp si <E7>balím, proč, Bůh <Ami>ví.
 \ks
 
 
 
 \zr
-Přišel čas \Ch{F}{slunce,} {zroz}ení a \Ch{C}{tratí,}
+Přišel čas <F>slunce, {zroz}ení a <C>tratí,
 
-na kterejch \Ch{F}{potkáš} {klu}ky ze všech \Ch{C}{stran,}
+na kterejch <F>potkáš {klu}ky ze všech <C>stran,
 
-/: \Ch{E7}{Hubenej} \Ch{Ami}{Joe,} Čára, Ušoun se ti \Ch{Dmi}{vrátí,}
+/: <E7>Hubenej <Ami>Joe, Čára, Ušoun se ti <Dmi>vrátí,
 
-oživne \Ch{F}{kemp,} \Ch{E7}{jaro,} vítej k \Ch{Ami}{nám.} :/
+oživne <F>kemp, <E7>jaro, vítej k <Ami>nám. :/
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Kytka.tex
+++ b/tp-songs/01_folk/Brontosauři____Kytka.tex
@@ -3,9 +3,9 @@
 \zp{Kytka}{Brontosauři}
 
 \zs
-Otvírám \Ch{G}{lásku} na stránce \Ch{D}{rád},
+Otvírám <G>lásku na stránce <D>rád,
 
-přišel jsem, \Ch{A7}{milá} má, něco ti \Ch{D}{dát.}
+přišel jsem, <A7>milá má, něco ti <D>dát.
 
 Zeptat se, co děláš a jakej byl den,
 

--- a/tp-songs/01_folk/Brontosauři____Na_kameni_kámen.tex
+++ b/tp-songs/01_folk/Brontosauři____Na_kameni_kámen.tex
@@ -3,19 +3,19 @@
 \zp{Na kameni kámen}{Brontosauři}
 
 \zs
-Jako \Ch{C}{starej} suchej strom, jako \Ch{Fmaj7}{všeničící} hrom,
-jak v poli \Ch{C}{tráva}
+Jako <C>starej suchej strom, jako <Fmaj7>všeničící hrom,
+jak v poli <C>tráva
 
-připadá mi ten náš svět, plnej \Ch{Fmaj7}{řečí a čím} \Ch{Ami}{víc,} tím 
-\Ch{G}{líp} se \Ch{C}{mám.}
+připadá mi ten náš svět, plnej <Fmaj7>řečí a čím <Ami>víc, tím 
+<G>líp se <C>mám.
 \ks
 
 \zr
-Budem \Ch{Fmaj7}{o něco} se rvát, až tu \Ch{Ami}{nezůstane} \Ch{G}{stát} na 
-kameni \Ch{C}{kámen}.
+Budem <Fmaj7>o něco se rvát, až tu <Ami>nezůstane <G>stát na 
+kameni <C>kámen.
 
-A jestli \Ch{Fmaj7}{není žádnej} Bůh, tak nás \Ch{Ami}{vezme} země, 
-\Ch{G}{vzduch}, no a potom \Ch{C}{amen.}
+A jestli <Fmaj7>není žádnej Bůh, tak nás <Ami>vezme země, 
+<G>vzduch, no a potom <C>amen.
 \kr
 
 

--- a/tp-songs/01_folk/Brontosauři____Nad_Sázavou.tex
+++ b/tp-songs/01_folk/Brontosauři____Nad_Sázavou.tex
@@ -3,17 +3,17 @@
 \zp{Nad Sázavou}{Brontosauři}
 
 \zs
-\Ch{Emi}{Do noci} před tunelem zahouká
+<Emi>Do noci před tunelem zahouká
 
-poslední vlak, co veze opuštěný nádražáky \Ch{Ami}{domů spát,}
+poslední vlak, co veze opuštěný nádražáky <Ami>domů spát,
 
-\Ch{H7}{zhasni tu} písničku a napít mi dej,
+<H7>zhasni tu písničku a napít mi dej,
 
-před spaním \Ch{Emi}{chci si ještě} \Ch{Emi/D}{přečíst pár} \Ch{C}{hvězd,} \Ch{C/H}{}
+před spaním <Emi>chci si ještě <Emi/D>přečíst pár <C>hvězd, <C/H>
 
-ta \Ch{Ami}{řeka je jak} pohádka,
+ta <Ami>řeka je jak pohádka,
 
-co \Ch{H7}{vyprávěli} naši v chatě, \Ch{Emi}{kde byl les.}
+co <H7>vyprávěli naši v chatě, <Emi>kde byl les.
 \ks
 
 \zs
@@ -33,11 +33,11 @@ když chodili jsme domů spát.
 \ks
 
 \zr
-Nad \Ch{E7}{Sáza}\Ch{Ami}{vou, nad} \Ch{D7}{Sáza}\Ch{G}{vou,}
+Nad <E7>Sáza<Ami>vou, nad <D7>Sáza<G>vou,
 
-občas \Ch{Emi}{vzpomene} si člověk asi \Ch{Ami}{na ty časy} krásný,
+občas <Emi>vzpomene si člověk asi <Ami>na ty časy krásný,
 
-kdy \Ch{H7}{zpívali} jsme Brontosaury, \Ch{Emi}{Spirituál.}
+kdy <H7>zpívali jsme Brontosaury, <Emi>Spirituál.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Podvod.tex
+++ b/tp-songs/01_folk/Brontosauři____Podvod.tex
@@ -3,13 +3,13 @@
 \zp{Podvod}{Brontosauři}
 
 \zs
-\Ch{Emi}{Na dl}ani jednu z tvých řas, do tmy se \Ch{Ami}{koukám},
+<Emi>Na dlani jednu z tvých řas, do tmy se <Ami>koukám,
 
-\Ch{D}{hraju} si písničky tvý, co jsem ti \Ch{G}{psal},
+<D>hraju si písničky tvý, co jsem ti <G>psal,
 
-je skoro \Ch{Ami}{půlnoc} a z kostela \Ch{Ami/C}{zvon mi} noc \Ch{Emi}{připomíná},
+je skoro <Ami>půlnoc a z kostela <Ami/C>zvon mi noc <Emi>připomíná,
 
-půjdu se \Ch{Ami}{mejt} a pozhasínám, co bude \Ch{H7}{dál}?
+půjdu se <Ami>mejt a pozhasínám, co bude <H7>dál?
 \ks
 
 \zs
@@ -23,15 +23,15 @@ půjdu se mejt a pozhasínám, co bude dál?
 \ks
 
 \zr
-Chtěl jsem to \Ch{Ami}{ráno,} kdy naposled snídal jsem s tebou,
+Chtěl jsem to <Ami>ráno, kdy naposled snídal jsem s tebou,
 
-ti \Ch{Emi}{říct,} že už ti nezavolám,
+ti <Emi>říct, že už ti nezavolám,
 
-pro jednu pitomou \Ch{Ami}{holku}, pro pár nocí \Ch{D7}{touhy}
+pro jednu pitomou <Ami>holku, pro pár nocí <D7>touhy
 
-podved jsem \Ch{G}{všechno,} o čem doma si \Ch{H7}{sníš,}
+podved jsem <G>všechno, o čem doma si <H7>sníš,
 
-teď je mi to \Ch{Emi}{líto.}
+teď je mi to <Emi>líto.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Růže_z_papíru.tex
+++ b/tp-songs/01_folk/Brontosauři____Růže_z_papíru.tex
@@ -3,29 +3,29 @@
 \zp{Růže z papíru}{Brontosauři}
 
 \zs
-Do tvých \Ch{Dmi}{očí jsem} se zbláznil
+Do tvých <Dmi>očí jsem se zbláznil
 
-a teď \Ch{E7}{nemám,} nemám \Ch{Gmi}{klid,}
+a teď <E7>nemám, nemám <Gmi>klid,
 
-\Ch{Ami}{hlava} třeští, asi tě mám \Ch{Dmi}{rád.}
+<Ami>hlava třeští, asi tě mám <Dmi>rád.
 
 Stále někdo říká: \uv{Vzbuď se,}
 
-\Ch{E7}{věčně} trhá \Ch{Gmi}{nit,}
+<E7>věčně trhá <Gmi>nit,
 
-\Ch{Ami}{studenou} sprchu měl bych si \Ch{Dmi}{dát.}
+<Ami>studenou sprchu měl bych si <Dmi>dát.
 \ks
 
 \zr
-\Ch{D7}{Na} pouti jsem vystřelil \Ch{Gmi}{růži z} papíru,
+<D7>Na pouti jsem vystřelil <Gmi>růži z papíru,
 
-\Ch{C7}{dala} sis ji do vlasů, kde \Ch{F}{hladívám} tě \Ch{A7}{já.}
+<C7>dala sis ji do vlasů, kde <F>hladívám tě <A7>já.
 
-\Ch{Dmi}{V tom}hle smutným světě
+<Dmi>V tomhle smutným světě
 
-jsi má \Ch{Gmi}{naděj'} na víru,
+jsi má <Gmi>naděj' na víru,
 
-že \Ch{Ami}{nebe} modrý ještě smysl \Ch{Dmi}{má.}
+že <Ami>nebe modrý ještě smysl <Dmi>má.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Sedmikráska.tex
+++ b/tp-songs/01_folk/Brontosauři____Sedmikráska.tex
@@ -3,11 +3,11 @@
 \zp{Sedmikráska}{Brontosauři}
 
 \zs
-\Ch{Ami4+}{V řece plavou} bílý lístky, sedmikrásky někdo blízký
+<Ami4+>V řece plavou bílý lístky, sedmikrásky někdo blízký
 
-\Ch{Dmi}{druhému} se ptal, zda na něj \Ch{Ami}{myslí, vzpomí}\Ch{E7}{ná,}
+<Dmi>druhému se ptal, zda na něj <Ami>myslí, vzpomí<E7>ná,
 
-má, nemá \Ch{Ami4+}{rád.}
+má, nemá <Ami4+>rád.
 \ks
 
 \zs
@@ -17,13 +17,13 @@ nemá, nemá, řeko němá, pospíchej, ať nebolí to tak.
 \ks
 
 \zr
-\Ch{A}{Chvíli} si myslíš, že \Ch{A7}{svět ztratil} tvar,
+<A>Chvíli si myslíš, že <A7>svět ztratil tvar,
 
-\Ch{Dmi}{prostor se} zúžil na má dáti -- dal,
+<Dmi>prostor se zúžil na má dáti -- dal,
 
-jak \Ch{G}{mokrá} sirka připadáš si \Ch{G7}{zbytečná,}
+jak <G>mokrá sirka připadáš si <G7>zbytečná,
 
-jak \Ch{C}{zapálený} trsy \Ch{E7}{trav,} na na na na \Ch{Ami4+}{ná.}
+jak <C>zapálený trsy <E7>trav, na na na na <Ami4+>ná.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Signály.tex
+++ b/tp-songs/01_folk/Brontosauři____Signály.tex
@@ -2,27 +2,27 @@
 
 \zp{Signály}{Brontosauři}
 \zs
-\Ch{C}{Ces}ty jsou blátem pose\Ch{E}{dlý,}
+<C>Cesty jsou blátem pose<E>dlý,
 
-vzduch jarní \Ch{E7}{vůni} zavo\Ch{F}{ní}
+vzduch jarní <E7>vůni zavo<F>ní
 
-z kouřovejch signá\Ch{C}{lů.}
+z kouřovejch signá<C>lů.
 
-A bílý stopy ve ska\Ch{E}{lách}
+A bílý stopy ve ska<E>lách
 
-umyje \Ch{E7}{slunce} jako \Ch{F}{prach}
+umyje <E7>slunce jako <F>prach
 
-na cestách tulá\Ch{C}{ků.}
+na cestách tulá<C>ků.
 \ks
 
 \zr
-\Ch{C}{Zas} bude teplej vítr \Ch{C7}{vát}
+<C>Zas bude teplej vítr <C7>vát
 
-a slunce \Ch{F}{skály} v kempu \Ch{C}{hřát.}
+a slunce <F>skály v kempu <C>hřát.
 
-Tak ahoj, slunce, vítej k \Ch{E}{nám,}
+Tak ahoj, slunce, vítej k <E>nám,
 
-písničku \Ch{E7}{první} tobě \Ch{F}{dám} a budu \Ch{C}{hrát.}
+písničku <E7>první tobě <F>dám a budu <C>hrát.
 \kr
 
 

--- a/tp-songs/01_folk/Brontosauři____Slunovrat.tex
+++ b/tp-songs/01_folk/Brontosauři____Slunovrat.tex
@@ -3,19 +3,19 @@
 \zp{Slunovrat}{Brontosauři}
 
 \zs
-\Ch{Ami}{Stíny} nad obzo\Ch{Ami/C}{rem pomalu} \Ch{H7}{jdou},
-\Ch{E7}{noc} se \Ch{Ami}{snáší,}
+<Ami>Stíny nad obzo<Ami/C>rem pomalu <H7>jdou,
+<E7>noc se <Ami>snáší,
 
-paseky osvítí \Ch{Ami/C}{zář z bor}ovejch \Ch{Ami}{klád} 
-zapále\Ch{Emi}{nejch.}
+paseky osvítí <Ami/C>zář z borovejch <Ami>klád 
+zapále<Emi>nejch.
 \ks
 
 \zr
-\Ch{Ami}{Sešli} se zapome\Ch{C}{nout,}
-\Ch{G}{a zved}nout hlavu, to \Ch{Dmi}{stačí.}
+<Ami>Sešli se zapome<C>nout,
+<G>a zvednout hlavu, to <Dmi>stačí.
 
-\Ch{Ami}{Jen tr}ochu popadnout \Ch{Emi/H}{dech,
-než} půjdou zas \Ch{Ami}{dál.}
+<Ami>Jen trochu popadnout <Emi/H>dech,
+než půjdou zas <Ami>dál.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Stánky.tex
+++ b/tp-songs/01_folk/Brontosauři____Stánky.tex
@@ -3,11 +3,11 @@
 \zp{Stánky}{Brontosauři}
 
 \zs
-\Ch{D}{U} stánků na \Ch{G}{levnou} krásu
+<D>U stánků na <G>levnou krásu
 
-\Ch{D}{postávaj} a \Ch{Gmi}{smějou} se času
+<D>postávaj a <Gmi>smějou se času
 
-s \Ch{D}{cigaretou} a s \Ch{A7}{holkou,} co nemá kam \Ch{D}{jít}.
+s <D>cigaretou a s <A7>holkou, co nemá kam <D>jít.
 \ks
 
 \zs
@@ -19,13 +19,13 @@ neuměj žít, bouřej se a neposlouchaj.
 \ks
 
 \zr
-\Ch{G}{Jen} zahlídli svět, maj \Ch{A7}{na duši} vrásky,
+<G>Jen zahlídli svět, maj <A7>na duši vrásky,
 
-tak \Ch{D}{málo} jen, tak \Ch{Gmi}{málo je lás}ky,
+tak <D>málo jen, tak <Gmi>málo je lásky,
 
-\Ch{D}{ztracená} víra \Ch{A7}{hrozny} z vinic
+<D>ztracená víra <A7>hrozny z vinic
 
-neposbí\Ch{D}{rá.}
+neposbí<D>rá.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Tulácký_ráno.tex
+++ b/tp-songs/01_folk/Brontosauři____Tulácký_ráno.tex
@@ -3,19 +3,19 @@
 \zp{Tulácký ráno}{Brontosauři}
 
 \zs
-\Ch{Dmi}{Posvá}tný je mi každý ráno,
-\Ch{Ami}{když} ze sna budí šumící \Ch{Dmi}{les}
+<Dmi>Posvátný je mi každý ráno,
+<Ami>když ze sna budí šumící <Dmi>les
 
 a když se zvedám s písničkou známou
-\Ch{Ami}{a přez}ky chřestí o skalnatou \Ch{Dmi}{mez.}
+<Ami>a přezky chřestí o skalnatou <Dmi>mez.
 \ks
 
 \zr
 Tulácký ráno na kemp se snáší,
-\Ch{B}{za ch}víli půjdem \Ch{C}{toul}at se \Ch{F}{dál}
+<B>za chvíli půjdem <C>toulat se <F>dál
 
-\Ch{Dmi}{a vod}ou z říčky oheň se zháší,
-\Ch{B}{tak} zase půjdem \Ch{C}{toulat} se \Ch{Dmi}{dál.}
+<Dmi>a vodou z říčky oheň se zháší,
+<B>tak zase půjdem <C>toulat se <Dmi>dál.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Brontosauři____Valčíček.tex
+++ b/tp-songs/01_folk/Brontosauři____Valčíček.tex
@@ -3,13 +3,13 @@
 \zp{Valčíček}{Brontosauři}
 
 \zr
-Tuhle \Ch{C}{písničku} chtěl bych ti, \Ch{G}{lásko}, dát,
+Tuhle <C>písničku chtěl bych ti, <G>lásko, dát,
 
-ať ti \Ch{G7}{každej} den připomí\Ch{C}{ná},
+ať ti <G7>každej den připomí<C>ná,
 
-/: toho, {kdo} je tvůj, \Ch{C7}{čí ty} jsi \Ch{F}{a} kdo má \Ch{C}{rád,}
+/: toho, {kdo} je tvůj, <C7>čí ty jsi <F>a kdo má <C>rád,
 
-ať ti každej den \Ch{G}{připomí}\Ch{C}{ná} :/
+ať ti každej den <G>připomí<C>ná :/
 \kr
 
 \zs

--- a/tp-songs/01_folk/Fešáci____Jaro.tex
+++ b/tp-songs/01_folk/Fešáci____Jaro.tex
@@ -2,7 +2,7 @@
 
 \zp{Jaro}{Fešáci}
 \zs
-\Ch{Ami}{My} čekali \Ch{C}{jaro} a \Ch{G}{zatím} přišel \Ch{Ami}{mráz},
+\Ch{Ami}{My} čekali \Ch{C}{jaro} a \Ch{G}{zatím} přišel \Ch{Ami}{mráz,}
 tak strašlivou \Ch{C}{zimu} ne\Ch{G}{zažil} nikdo z \Ch{Ami}{nás,}
 
 z těžkých černých \Ch{C}{mraků} se \Ch{G}{stále} sypal \Ch{Ami}{sníh}

--- a/tp-songs/01_folk/Fešáci____Jaro.tex
+++ b/tp-songs/01_folk/Fešáci____Jaro.tex
@@ -2,17 +2,17 @@
 
 \zp{Jaro}{Fešáci}
 \zs
-\Ch{Ami}{My} čekali \Ch{C}{jaro} a \Ch{G}{zatím} přišel \Ch{Ami}{mráz,}
-tak strašlivou \Ch{C}{zimu} ne\Ch{G}{zažil} nikdo z \Ch{Ami}{nás,}
+<Ami>My čekali <C>jaro a <G>zatím přišel <Ami>mráz,
+tak strašlivou <C>zimu ne<G>zažil nikdo z <Ami>nás,
 
-z těžkých černých \Ch{C}{mraků} se \Ch{G}{stále} sypal \Ch{Ami}{sníh}
-a vánice \Ch{C}{sílí} v po\Ch{G}{ryvech} ledo\Ch{Ami}{vých.}
+z těžkých černých <C>mraků se <G>stále sypal <Ami>sníh
+a vánice <C>sílí v po<G>ryvech ledo<Ami>vých.
 
-Z \Ch{C}{chýší} dřevo mizí a \Ch{G}{mouky} ubývá,
-\Ch{Dmi}{do sýpek} se raději už \Ch{G}{nikdo} nedívá,
+Z <C>chýší dřevo mizí a <G>mouky ubývá,
+<Dmi>do sýpek se raději už <G>nikdo nedívá,
 
-\Ch{C}{zvěř} z okolních lesů nám \Ch{G}{stála} u dveří
-\Ch{Dmi}{a hladoví} ptáci při\Ch{G}{létli} za zvěří a stále \Ch{Ami}{blíž.}
+<C>zvěř z okolních lesů nám <G>stála u dveří
+<Dmi>a hladoví ptáci při<G>létli za zvěří a stále <Ami>blíž.
 \ks
 \zs
 Jednoho dne večer, to už jsem skoro spal,
@@ -49,7 +49,7 @@ a pak ho někdo spatřil, jak tam leží pod srázem,
 krev nám tuhla v žilách nad tím obrazem, já klobouk sňal.
 \ks
 
-\Ch{Ami}{Někdy} ten, kdo \Ch{C}{spěchá}, se \Ch{G}{domů} nevra\Ch{Ami}{cí...}
+<Ami>Někdy ten, kdo <C>spěchá, se <G>domů nevra<Ami>cí...
 \kp
 
 

--- a/tp-songs/01_folk/Fešáci____Lojza_a_Líza.tex
+++ b/tp-songs/01_folk/Fešáci____Lojza_a_Líza.tex
@@ -14,9 +14,9 @@
 
 
 \zs
-Vědro \Ch{G}{má} ve dně \Ch{C}{díru,} milá Lízo, milá Lízo,
+Vědro <G>má ve dně <C>díru, milá Lízo, milá Lízo,
 
-vědro \Ch{G}{má} ve dně \Ch{C}{díru,} milá \Ch{D}{Lízo,} jak \Ch{G}{hrom.}
+vědro <G>má ve dně <C>díru, milá <D>Lízo, jak <G>hrom.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Fleret____Zafúkané.tex
+++ b/tp-songs/01_folk/Fleret____Zafúkané.tex
@@ -7,25 +7,25 @@
 
 
 \zs
-\Ch{Ami}{Větr} sněh \Ch{A2}{zanésl} z \Ch{Ami}{hor do} \Ch{A2}{polí},
+<Ami>Větr sněh <A2>zanésl z <Ami>hor do <A2>polí,
 
-\Ch{Ami}{já idu} \Ch{C}{přes} kopce, \Ch{G}{přes} údolí, \Ch{Ami}{}
+<Ami>já idu <C>přes kopce, <G>přes údolí, <Ami>
 
-\Ch{C}{idu} k tvej \Ch{G}{dědině} zatúla\Ch{C}{nej},
+<C>idu k tvej <G>dědině zatúla<C>nej,
 
-\Ch{F}{cestičky} sně\Ch{C}{hem} sú \Ch{E}{zafúkané}. \Ch{Ami}{} \Ch{Fmaj7}{} 
-\Ch{Ami}{} \Ch{E4sus}{}
+<F>cestičky sně<C>hem sú <E>zafúkané. <Ami> <Fmaj7> 
+<Ami> <E4sus>
 \ks
 
 \zr
-\Ch{Ami}{Zafúk}\Ch{C}{ané,} \Ch{G}{zafúk}\Ch{C}{ané,}
+<Ami>Zafúk<C>ané, <G>zafúk<C>ané,
 
-\Ch{F}{kolem} mňa vše\Ch{C}{cko} je \Ch{Dmi}{zafúkané.} \Ch{E}{}
+<F>kolem mňa vše<C>cko je <Dmi>zafúkané. <E>
 
-\Ch{Ami}{Zafúka}\Ch{C}{né,}  \Ch{G}{zafúk}\Ch{C}{ané,}
+<Ami>Zafúka<C>né, <G>zafúk<C>ané,
 
-\Ch{F}{kolem} mňa \Ch{C}{všecko} je \Ch{E}{zafúkané.} \Ch{Ami}{} \Ch{Emi}{} 
-\Ch{D}{} \Ch{G}{} \Ch{H7}{} \Ch{Emi}{} \Ch{D}{} \Ch{G}{} \Ch{H7}{} \Ch{Emi}{}
+<F>kolem mňa <C>všecko je <E>zafúkané. <Ami> <Emi> 
+<D> <G> <H7> <Emi> <D> <G> <H7> <Emi>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Folk_Team____Beze_slov.tex
+++ b/tp-songs/01_folk/Folk_Team____Beze_slov.tex
@@ -3,9 +3,9 @@
 \zp{Beze slov}{Folk Team}
 
 \zs
-\Ch{Ami}{Mluvíme} spolu \Ch{F}{beze} slov a \Ch{G}{milujem} se \Ch{C}{po} paměti,
+<Ami>Mluvíme spolu <F>beze slov a <G>milujem se <C>po paměti,
 
-\Ch{F}{chodíme} domů \Ch{C}{na} ostrov, \Ch{E7}{adoptujem} vlastní \Ch{F}{děti.} \Ch{G}{}
+<F>chodíme domů <C>na ostrov, <E7>adoptujem vlastní <F>děti. <G>
 \ks
 
 \zs
@@ -15,9 +15,9 @@ ryby, co čekaj na výlov, zvadlé a otupené dusnem.
 \ks
 
 \zr
-\Ch{C}{Slova} jsou jak \Ch{Dmi}{motýli,} \Ch{G}{co nám} kdysi \Ch{B}{uletěli,}
+<C>Slova jsou jak <Dmi>motýli, <G>co nám kdysi <B>uletěli,
 
-\Ch{C}{chytíme} je \Ch{Emi}{na chvíli}, \Ch{B}{ulét}nou nám \Ch{E7}{po ned}ěli.
+<C>chytíme je <Emi>na chvíli, <B>ulétnou nám <E7>po neděli.
 \kr
 
 \zs
@@ -35,7 +35,7 @@ kéž bych byl teď někde pryč, mezi lidmi, co se baví.
 \zr Ta da da ... \kr
 
 
-\Ch{Ami}{Mluvíme} spolu \Ch{F}{beze} slov, \Ch{G}{milujem} se \Ch{C}{po 
-paměti...}
+<Ami>Mluvíme spolu <F>beze slov, <G>milujem se <C>po 
+paměti...
 
 \kp

--- a/tp-songs/01_folk/František_Nedvěd____Kočovní_herci.tex
+++ b/tp-songs/01_folk/František_Nedvěd____Kočovní_herci.tex
@@ -2,23 +2,23 @@
 
 \zp{Kočovní herci}{František Nedvěd}
 \zs
-\Ch{G}{Laciné} šminky, přilepený nos
+<G>Laciné šminky, přilepený nos
 
-budka s \Ch{Ami}{nápovědou,}
+budka s <Ami>nápovědou,
 
-\Ch{C}{to} pro ty co zapomněli,
+<C>to pro ty co zapomněli,
 
-\Ch{D}{jak} svou roli mají \Ch{G}{správně} hrát.\Ch{G7}{ }
+<D>jak svou roli mají <G>správně hrát.<G7> 
 \ks
 \zr
 
-\Ch{C}{Kočovní} herci tu \Ch{D}{jsou}, máky kvetou,
+<C>Kočovní herci tu <D>jsou, máky kvetou,
 
-\Ch{C}{principál} je\Ch{G}{ pán,}
+<C>principál je<G> pán,
 
-\Ch{C}{kočovní} herci tu \Ch{D}{jsou}, s nimi léto
+<C>kočovní herci tu <D>jsou, s nimi léto
 
-\Ch{C}{přijelo} \Ch{G}{k} nám.
+<C>přijelo <G>k nám.
 \kr
 \zs
 
@@ -31,7 +31,7 @@ Stejně musí na neděli
 paní principálka prádlo prát.
 
 \ks
-\zr   \kr
+\zr \kr
 \zs
 
 

--- a/tp-songs/01_folk/František_Nedvěd____Řemeslo.tex
+++ b/tp-songs/01_folk/František_Nedvěd____Řemeslo.tex
@@ -3,33 +3,33 @@
 \zp{Řemeslo}{František Nedvěd}
 \zs
 
-Zase od\Ch{E}{jíždím} z míst, kam mě to zaneslo
+Zase od<E>jíždím z míst, kam mě to zaneslo
 
-moje \Ch{H7}{krásný} a milovaný \Ch{E}{řemeslo}.
+moje <H7>krásný a milovaný <E>řemeslo.
 \ks
 \zr
-Je půlnoc, \Ch{A}{chce} se mi spát,
+Je půlnoc, <A>chce se mi spát,
 
-ale \Ch{D}{dřív} musím u pumpy si \Ch{E}{kafe} dát.
+ale <D>dřív musím u pumpy si <E>kafe dát.
 \kr
 \zs
 Pumpař řek, že prej všechny moje desky má,
 
 dal mi kávu a k tomu čtyři eskyma.
 \ks
-\zr     \kr
+\zr \kr
 \zs
 Aspoň na černou kávu mi to vyneslo,
 
 moje krásný a milovaný řemeslo.
 \ks
-\zr     \kr
+\zr \kr
 \zs
 Chtěl jsem nastartovat, auto ani nehleslo,
 
 to je tím, že jsem přechválil svý řemeslo.
 \ks
-\zr     \kr
+\zr \kr
 \kp
 
 

--- a/tp-songs/01_folk/Greenhorni____Blues_folsomské_věznice.tex
+++ b/tp-songs/01_folk/Greenhorni____Blues_folsomské_věznice.tex
@@ -3,13 +3,13 @@
 \zp{Blues folsomské věznice}{Greenhorni}
 
 \zs
-Můj \Ch{G}{děda} bejval blázen, texaskej ahasver,
+Můj <G>děda bejval blázen, texaskej ahasver,
 
-a na půdě nám po něm zůstal \Ch{G7}{ošoupanej} kvér,
+a na půdě nám po něm zůstal <G7>ošoupanej kvér,
 
-ten \Ch{C}{kvér} obdivovali všichni kámoši z oko\Ch{G}{lí}
+ten <C>kvér obdivovali všichni kámoši z oko<G>lí
 
-a \Ch{D7}{máma} mi říkala: \uv{Nehraj si s tou pisto\Ch{G}{lí}!}
+a <D7>máma mi říkala: \uv{Nehraj si s tou pisto<G>lí!}
 \ks
 
 \zs

--- a/tp-songs/01_folk/Greenhorni____Cizinec.tex
+++ b/tp-songs/01_folk/Greenhorni____Cizinec.tex
@@ -3,13 +3,13 @@
 \zp{Cizinec}{Greenhorni}
 
 \zs
-\Ch{Ami}{Na kra}ji pouště slun\Ch{Dmi}{cem} spále\Ch{Ami}{ný}
+<Ami>Na kraji pouště slun<Dmi>cem spále<Ami>ný
 
-sto\Ch{Dmi}{jí na}še \Ch{Ami}{malý} měs\Ch{E}{to} dřevě\Ch{Ami}{ný.}
+sto<Dmi>jí naše <Ami>malý měs<E>to dřevě<Ami>ný.
 
-Jednoho dne, právě čas \Ch{Dmi}{oběda} \Ch{Ami}{byl,}
+Jednoho dne, právě čas <Dmi>oběda <Ami>byl,
 
-se \Ch{Dmi}{na kra}ji \Ch{Ami}{města} jez\Ch{E}{dec} obje\Ch{Ami}{vil.}
+se <Dmi>na kraji <Ami>města jez<E>dec obje<Ami>vil.
 \ks
 
 \zs
@@ -23,13 +23,13 @@ na stehnech pouzdra z chřestýších kůží.
 \ks
 
 \zr
-\Ch{F}{Tu} jeho tvář, tu kaž\Ch{G}{dý} z nás poznal,
+<F>Tu jeho tvář, tu kaž<G>dý z nás poznal,
 
-\Ch{F}{na} každém nároží \Ch{C}{zatykač} vlál,
+<F>na každém nároží <C>zatykač vlál,
 
-\Ch{Dmi}{na něm} cifra, za kte\Ch{Ami}{rou by} sis žil,
+<Dmi>na něm cifra, za kte<Ami>rou by sis žil,
 
-\Ch{E}{a} přece nikdo z nás \Ch{Ami}{nevystřelil}.
+<E>a přece nikdo z nás <Ami>nevystřelil.
 \kr
 
 \zs
@@ -52,7 +52,7 @@ objednal si pití a v místnostech těch
 každej z chlapů poslouchal jenom svůj dech.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 On jenom se usmál a dopil svůj drink,

--- a/tp-songs/01_folk/Greenhorni____Když_náš_táta_hrál.tex
+++ b/tp-songs/01_folk/Greenhorni____Když_náš_táta_hrál.tex
@@ -3,17 +3,17 @@
 \zp{Když náš táta hrál}{Greenhorni}
 
 \zs
-Když \Ch{G}{jsem} byl chlapec malej, tak metr nad zemí,
+Když <G>jsem byl chlapec malej, tak metr nad zemí,
 
-\Ch{C}{scházeli} se farmáři tam \Ch{G}{u} nás v přízemí,
+<C>scházeli se farmáři tam <G>u nás v přízemí,
 
 mezi nima můj táta u piva sedával
 
-\Ch{D7}{a tu} svoji nejmilejší \Ch{G}{hrál}.
-\Ch{C}{~~}
-\Ch{G}{~~}
-\Ch{D7}{~~}
-\Ch{G}{~~}
+<D7>a tu svoji nejmilejší <G>hrál.
+<C>~~
+<G>~~
+<D7>~~
+<G>~~
 \ks
 
 \zs

--- a/tp-songs/01_folk/Greenhorni____Rocky_Top.tex
+++ b/tp-songs/01_folk/Greenhorni____Rocky_Top.tex
@@ -3,21 +3,21 @@
 \zp{Rocky Top}{Greenhorni}
 
 \zs
-\Ch{C}{Byl} to démon, \Ch{F}{co} ho\Ch{C}{ru} Rocky Top
+<C>Byl to démon, <F>co ho<C>ru Rocky Top
 
-\Ch{Ami}{zaklel} do \Ch{G}{Tennessee} \Ch{C}{Hills},
+<Ami>zaklel do <G>Tennessee <C>Hills,
 
-prach a skály, \Ch{F}{to} je \Ch{C}{Rocky} Top,
+prach a skály, <F>to je <C>Rocky Top,
 
-\Ch{Ami}{pustina} v \Ch{G}{Tennessee} \Ch{C}{Hills}.
+<Ami>pustina v <G>Tennessee <C>Hills.
 \ks
 
 \zr
-\Ch{Ami}{Mraky} táhnou, \Ch{G}{táhnou} níž, \Ch{B}{vášeň} ti uha\Ch{F}{sí},
+<Ami>Mraky táhnou, <G>táhnou níž, <B>vášeň ti uha<F>sí,
 
-soudí tě \Ch{C}{Rocky} Top, Rocky Top v \Ch{B}{Tennes}\Ch{C}{see}
+soudí tě <C>Rocky Top, Rocky Top v <B>Tennes<C>see
 
-\Ch{C}{Rocky} Top v \Ch{B}{Tennes}\Ch{C}{see}.
+<C>Rocky Top v <B>Tennes<C>see.
 \kr
 
 \zs
@@ -30,7 +30,7 @@ kterou cestou zpátky dolů jít,
 už nikdy nepoznáš.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Na dně rokle do prachu zahodí
@@ -43,8 +43,8 @@ nevím, co by tu chtěl.
 \ks
 
 \zr
-\Ch{C}{Rocky} Top v \Ch{B}{Tenn}\Ch{H}{ess}\Ch{C}{ee...} \Ch{B}{ }
-\Ch{F}{ } \Ch{C}{}
+<C>Rocky Top v <B>Tenn<H>ess<C>ee... <B> 
+<F> <C>
 \kr
 
 

--- a/tp-songs/01_folk/Greenhorni____Rovnou_tady_rovnou.tex
+++ b/tp-songs/01_folk/Greenhorni____Rovnou_tady_rovnou.tex
@@ -3,13 +3,13 @@
 \zp{Rovnou, tady rovnou}{Greenhorni}
 
 \zs
-\Ch{D}{Tak} už jsem ti teda \Ch{D7}{fouk'},
+<D>Tak už jsem ti teda <D7>fouk',
 
-\Ch{G}{prsten} si dej za klo\Ch{D}{bouk},
+<G>prsten si dej za klo<D>bouk,
 
-\Ch{G}{nechci} tě \Ch{A}{znát} a \Ch{D}{neměl} jsem tě rád,
+<G>nechci tě <A>znát a <D>neměl jsem tě rád,
 
-\Ch{D}{to} ti ří\Ch{A7}{kám} rov\Ch{D}{nou}.
+<D>to ti ří<A7>kám rov<D>nou.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Greenhorni____Zátoka.tex
+++ b/tp-songs/01_folk/Greenhorni____Zátoka.tex
@@ -3,13 +3,13 @@
 \zp{Zátoka}{Greenhorni}
 
 \zs
-V zátoce \Ch{C}{naší} je \Ch{G7}{celej} den \Ch{C}{stín},
+V zátoce <C>naší je <G7>celej den <C>stín,
 
-dneska je \Ch{Ami}{tichá}, já dobře \Ch{C}{vím},
+dneska je <Ami>tichá, já dobře <C>vím,
 
-kdy ten stín \Ch{Ami}{zmizí} i z duše mo\Ch{C}{jí},
+kdy ten stín <Ami>zmizí i z duše mo<C>jí,
 
-za vodou \Ch{F}{čekám} na lásku svo\Ch{C}{ji}.
+za vodou <F>čekám na lásku svo<C>ji.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Hlavolam____Ztráty_a_nálezy.tex
+++ b/tp-songs/01_folk/Hlavolam____Ztráty_a_nálezy.tex
@@ -2,26 +2,26 @@
 
 \zp{Ztráty a nálezy}{Hlavolam}
 
-\Ch{Emi}{} \Ch{D}{} \Ch{Ami}{} \Ch{Emi}{} \Ch{H}{}
+<Emi> <D> <Ami> <Emi> <H>
 
 \zs
-\Ch{Emi}{Kolikrát} jsem minul tuhletu výlohu \Ch{D}{s panáčkem} od sazí,
+<Emi>Kolikrát jsem minul tuhletu výlohu <D>s panáčkem od sazí,
 
-\Ch{Ami}{nikdy} jsem nepřišel na to, co znamená \uv{\Ch{Emi}{ztráty} a nále\Ch{H}{zy}},
+<Ami>nikdy jsem nepřišel na to, co znamená \uv{<Emi>ztráty a nále<H>zy},
 
-\Ch{Emi}{když} dneska pomyslím na ta dvě slovíčka, \Ch{D}{trochu} mě zamrazí,
+<Emi>když dneska pomyslím na ta dvě slovíčka, <D>trochu mě zamrazí,
 
-\Ch{Ami}{vždyť} i v mém životě hrají hlavní roli \Ch{Emi}{ztráty} a nále\Ch{H}{zy.}
+<Ami>vždyť i v mém životě hrají hlavní roli <Emi>ztráty a nále<H>zy.
 \ks
 
 \zr
-A tak ať \Ch{Emi}{hledám} či nehle\Ch{C}{dám,} staré \Ch{D}{ztrácím,} nové nalé\Ch{G}{zám},
+A tak ať <Emi>hledám či nehle<C>dám, staré <D>ztrácím, nové nalé<G>zám,
 
-něco \Ch{Emi}{mám} a pak ne\Ch{C}{mám} zase \Ch{H}{nic},
+něco <Emi>mám a pak ne<C>mám zase <H>nic,
 
-říka\Ch{Emi}{jí, že} je jen \Ch{C}{klam} úsměv \Ch{D}{čarokrásných} \Ch{G}{dam,}
+říka<Emi>jí, že je jen <C>klam úsměv <D>čarokrásných <G>dam,
 
-stále \Ch{Emi}{ztrácím} a nalé\Ch{C}{zám}, někdy \Ch{H}{málo} a někdy víc.
+stále <Emi>ztrácím a nalé<C>zám, někdy <H>málo a někdy víc.
 \kr
 
 \zs
@@ -44,7 +44,7 @@ proto včerejšek dnes smaž, málo vezmeš a snad více dáš,
 stále ztrácíš a nalézáš, někdy málo a někdy víc.
 \kr
 
-Co dál k tomu \Ch{Emi}{říct...} \Ch{D}{} \Ch{Ami}{} \Ch{Emi}{} \Ch{H}{} \Ch{Emi}{}
+Co dál k tomu <Emi>říct... <D> <Ami> <Emi> <H> <Emi>
 
 \kp
 

--- a/tp-songs/01_folk/Hoboes____Bedna_od_whisky.tex
+++ b/tp-songs/01_folk/Hoboes____Bedna_od_whisky.tex
@@ -2,22 +2,22 @@
 
 \zp{Bedna od whisky}{Hoboes}
 \zs
-\Ch{Ami}{Dneska} už mi \Ch{C}{fóry} ňák \Ch{Ami}{nejdou} přes \Ch{E7}{pysky,}
+<Ami>Dneska už mi <C>fóry ňák <Ami>nejdou přes <E7>pysky,
 
-\Ch{Ami}{stojím} s dlouhou \Ch{C}{kravatou} na \Ch{Ami}{bedně} \Ch{E7}{vod} whis\Ch{Ami}{ky.}
+<Ami>stojím s dlouhou <C>kravatou na <Ami>bedně <E7>vod whis<Ami>ky.
 
-Stojím s dlouhým \Ch{C}{vobojkem,} jak \Ch{Ami}{stájovej} \Ch{E7}{pinč,}
+Stojím s dlouhým <C>vobojkem, jak <Ami>stájovej <E7>pinč,
 
-tu \Ch{Ami}{kravatu,} co \Ch{C}{nosím,} mi \Ch{Ami}{navlík} \Ch{E7}{soudce} \Ch{A}{lynč.}  \Ch{G#}{} \Ch{A}{} \Ch{G#}{} \Ch{A}{}
+tu <Ami>kravatu, co <C>nosím, mi <Ami>navlík <E7>soudce <A>lynč. <G#> <A> <G#> <A>
 \ks
 \zr
-Tak kopni do tý \Ch{D}{bedny,} ať \Ch{E}{panstvo} ne\Ch{A}{čeká,}
+Tak kopni do tý <D>bedny, ať <E>panstvo ne<A>čeká,
 
-jsou dlouhý schody \Ch{D}{do nebe} a \Ch{E}{štreka} dale\Ch{A}{ká}
+jsou dlouhý schody <D>do nebe a <E>štreka dale<A>ká
 
-do nebeskýho \Ch{D}{báru,} já \Ch{E}{sucho} v krku \Ch{A}{mám,}
+do nebeskýho <D>báru, já <E>sucho v krku <A>mám,
 
-tak kopni do tý \Ch{D}{bedny,} ať \Ch{E}{na cestu} se \Ch{A}{dám.} \Ch{Ami}{}
+tak kopni do tý <D>bedny, ať <E>na cestu se <A>dám. <Ami>
 \kr
 \zs
 Mít tak všechny bedny od whisky vypitý,
@@ -26,7 +26,7 @@ postavil bych malej dům na louce ukrytý.
 Postavil bych malej dům a z okna koukal ven
 a chlastal bych tam s Billem a chlastal by tam Ben.
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Kdyby 'si se hochu jen pořád nechtěl rvát,
 nemusel jsi dneska na týhle bedně stát.
@@ -34,7 +34,7 @@ nemusel jsi dneska na týhle bedně stát.
 Moh' si někde v suchu tu svoji whisky pít,
 nemusel si dneska na krku laso mít.
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Až kopneš do tý bedny, jak se to dělává,
 do krku mi zůstane jen dírka mrňavá.

--- a/tp-songs/01_folk/Hoboes____Mrtvej_vlak.tex
+++ b/tp-songs/01_folk/Hoboes____Mrtvej_vlak.tex
@@ -3,13 +3,13 @@
 \zp{Mrtvej vlak}{Hoboes}
 
 \zs
-\Ch{Ami}{Znáš tu trať,} co jezdit po ní \Ch{Dmi}{je tak zrovna} k zblázně\Ch{Ami}{ní,}
+<Ami>Znáš tu trať, co jezdit po ní <Dmi>je tak zrovna k zblázně<Ami>ní,
 
-v semaforu místo lampy \Ch{Dmi}{svítěj' kosti} zkříže\Ch{E7}{ný,}
+v semaforu místo lampy <Dmi>svítěj' kosti zkříže<E7>ný,
 
-\Ch{Dmi}{pták tam zpívat} zapomněl a \Ch{F}{vítr jenom} v drátech \Ch{E7}{zní,}
+<Dmi>pták tam zpívat zapomněl a <F>vítr jenom v drátech <E7>zní,
 
-\Ch{Ami}{jednou za rok} touhle tratí \Ch{Dmi}{zaduní vlak} pohřeb\Ch{Ami}{ní.}
+<Ami>jednou za rok touhle tratí <Dmi>zaduní vlak pohřeb<Ami>ní.
 \ks
 
 \zs
@@ -23,13 +23,13 @@ s pavučinou místo kouře jede nocí mrtvej vlak.
 \ks
 
 \zr
-Mrtvej \Ch{Dmi}{vlak, mrtvej} \Ch{F}{vlak nedr}\Ch{Ami}{ží jízdní} \Ch{Cdim}{řád,}
+Mrtvej <Dmi>vlak, mrtvej <F>vlak nedr<Ami>ží jízdní <Cdim>řád,
 
-dálku \Ch{Ami}{máš přece} \Ch{Cdim}{rád,} \Ch{E7}{tak nase}\Ch{Ami}{dat.}
+dálku <Ami>máš přece <Cdim>rád, <E7>tak nase<Ami>dat.
 
-Neměj \Ch{Dmi}{strach, ve ska}\Ch{F}{lách zadu}\Ch{Ami}{ní mrtvej} \Ch{Cdim}{vlak,}
+Neměj <Dmi>strach, ve ska<F>lách zadu<Ami>ní mrtvej <Cdim>vlak,
 
-chceš mít \Ch{Ami}{klid? Máš ho} \Ch{Cdim}{mít,} \Ch{E7}{už jede} \Ch{Ami}{vlak.}
+chceš mít <Ami>klid? Máš ho <Cdim>mít, <E7>už jede <Ami>vlak.
 \kr
 
 \zs
@@ -54,7 +54,7 @@ slunce tady nevychází, cesty zpátky nevedou,
 
 \zr\kr
 
-už jede \Ch{Ami}{vlak, už jede} vlak...
+už jede <Ami>vlak, už jede vlak...
 
 
 \kp

--- a/tp-songs/01_folk/Hoboes____Tak_už_mi_má_holka_mává.tex
+++ b/tp-songs/01_folk/Hoboes____Tak_už_mi_má_holka_mává.tex
@@ -3,27 +3,27 @@
 \zp{Tak už mi má holka mává}{Hoboes}
 
 \zs
-\Ch{Emi}{Posledních} \Ch{D}{pár} minut \Ch{C}{zbejvá} \Ch{Emi}{jen,}
+<Emi>Posledních <D>pár minut <C>zbejvá <Emi>jen,
 
-máš teplou \Ch{D}{dlaň}, už se \Ch{A}{stmí}\Ch{Emi}{vá.}
+máš teplou <D>dlaň, už se <A>stmí<Emi>vá.
 
-Těžký je \Ch{D}{říct}, že se \Ch{C}{končí} \Ch{Emi}{den,}
+Těžký je <D>říct, že se <C>končí <Emi>den,
 
-vlak posl\Ch{D}{ední} vagón \Ch{A}{mív}\Ch{C}{á.}\Ch{E}{}
+vlak posl<D>ední vagón <A>mív<C>á.<E>
 \ks
 
 \zr
-\Ch{G}{Tak} už mi má holka mává,
+<G>Tak už mi má holka mává,
 
-ve vočích má slzy \Ch{F}{páli}\Ch{D}{vý.}
+ve vočích má slzy <F>páli<D>vý.
 
-\Ch{Emi}{Život} jde dál, to se \Ch{C}{stává}, \Ch{A7}{já to} \Ch{D7}{vím.}
+<Emi>Život jde dál, to se <C>stává, <A7>já to <D7>vím.
 
-\Ch{G}{Tak} už mi má holka mává,
+<G>Tak už mi má holka mává,
 
-výpravčí zelenou \Ch{F}{dá}\Ch{D}{vá,}
+výpravčí zelenou <F>dá<D>vá,
 
-tak \Ch{Emi}{jeď,} jeď, jeď, tak jeď.
+tak <Emi>jeď, jeď, jeď, tak jeď.
 \kr
 
 \zs
@@ -36,7 +36,7 @@ smutek je šátek osamění,
 co mužskejm na cestu dává.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Za zády zůstal mi pláč a smích,
@@ -48,7 +48,7 @@ zmizela holka jak loňskej sníh
 a světla měst v dálce svítí.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Hoboes____Tereza.tex
+++ b/tp-songs/01_folk/Hoboes____Tereza.tex
@@ -3,25 +3,25 @@
 \zp{Tereza}{Hoboes}
 
 \zs
-Ten \Ch{C}{den,} co vítr \Ch{D}{listí} z města \Ch{G}{svál,}
+Ten <C>den, co vítr <D>listí z města <G>svál,
 
-můj \Ch{C}{džíp} se vracel, \Ch{D}{jako} by se \Ch{Emi}{bál,}
+můj <C>džíp se vracel, <D>jako by se <Emi>bál,
 
-že \Ch{C}{asfaltov}ý \Ch{D}{moře} odliv \Ch{G}{má}
+že <C>asfaltový <D>moře odliv <G>má
 
-a \Ch{C}{stáj,} že svýho \Ch{D}{koně} \Ch{E}{nepozná.}
+a <C>stáj, že svýho <D>koně <E>nepozná.
 \ks
 
 \zr
-Řekni, \Ch{G}{kolik} je na světě, kolik je takovejch \Ch{D}{měst,}
+Řekni, <G>kolik je na světě, kolik je takovejch <D>měst,
 
-řekni, \Ch{Ami}{kdo} by se vracel, když všude je tisíce \Ch{Emi}{cest.}
+řekni, <Ami>kdo by se vracel, když všude je tisíce <Emi>cest.
 
-Tenkrát, \Ch{G}{když} jsi mi, Terezo, řekla, že ráda mě \Ch{D}{máš,}
+Tenkrát, <G>když jsi mi, Terezo, řekla, že ráda mě <D>máš,
 
-tenkrát \Ch{Ami}{ptal} jsem se, Terezo, kolik mi polibků \Ch{Emi}{dáš,}
+tenkrát <Ami>ptal jsem se, Terezo, kolik mi polibků <Emi>dáš,
 
-napos\Ch{D}{led,} napos\Ch{G}{led.}
+napos<D>led, napos<G>led.
 \kr
 
 \zs
@@ -34,7 +34,7 @@ proč vítr mlátí spoustou okenic,
 proč jsou v ulicích auta, jinak nic.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Do prázdnejch beden zotvíranejch aut
@@ -46,7 +46,7 @@ a v závěji starýho papíru
 válej' se černý klapky z klavírů.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Tak loudám se tím hrozným městem sám
@@ -58,6 +58,6 @@ Jen já tu zůstal s prázdnou ulicí
 a osamělý město mlčící.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Hoboes____Tunel_jménem_Čas.tex
+++ b/tp-songs/01_folk/Hoboes____Tunel_jménem_Čas.tex
@@ -3,13 +3,13 @@
 \zp{Tunel jménem Čas}{Hoboes}
 
 \zs
-Těch \Ch{E}{strašnejch vlaků,} \Ch{G#mi}{co se ženou} \Ch{E7}{kolejí tvejch} \Ch{A}{snů,}
+Těch <E>strašnejch vlaků, <G#mi>co se ženou <E7>kolejí tvejch <A>snů,
 
-těch \Ch{Ami}{asi už se} \Ch{E}{nezbavíš} \Ch{F#7}{do posledních} \Ch{H7}{dnů,}
+těch <Ami>asi už se <E>nezbavíš <F#7>do posledních <H7>dnů,
 
-a \Ch{E}{hvězdy žhavejch} \Ch{G#mi}{uhlíků ti} \Ch{E7}{nikdy nedaj'} \Ch{A}{spát,}
+a <E>hvězdy žhavejch <G#mi>uhlíků ti <E7>nikdy nedaj' <A>spát,
 
-tvá \Ch{Ami}{dráha míří} k \Ch{E}{tunelu} a \Ch{F/E}{tunel, ten má} \Ch{E}{hlad.}
+tvá <Ami>dráha míří k <E>tunelu a <F/E>tunel, ten má <E>hlad.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Hop_Trop____Amazonka.tex
+++ b/tp-songs/01_folk/Hop_Trop____Amazonka.tex
@@ -2,11 +2,11 @@
 
 \zp{Amazonka}{Hop Trop}
 \zs
-Byly krásný naše \Ch{G}{plány},
-{byla} jsi můj celej \Ch{Hmi}{svět}, \Ch{A#mi}{} \Ch{Ami}{}
+Byly krásný naše <G>plány,
+{byla} jsi můj celej <Hmi>svět, <A#mi> <Ami>
 
-čas je vzal a nechal \Ch{G}{rány},
-\Ch{Ami}{starší} jsme jen o pár \Ch{D}{let.}
+čas je vzal a nechal <G>rány,
+<Ami>starší jsme jen o pár <D>let.
 \ks
 \zs
 Tenkrát byly děti malý, ale život utíká,
@@ -14,9 +14,9 @@ Tenkrát byly děti malý, ale život utíká,
 už na \uv{táto} slyší jinej, i když si tak neříká.
 \ks
 \zr
-Nebe modrý zrcad\Ch{G}{lí} se \Ch{E7}{v ře}ce, která všechno \Ch{Ami}{ví,}
+Nebe modrý zrcad<G>lí se <E7>v řece, která všechno <Ami>ví,
 
-stejnou barvou, jakou \Ch{G}{měly} \Ch{Ami}{tvoje} oči džín\Ch{D}{ový.}
+stejnou barvou, jakou <G>měly <Ami>tvoje oči džín<D>ový.
 \kr
 \zs
 Kluci tenkrát, co tě znali, všude kde jsem s tebou byl,
@@ -28,7 +28,7 @@ Tvoje strachy, že ti mládí pod rukama utíká,
 
 vedly k tomu, že ti nikdo Amazonka neříká.
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Zlatý kráse cingrlátek,
 jak sis časem myslela,
@@ -37,11 +37,11 @@ vadil možná trampskej šátek,
 nosit dál's ho nechtěla.
 \ks
 \zs
-Teď si víla z pane\Ch{G}{láku,} \Ch{E7}{samá} dečka, samej \Ch{Ami}{krám.}
+Teď si víla z pane<G>láku, <E7>samá dečka, samej <Ami>krám.
 
-Já si přál jen, abys \Ch{G}{byla} \Ch{Ami}{pořád} stejná, přísa\Ch{G}{hám,}
+Já si přál jen, abys <G>byla <Ami>pořád stejná, přísa<G>hám,
 
-\Ch{Ami}{pořád} stejná, přísa\Ch{G}{hám}.
+<Ami>pořád stejná, přísa<G>hám.
 \ks
 \zr \kr
 \kp

--- a/tp-songs/01_folk/Hop_Trop____Lufťáci.tex
+++ b/tp-songs/01_folk/Hop_Trop____Lufťáci.tex
@@ -3,23 +3,23 @@
 \zp{Lufťáci}{Hop Trop}
 
 \zs
-Lufťáků \Ch{D}{parta} zamkla svý auta, na vejlet každej vyjel se svou mami\Ch{A7}{nou}
+Lufťáků <D>parta zamkla svý auta, na vejlet každej vyjel se svou mami<A7>nou
 
-navštívit zámky, oběhnout stánky a ušmudlanej z rozhledny se kochat kraji\Ch{D}{nou.}
+navštívit zámky, oběhnout stánky a ušmudlanej z rozhledny se kochat kraji<D>nou.
 
-Hradem se mihli, to aby stihli proběhnout památku a hurá za ji\Ch{A7}{nou,}
+Hradem se mihli, to aby stihli proběhnout památku a hurá za ji<A7>nou,
 
-nohama pletli, do hlav si \Ch{Hmi}{hnětli} \Ch{A}{Švarcenberky,} Rožmberky, Žižku s Kozi\Ch{D}{nou.}
+nohama pletli, do hlav si <Hmi>hnětli <A>Švarcenberky, Rožmberky, Žižku s Kozi<D>nou.
 \ks
 
 \zr
-\Ch{Hmi}{Fousatej pobuda} u cesty v širáku na malej ohníček přikládá \Ch{F#7}{chrastí,}
+<Hmi>Fousatej pobuda u cesty v širáku na malej ohníček přikládá <F#7>chrastí,
 
-sedí na šutráku, vestu má chlupatou a lžící vohnutou konzervu \Ch{Hmi}{baští.}
+sedí na šutráku, vestu má chlupatou a lžící vohnutou konzervu <Hmi>baští.
 
-\uv{To bude chuligán,} nejstarší varuje, \uv{všechny nás oloupí, nechoďte k \Ch{F#7}{němu!}
+\uv{To bude chuligán,} nejstarší varuje, \uv{všechny nás oloupí, nechoďte k <F#7>němu!
 
-Půjdeme obloukem a já pro jistotu do ruky pořádnej klacek si \Ch{Hmi}{ve-}\Ch{A}{mu.}}
+Půjdeme obloukem a já pro jistotu do ruky pořádnej klacek si <Hmi>ve-<A>mu.}
 \kr
 
 \zs

--- a/tp-songs/01_folk/Hop_Trop____Lufťáci.tex
+++ b/tp-songs/01_folk/Hop_Trop____Lufťáci.tex
@@ -19,7 +19,7 @@ sedí na šutráku, vestu má chlupatou a lžící vohnutou konzervu <Hmi>bašt�
 
 \uv{To bude chuligán,} nejstarší varuje, \uv{všechny nás oloupí, nechoďte k <F#7>němu!
 
-Půjdeme obloukem a já pro jistotu do ruky pořádnej klacek si <Hmi>ve-<A>mu.}
+Půjdeme obloukem a já pro jistotu do ruky pořádnej klacek si <Hmi>ve<A>mu.}
 \kr
 
 \zs

--- a/tp-songs/01_folk/Hop_Trop____Překvápko.tex
+++ b/tp-songs/01_folk/Hop_Trop____Překvápko.tex
@@ -3,13 +3,13 @@
 \zp{Překvápko}{Hop Trop}
 
 \zs
-\Ch{C}{Zaslech'} \Ch{Ami}{jsem, že} \Ch{Dmi}{tuto}\Ch{G7}{vě v} \Ch{C}{Praze} \Ch{Ami}{pět na} \Ch{Dmi}{Smícho}\Ch{G7}{vě}
+<C>Zaslech' <Ami>jsem, že <Dmi>tuto<G7>vě v <C>Praze <Ami>pět na <Dmi>Smícho<G7>vě
 
-\Ch{C}{někdo} \Ch{Ami}{střelí} \Ch{Dmi}{indi}\Ch{G7}{ánskou} \Ch{C}{loď,} \Ch{C7}{}
+<C>někdo <Ami>střelí <Dmi>indi<G7>ánskou <C>loď, <C7>
 
-hned \Ch{F}{napadlo} mě \Ch{C7}{bleskově,} že \Ch{F}{po důkladný} \Ch{C7}{opravě}
+hned <F>napadlo mě <C7>bleskově, že <F>po důkladný <C7>opravě
 
-s ní \Ch{F}{překvapím} svou \Ch{C7}{milovanou} \Ch{F}{choť.} \Ch{G}{}
+s ní <F>překvapím svou <C7>milovanou <F>choť. <G>
 \ks
 
 \zs
@@ -33,13 +33,13 @@ mě stálo tenkrát čtyřicet dvě flašky.
 \ks
 
 \zr
-\Ch{G}{Poplujem} \Ch{D7}{spolu} tam dolů tou peřejí,
+<G>Poplujem <D7>spolu tam dolů tou peřejí,
 
-přestože \Ch{G}{vodákům} v ČSD nepřejí,
+přestože <G>vodákům v ČSD nepřejí,
 
-řeka nám \Ch{C}{píseň} \Ch{Cmi}{bude} \Ch{G}{hrát,}
+řeka nám <C>píseň <Cmi>bude <G>hrát,
 
-že lodě \Ch{D7}{nechtěj'} nikde \Ch{G}{brát.}
+že lodě <D7>nechtěj' nikde <G>brát.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Hop_Trop____Tři_kříže.tex
+++ b/tp-songs/01_folk/Hop_Trop____Tři_kříže.tex
@@ -2,35 +2,35 @@
 
 \zp{Tři kříže}{Hop Trop}
 \zs
-\Ch{Dmi}{Dávám} sbohem \Ch{C}{břehům} prokla\Ch{Ami}{tejm},
+<Dmi>Dávám sbohem <C>břehům prokla<Ami>tejm,
 
-který v \Ch{Dmi}{drápech} má \Ch{C}{Ďábel} \Ch{Dmi}{sám.}
+který v <Dmi>drápech má <C>Ďábel <Dmi>sám.
 
-Bílou přídí \Ch{C}{šalupa} \uv{My \Ch{Ami}{Grave}}
+Bílou přídí <C>šalupa \uv{My <Ami>Grave}
 
-míří \Ch{Dmi}{k úte}sům, \Ch{C}{který} \Ch{Dmi}{znám.}
+míří <Dmi>k útesům, <C>který <Dmi>znám.
 \ks
 \zr
-Jen tři \Ch{F}{kříže} z bí\Ch{C}{lýho} kame\Ch{Ami}{ní}
+Jen tři <F>kříže z bí<C>lýho kame<Ami>ní
 
-někdo \Ch{Dmi}{do pí}sku \Ch{C}{posklá}\Ch{Dmi}{dal.}
+někdo <Dmi>do písku <C>posklá<Dmi>dal.
 
-Slzy v \Ch{F}{očích} měl a v \Ch{C}{ruce} znave\Ch{Ami}{ný}
+Slzy v <F>očích měl a v <C>ruce znave<Ami>ný
 
-lodní \Ch{Dmi}{deník}, co \Ch{C}{sám} do něj \Ch{Dmi}{psal}.
+lodní <Dmi>deník, co <C>sám do něj <Dmi>psal.
 \kr
 \zs
 První kříž má pod sebou jen hřích, samý pití a rvačka jen.
 
 Chřestot nožů, při kterých přejde smích, srdce kámen a jméno Sten.
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Já, Bob Green, mám tváře zjizvený, štěkot psa zněl, když jsem se smál.
 
 Druhej kříž mám a spím pod zemí, že jsem falešný karty hrál.
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Třetí kříž sand vyvolá jen vztek, Katty Rodgers těm dvoum život vzal.
 

--- a/tp-songs/01_folk/Hop_Trop____Černej_den.tex
+++ b/tp-songs/01_folk/Hop_Trop____Černej_den.tex
@@ -3,39 +3,39 @@
 \zp{Černej den}{Hop Trop}
 
 \zs
-\Ch{Dmi}{Ten den byl} beznadějně \Ch{C}{černej,}
+<Dmi>Ten den byl beznadějně <C>černej,
 
-\Ch{Dmi}{jak darebáků} svědo\Ch{C}{mí,}
+<Dmi>jak darebáků svědo<C>mí,
 
-\Ch{B}{jak smutku} nával nepře\Ch{A7}{bernej,}
+<B>jak smutku nával nepře<A7>bernej,
 
-\Ch{B}{kterej se} náhle prolo\Ch{A7}{mí.}
+<B>kterej se náhle prolo<A7>mí.
 
-\Ch{Dmi}{Pomalu stoupali} jsme \Ch{C}{strání}
+<Dmi>Pomalu stoupali jsme <C>strání
 
-\Ch{Dmi}{až k jedný} z nevelikejch \Ch{C}{skal,}
+<Dmi>až k jedný z nevelikejch <C>skal,
 
-\Ch{B}{na který} nechal sny a \Ch{A7}{plány}
+<B>na který nechal sny a <A7>plány
 
-\Ch{B}{jeden} z těch \Ch{A7}{kluků,} co jsem \Ch{Dmi}{znal.}
+<B>jeden z těch <A7>kluků, co jsem <Dmi>znal.
 \ks
 
 \zr
-\Ch{F}{Stačilo} málo chybnejch \Ch{C}{kroků,}
+<F>Stačilo málo chybnejch <C>kroků,
 
-\Ch{F}{vtom} znenadání volnej \Ch{A7}{pád,}
+<F>vtom znenadání volnej <A7>pád,
 
-\Ch{Dmi}{je to už} pěkná řádka \Ch{C}{roků,}
+<Dmi>je to už pěkná řádka <C>roků,
 
-v \Ch{B}{noci si} \Ch{A7}{lesem cestu} \Ch{Dmi}{zmát'.}
+v <B>noci si <A7>lesem cestu <Dmi>zmát'.
 
-Pak \Ch{F}{ležel} s kostrou zlámanou a \Ch{C}{strašně} moc chtěl žít,
+Pak <F>ležel s kostrou zlámanou a <C>strašně moc chtěl žít,
 
-však \Ch{Dmi}{usíná a přestanou} myš\Ch{A7}{lenky hlavou jít,}
+však <Dmi>usíná a přestanou myš<A7>lenky hlavou jít,
 
-z nás \Ch{F}{každej} potom nad ním stál, chlad \Ch{C}{rána} na nás dejch',
+z nás <F>každej potom nad ním stál, chlad <C>rána na nás dejch',
 
-ví\Ch{Dmi}{tr si s listím} pohrával ve \Ch{A7}{větvích březovejch.}
+ví<Dmi>tr si s listím pohrával ve <A7>větvích březovejch.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Hop_Trop____Švorcák.tex
+++ b/tp-songs/01_folk/Hop_Trop____Švorcák.tex
@@ -3,14 +3,14 @@
 \zp{Švorcák}{Hop Trop}
 
 \zs
-S \Ch{Dmi}{partou} kluků v \Ch{B}{koutě} na pe\Ch{A7}{rónu}
+S <Dmi>partou kluků v <B>koutě na pe<A7>rónu
 
-\Ch{Dmi}{tejrali} jsme \Ch{B}{jednou} struny \Ch{C}{kytar} laci\Ch{A7}{nejch},
+<Dmi>tejrali jsme <B>jednou struny <C>kytar laci<A7>nejch,
 
-\Ch{Dmi}{vo pár} kroků \Ch{B}{dál} se na nás \Ch{A7}{díval}
+<Dmi>vo pár kroků <B>dál se na nás <A7>díval
 
-\Ch{Dmi}{starej} pán, už \Ch{B}{vod} pohledu \Ch{C}{trochu} 
-podiv\Ch{Dmi}{nej.}
+<Dmi>starej pán, už <B>vod pohledu <C>trochu 
+podiv<Dmi>nej.
 \ks
 \zs
 Hned se vecpal s náma do vagónu,
@@ -22,13 +22,13 @@ na kytaru na mým klíně koukal
 a za chvíli ptal se, jestli mu ji neprodám.
 \ks
 \zr
-\Ch{F}{Nezdálo} se, že je ňákej \Ch{Gmi}{švorcák},
+<F>Nezdálo se, že je ňákej <Gmi>švorcák,
 
-\Ch{F}{co} by neměl prachy, který \Ch{Gmi}{dal by} za no\Ch{A}{vou},
+<F>co by neměl prachy, který <Gmi>dal by za no<A>vou,
 
-\Ch{F}{měl} podivnej hlas a divný \Ch{Gmi}{voči,}\Ch{A}{}
+<F>měl podivnej hlas a divný <Gmi>voči,<A>
 
-\Ch{Dmi}{říkal}, že měl \Ch{B}{kdysi} dávno \Ch{C}{taky} tako\Ch{Dmi}{vou.}
+<Dmi>říkal, že měl <B>kdysi dávno <C>taky tako<Dmi>vou.
 \kr
 \zs
 \uv{To vomlácený dřevo není k mání,
@@ -39,7 +39,7 @@ je to dárek od někoho z mládí,
 
 a ten jistě nikomu a nikdy neprodá.}
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Když jsem večer v neděli svý mámě
 

--- a/tp-songs/01_folk/Humbuk____MatFyz_Blues.tex
+++ b/tp-songs/01_folk/Humbuk____MatFyz_Blues.tex
@@ -3,13 +3,13 @@
 \zp{Matfyz Blues}{Humbuk}
 
 \zs
-\Ch{E}{Nabalil} jsem na Matfyzu doktorku,
+<E>Nabalil jsem na Matfyzu doktorku,
 tato kost mi pronikla až do morku,
 
 děsila mě, že si spolu nehajnem,
 nebudu-li nosit triko s Einsteinem,
 
-triko s Eins\Ch{A7}{teinem}, jinak si nehaj\Ch{E}{nem},
+triko s Eins<A7>teinem, jinak si nehaj<E>nem,
 jinak nehajnem, jinak nehajnem.
 \ks
 

--- a/tp-songs/01_folk/Ivan_Mládek____Hlasná_třebáň.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Hlasná_třebáň.tex
@@ -2,24 +2,24 @@
 
 \zp{Hlásná Třebáň}{Ivan Mládek}
 \zr
-\Ch{A}{Hlásná} Třebáň je \Ch{C#mi}{krásná,}
+<A>Hlásná Třebáň je <C#mi>krásná,
 
-a proto \Ch{Hmi}{ke svý Máně} \Ch{E7}{do Třebáně}
+a proto <Hmi>ke svý Máně <E7>do Třebáně
 
-\Ch{A}{často} jezdit \Ch{E7}{hledím.}
+<A>často jezdit <E7>hledím.
 
-\Ch{A}{Hlásná} Třebáň je \Ch{C#mi}{krásná,}
+<A>Hlásná Třebáň je <C#mi>krásná,
 
-u Máni v \Ch{Hmi}{Třebáni} si \Ch{E7}{prostě} lebe\Ch{A}{dím.}
+u Máni v <Hmi>Třebáni si <E7>prostě lebe<A>dím.
 \kr
 \zs
-\Ch{D}{Dole} u Berounky \Ch{A}{roste kapradí,}
+<D>Dole u Berounky <A>roste kapradí,
 
-\Ch{Hmi}{komáři} že \Ch{E7}{koušou,} \Ch{A}{to nám} neva\Ch{A7}{dí.}
+<Hmi>komáři že <E7>koušou, <A>to nám neva<A7>dí.
 
-\Ch{D}{Máňu} u řeky když \Ch{A}{večer} objímám,
+<D>Máňu u řeky když <A>večer objímám,
 
-\Ch{H7}{tak} bodání hmyzu \Ch{E7}{vůbec} nevnímám.  \ks
+<H7>tak bodání hmyzu <E7>vůbec nevnímám. \ks
 
 \zr
 Hlásná Třebáň je krásná,

--- a/tp-songs/01_folk/Ivan_Mládek____Jez.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Jez.tex
@@ -2,23 +2,23 @@
 
 \zp{Jez}{Ivan Mládek}
 \zs
-\Ch{A}{Na} vodu už \Ch{E7}{jezdím} jenom s \Ch{A}{Vendou}, s \Ch{E7}{Vendou},
+<A>Na vodu už <E7>jezdím jenom s <A>Vendou, s <E7>Vendou,
 
-\Ch{A}{do} kanoe \Ch{E7}{nevlezu} už s \Ch{A}{Jendou} \Ch{E7}{Bendou},
+<A>do kanoe <E7>nevlezu už s <A>Jendou <E7>Bendou,
 
-\Ch{Hmi}{Jenda} \Ch{E7}{Benda} \Ch{A}{nemožný} je \Ch{F#7}{zadák},
+<Hmi>Jenda <E7>Benda <A>nemožný je <F#7>zadák,
 
-\Ch{H7}{nemá} vlohy a je \Ch{E7}{laj}-, laj-, lajdák:
+<H7>nemá vlohy a je <E7>laj-, laj-, lajdák:
 \ks
 
 \zr
-Von \Ch{A}{ví}, že šumí les, že \Ch{F#7}{kvete} bílý bez,
+Von <A>ví, že šumí les, že <F#7>kvete bílý bez,
 
-že \Ch{H7}{v dáli} hárá pes, že \Ch{E7}{vysouší} se mez
+že <H7>v dáli hárá pes, že <E7>vysouší se mez
 
-a že \Ch{A}{mostem} cloumá rez, že \Ch{F#7}{říčka} jde skrz ves,
+a že <A>mostem cloumá rez, že <F#7>říčka jde skrz ves,
 
-ale \Ch{H7}{nevšimne} si, že se blíží \Ch{F7}{jez}, \Ch{E7}{jez}, \Ch{A}{jez}.
+ale <H7>nevšimne si, že se blíží <F7>jez, <E7>jez, <A>jez.
 \kr
 \zs
 Jel jsem tuhle Ohři s Jendou Bendou, Bendou,

--- a/tp-songs/01_folk/Ivan_Mládek____Jožin_z_bažin.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Jožin_z_bažin.tex
@@ -8,7 +8,7 @@ spěchám, proto riskuji, <E>projíždím přes <Ami>Moravu.
 
 <G7>Řádí tam to <C>strašidlo, <G7>vystupuje z <C>ba<E>žin,
 
-<Ami>žere hlavně Pražáky, <E>jmenuje se <Ami>Jo-<G7>žin.
+<Ami>žere hlavně Pražáky, <E>jmenuje se <Ami>Jo<G7>žin.
 \ks
 \zr
 <C>Jožin z bažin močálem se <G7>plíží,

--- a/tp-songs/01_folk/Ivan_Mládek____Jožin_z_bažin.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Jožin_z_bažin.tex
@@ -2,26 +2,26 @@
 
 \zp{Jožin z bažin}{Ivan Mládek}
 \zs
-\Ch{Ami}{Jedu} takhle tábořit \Ch{E}{Škodou} 100 na \Ch{Ami}{Oravu,}
+<Ami>Jedu takhle tábořit <E>Škodou 100 na <Ami>Oravu,
 
-spěchám, proto riskuji, \Ch{E}{projíždím} přes \Ch{Ami}{Moravu.}
+spěchám, proto riskuji, <E>projíždím přes <Ami>Moravu.
 
-\Ch{G7}{Řádí} tam to \Ch{C}{strašidlo}, \Ch{G7}{vystupuje} z \Ch{C}{ba}\Ch{E}{žin,}
+<G7>Řádí tam to <C>strašidlo, <G7>vystupuje z <C>ba<E>žin,
 
-\Ch{Ami}{žere} hlavně Pražáky, \Ch{E}{jmenuje} se \Ch{Ami}{Jo-}\Ch{G7}{žin.}
+<Ami>žere hlavně Pražáky, <E>jmenuje se <Ami>Jo-<G7>žin.
 \ks
 \zr
-\Ch{C}{Jožin} z bažin močálem se \Ch{G7}{plíží,}
+<C>Jožin z bažin močálem se <G7>plíží,
 
-Jožin z bažin k vesnici se \Ch{C}{blíží,}
+Jožin z bažin k vesnici se <C>blíží,
 
-Jožin z bažin už si zuby \Ch{G7}{brousí,}
+Jožin z bažin už si zuby <G7>brousí,
 
-Jožin z bažin kouše, saje, \Ch{C}{rdousí.}
+Jožin z bažin kouše, saje, <C>rdousí.
 
-\Ch{F}{Na Jožina} z \Ch{C}{bažin}, \Ch{G}{koho} by to napad\Ch{C}{lo},
+<F>Na Jožina z <C>bažin, <G>koho by to napad<C>lo,
 
-\Ch{F}{platí} jen a \Ch{C}{pouze} \Ch{G}{práškovací} letad\Ch{C}{lo.} \Ch{E}{}
+<F>platí jen a <C>pouze <G>práškovací letad<C>lo. <E>
 \kr
 \zs
 Projížděl jsem Moravou směrem na Vizovice,
@@ -32,7 +32,7 @@ přivítal mě předseda, řek' mi u slivovice:
 
 tomu já dám za ženu dceru a půl JZD!}
 \ks
-\zr  \kr
+\zr \kr
 \zs
 Říkám: \uv{Dej mi, předsedo, letadlo a prášek,
 

--- a/tp-songs/01_folk/Ivan_Mládek____Láďa_jede_lodí.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Láďa_jede_lodí.tex
@@ -2,37 +2,37 @@
 
 \zp{Láďa jede lodí}{Ivan Mládek}
 \zs
-\Ch{C}{Láďa} \Ch{G7}{jede} \Ch{C}{lodí,} \Ch{G7}{tou} \Ch{C}{lodí} \Ch{G7}{výlet}\Ch{C}{ní,} \Ch{G7}{}
+<C>Láďa <G7>jede <C>lodí, <G7>tou <C>lodí <G7>výlet<C>ní, <G7>
 
-\Ch{C}{k Lí}dě, \Ch{G7}{co} s ní \Ch{C}{chodí,}
+<C>k Lídě, <G7>co s ní <C>chodí,
 
-\Ch{Ami}{Láďa} \Ch{Dmi}{Horký} \Ch{G7}{jede} \Ch{C}{k ní.} \Ch{G7}{}
+<Ami>Láďa <Dmi>Horký <G7>jede <C>k ní. <G7>
 
-\Ch{C}{Jestli} s \Ch{G7}{sebou} \Ch{C}{hodí,} \Ch{G7}{ten} \Ch{C}{parník} 
-\Ch{G7}{výlet}\Ch{C}{ní,} \Ch{G7}{}
+<C>Jestli s <G7>sebou <C>hodí, <G7>ten <C>parník 
+<G7>výlet<C>ní, <G7>
 
-\Ch{C}{Lída} \Ch{G7}{bude} \Ch{C}{překva}\Ch{Ami}{pena,} \Ch{Dmi}{že je} 
-\Ch{G7}{Láďa} s \Ch{C}{ní.} \Ch{G7}{}
+<C>Lída <G7>bude <C>překva<Ami>pena, <Dmi>že je 
+<G7>Láďa s <C>ní. <G7>
 \ks
 
 \zr
-\Ch{E7}{V pod}palubí topič přiklá\Ch{Ami}{dá,}
+<E7>V podpalubí topič přiklá<Ami>dá,
 
-\Ch{D7}{na} lodi je skvělá nála\Ch{G7}{da.}
+<D7>na lodi je skvělá nála<G7>da.
 
-\Ch{G7}{A ce}lý \Ch{C}{kraj,} \Ch{G7}{kraj,}
+<G7>A celý <C>kraj, <G7>kraj,
 
-\Ch{C}{kraj} \Ch{G7}{to} \Ch{C}{cítí,} \Ch{G7}{že} je \Ch{C}{máj,} \Ch{G7}{}
+<C>kraj <G7>to <C>cítí, <G7>že je <C>máj, <G7>
 
-\Ch{C}{Láďa} \Ch{G7}{Lídu} \Ch{C}{vyhle}\Ch{Ami}{dá a} \Ch{Dmi}{pak} si 
-\Ch{G7}{pusu} \Ch{C}{daj.}
+<C>Láďa <G7>Lídu <C>vyhle<Ami>dá a <Dmi>pak si 
+<G7>pusu <C>daj.
 
-\Ch{G7}{A celý} \Ch{C}{kraj,} \Ch{G7}{kraj,}
+<G7>A celý <C>kraj, <G7>kraj,
 
-\Ch{C}{kraj} \Ch{G7}{to} \Ch{C}{cítí,} \Ch{G7}{že} je \Ch{C}{máj,} \Ch{G7}{}
+<C>kraj <G7>to <C>cítí, <G7>že je <C>máj, <G7>
 
-\Ch{C}{Láďa} \Ch{G7}{Lídu} \Ch{C}{vyhle}\Ch{Ami}{dá a} \Ch{Dmi}{pak} si 
-\Ch{G7}{pusu} \Ch{C}{daj}
+<C>Láďa <G7>Lídu <C>vyhle<Ami>dá a <Dmi>pak si 
+<G7>pusu <C>daj
 \kr
 
 \zs

--- a/tp-songs/01_folk/Ivan_Mládek____Prachovské_skály.tex
+++ b/tp-songs/01_folk/Ivan_Mládek____Prachovské_skály.tex
@@ -2,37 +2,37 @@
 
 \zp{Prachovské skály}{Ivan Mládek}
 
-\Ch{Ami}{Tak} polez!
+<Ami>Tak polez!
 
 Nepolezu!
 
 \zs
-\Ch{Ami}{Zavři} svoje oči, Hano, rozvázalo se ti lano,
+<Ami>Zavři svoje oči, Hano, rozvázalo se ti lano,
 
-\Ch{Dmi}{padej} trochu doprava, pod námi jde výprava!
+<Dmi>padej trochu doprava, pod námi jde výprava!
 
-\Ch{E7}{BUCH!}
+<E7>BUCH!
 
-Tentokrát to \Ch{Ami}{dobře} dopadlo.
+Tentokrát to <Ami>dobře dopadlo.
 
-\Ch{H7}{Zahrála} si turistům \Ch{E7}{hrozné} divad\Ch{Ami}{lo.}  \Ch{G}{} \ks
+<H7>Zahrála si turistům <E7>hrozné divad<Ami>lo. <G> \ks
 
 \zr
-\Ch{C}{Co} bychom se báli \Ch{F}{na} Prachovské skály,
+<C>Co bychom se báli <F>na Prachovské skály,
 
-\Ch{C}{dudláj} \Ch{G7}{dudláj} \Ch{C}{dá.} /\Ch{G7}{ram} pam pam pam/
+<C>dudláj <G7>dudláj <C>dá. /<G7>ram pam pam pam/
 
-\Ch{C}{Do} Českého ráje \Ch{F}{cesta} příjemná je,
+<C>Do Českého ráje <F>cesta příjemná je,
 
-\Ch{C}{dudláj} \Ch{G7}{dudláj} \Ch{C}{dá.} /\Ch{C7}{ram} pam pam pam/
+<C>dudláj <G7>dudláj <C>dá. /<C7>ram pam pam pam/
 
-\Ch{F}{Horolezci}, horolezkyně, \Ch{C}{horolezčata},
+<F>Horolezci, horolezkyně, <C>horolezčata,
 
-\Ch{D7}{nelezte} na skálu, co je \Ch{G7}{hodně} špičatá.
+<D7>nelezte na skálu, co je <G7>hodně špičatá.
 
-\Ch{C}{Spadnete} do písku \Ch{F}{a svou} rodnou vísku
+<C>Spadnete do písku <F>a svou rodnou vísku
 
-nespatříte více dudláj \Ch{C}{dá.}
+nespatříte více dudláj <C>dá.
 \kr
 Neboj se, polez!
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Afričančata.tex
@@ -3,18 +3,18 @@
 \zp{Afričančata}{Jarek Nohavica}
 \zs
 
-\Ch{C}{V Africe}, tam žijou sloni \Ch{Ami}{a po}\Ch{Dmi}{dobná} 
-zvířa\Ch{G}{ta}, \Ch{C}{}
+<C>V Africe, tam žijou sloni <Ami>a po<Dmi>dobná 
+zvířa<G>ta, <C>
 
 
-mezi stromy je tam honí \Ch{Dmi}{Afri}\Ch{G}{čan}ča\Ch{C}{ta,}
+mezi stromy je tam honí <Dmi>Afri<G>čanča<C>ta,
 
 
-\Ch{F}{načančané} \Ch{G}{Afričanče} \Ch{C}{jako} \Ch{Dmi}{uhel} černé 
-\Ch{G}{je,}
+<F>načančané <G>Afričanče <C>jako <Dmi>uhel černé 
+<G>je,
 
 
-\Ch{C}{ráno} skočí na saranče \Ch{Ami}{a je}\Ch{Dmi}{de do} \Ch{G}{Guine}\Ch{C}{je}.\Ch{F}{ } \Ch{G}{ } \Ch{C}{ } \Ch{G}{ } \Ch{C}{ }
+<C>ráno skočí na saranče <Ami>a je<Dmi>de do <G>Guine<C>je.<F> <G> <C> <G> <C> 
 
 \ks
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Až_to_se_mnu_sekne.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Až_to_se_mnu_sekne.tex
@@ -6,21 +6,21 @@
 \zp{Až to se mnu sekne}{Jarek Nohavica}
 
 \zs
-Až \Ch{Ami}{obuju si} rano \Ch{E7}{černe} papirove \Ch{Ami}{boty,}
+Až <Ami>obuju si rano <E7>černe papirove <Ami>boty,
 
-až i \Ch{C}{moja} stara pocho\Ch{G}{pi, že nejdu} do ro\Ch{C}{boty,}
+až i <C>moja stara pocho<G>pi, že nejdu do ro<C>boty,
 
-až \Ch{Dmi}{vyjde dluhy pruvod} smutečnich hostu
+až <Dmi>vyjde dluhy pruvod smutečnich hostu
 
-na \Ch{Ami}{Slezsku Ostravu} od Sikorova mostu,
+na <Ami>Slezsku Ostravu od Sikorova mostu,
 
-\Ch{E7}{až to se mnu sekne,} to bude \Ch{Ami}{pěkne.}
+<E7>až to se mnu sekne, to bude <Ami>pěkne.
 \ks
 
 \zr
-\Ch{Dmi}{Pěkne, fajne} a \Ch{Ami}{pěkne,}
+<Dmi>Pěkne, fajne a <Ami>pěkne,
 
-\Ch{E7}{až to se mnu} definitivně \Ch{Ami}{sekne.} \Ch{E7}{} \Ch{Ami}{} \Ch{E7}{}
+<E7>až to se mnu definitivně <Ami>sekne. <E7> <Ami> <E7>
 \kr
 
 \zs
@@ -76,14 +76,14 @@ Až obuju si rano černe papirove boty,
 
 až i moja stara pochopi, že nejdu do roboty,
 
-/: \Ch{F}{kdybych,} co chtěl, dělal, všechno malo platne,
+/: <F>kdybych, co chtěl, dělal, všechno malo platne,
 
-\Ch{Ami}{mohlo to byt} horši, nebylo to \Ch{E7}{špatne,}
+<Ami>mohlo to byt horši, nebylo to <E7>špatne,
 
-až to se mnu \Ch{Ami}{sekne.} :/
+až to se mnu <Ami>sekne. :/
 \ks
 
-\Ch{Dmi}{Ná na na ná ná} \Ch{Ami}{ná na na ná ná} \Ch{E7}{...}
-\Ch{Ami}{} \Ch{Dmi}{} \Ch{Ami}{} \Ch{E7}{} \Ch{Ami}{}
+<Dmi>Ná na na ná ná <Ami>ná na na ná ná <E7>...
+<Ami> <Dmi> <Ami> <E7> <Ami>
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Básnířka.tex
@@ -2,20 +2,20 @@
 
 \zp{Básnířka}{Jarek Nohavica}
 \zs
-\Ch{G}{Mladičká} \Ch{D}{básnířka} s \Ch{C}{korálky} \Ch{D}{nad} kotní\Ch{G}{ky} \Ch{D}{} \Ch{C}{} \Ch{D}{}
+<G>Mladičká <D>básnířka s <C>korálky <D>nad kotní<G>ky <D> <C> <D>
 
-\Ch{G}{bouchala} \Ch{D}{na dvířka} \Ch{C}{paláce} \Ch{D}{poe}ti\Ch{Emi}{ky.}
+<G>bouchala <D>na dvířka <C>paláce <D>poeti<Emi>ky.
 \ifdefined\TPBAND
-	(\Ch{G}{ba}\Ch{B}{ss}\Ch{C}{a)}
+	(<G>ba<B>ss<C>a)
 \fi
 
-\Ch{G}{S někým} se \Ch{C}{vyspa}\Ch{G}{la}, někomu \Ch{C}{neda}\Ch{G}{la}, láska jako \Ch{D}{hobby,}
+<G>S někým se <C>vyspa<G>la, někomu <C>neda<G>la, láska jako <D>hobby,
 \ifdefined\TPBAND
-	(\Ch{E}{ba}\Ch{F#}{ssa)}
+	(<E>ba<F#>ssa)
 \fi
 
-\Ch{G}{pak} o tom \Ch{D}{nap}sala \Ch{C}{sonetu} na \Ch{D}{čtyř}i 
-\Ch{G}{doby.}  \Ch{D}{} \Ch{C}{} \Ch{D}{}
+<G>pak o tom <D>napsala <C>sonetu na <D>čtyři 
+<G>doby. <D> <C> <D>
 \ks
 \zs
 Svoje srdce skloňovala podle vzoru Ferlinghetti,

--- a/tp-songs/01_folk/Jarek_Nohavica____Cukrářská_bossanova.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Cukrářská_bossanova.tex
@@ -3,33 +3,33 @@
 \zp{Cukrářská bossanova}{Jarek Nohavica}
 
 \zs
-Můj \Ch{Cmaj7}{přítel} \Ch{C#dim}{snídá} sedm \Ch{Dmi7}{kremrolí,} \Ch{G7}{}
-a když je \Ch{Cmaj7}{spořádá}, dá si \Ch{C#dim}{repete},
-\Ch{Dmi7}{cukrlát}\Ch{G7}{ko,}
+Můj <Cmaj7>přítel <C#dim>snídá sedm <Dmi7>kremrolí, <G7>
+a když je <Cmaj7>spořádá, dá si <C#dim>repete,
+<Dmi7>cukrlát<G7>ko,
 
-on totiž \Ch{Cmaj7}{říká:} \uv{\Ch{C#dim}{Dobré} lidi zuby \Ch{Dmi7}{nebolí,}}
-\Ch{G7}{}
-a je to \Ch{Cmaj7}{paráda}, chodit \Ch{C#dim}{po světě,}
-a \Ch{Dmi7}{mít,} \Ch{G7}{} mít v ústech \Ch{Cmaj7}{sladko}. \Ch{C#dim}{} 
-\Ch{Dmi7}{} \Ch{G7}{}
+on totiž <Cmaj7>říká: \uv{<C#dim>Dobré lidi zuby <Dmi7>nebolí,}
+<G7>
+a je to <Cmaj7>paráda, chodit <C#dim>po světě,
+a <Dmi7>mít, <G7> mít v ústech <Cmaj7>sladko. <C#dim> 
+<Dmi7> <G7>
 \ks
 
 
 \zr
-\Ch{Cmaj7}{Sláva,} \Ch{C#dim}{cukr a} \Ch{Dmi7}{káva} a půl litru 
-\Ch{G7}{Becherovky},
+<Cmaj7>Sláva, <C#dim>cukr a <Dmi7>káva a půl litru 
+<G7>Becherovky,
 
-\Ch{Cmaj7}{hurá, hurá,} hu\Ch{C#dim}{rá,} půjč mi \Ch{Dmi7}{bůra}, útrata dnes 
-\Ch{G7}{dělá} čtyři stovky,
+<Cmaj7>hurá, hurá, hu<C#dim>rá, půjč mi <Dmi7>bůra, útrata dnes 
+<G7>dělá čtyři stovky,
 
-všechny \Ch{Cmaj7}{cukrářky} z celé \Ch{C#dim}{republiky}
+všechny <Cmaj7>cukrářky z celé <C#dim>republiky
 
-na něho \Ch{Dmi7}{dělají} slaďounké \Ch{G7}{cukrbliky}
+na něho <Dmi7>dělají slaďounké <G7>cukrbliky
 
-a on jim \Ch{Emi7}{za odmě}nu zpívá \Ch{A7}{zas} a znovu
+a on jim <Emi7>za odměnu zpívá <A7>zas a znovu
 
-\Ch{Dmi7}{tuhletu} \Ch{G7}{} cukrářskou bossano\Ch{Cmaj7}{vu.} \Ch{C#dim}{} 
-\Ch{Dmi7}{} \Ch{G7}{}
+<Dmi7>tuhletu <G7> cukrářskou bossano<Cmaj7>vu. <C#dim> 
+<Dmi7> <G7>
 \kr
 
 \zs
@@ -44,7 +44,7 @@ a až ho někdo kopne, odkutálí se mi pryč,
 a já zůstanu sám, úplně sám.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Můj přítel Karel Plíhal už na špičky si nevidí,
@@ -57,7 +57,7 @@ někdo se zkáruje, někdo se zfetuje
 a on jí bonpari, bon, bon, bon, bonpari.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex
@@ -3,24 +3,24 @@
 \zp{Danse Macabre}{Jarek Nohavica}
 \zr
 
-\Ch{Dmi}{Naj} \Ch{B}{na} na \Ch{Dmi}{naj} \Ch{B}{na} na \Ch{Dmi}{naj...  
-} \Ch{B}{ } \Ch{Dmi}{ } \Ch{B}{ } \Ch{Dmi}{ } \Ch{F}{ } \Ch{A}{ } \Ch{Dmi}{ 
-} \Ch{B}{ } \Ch{F}{ } \Ch{C}{ } \Ch{F}{ } \Ch{A}{ }
+<Dmi>Naj <B>na na <Dmi>naj <B>na na <Dmi>naj... 
+ <B> <Dmi> <B> <Dmi> <F> <A> <Dmi> 
+ <B> <F> <C> <F> <A> 
 
 \kr
 \zs
 
-\Ch{Dmi}{Šest} milionů srdcí vyletělo komí\Ch{B}{nem},
+<Dmi>Šest milionů srdcí vyletělo komí<B>nem,
 
-\Ch{Dmi}{svoje} malé lži si, lásko, dnes promi\Ch{B}{nem},
+<Dmi>svoje malé lži si, lásko, dnes promi<B>nem,
 
-\Ch{F}{budeme} tančit s \Ch{A}{venkovany},
+<F>budeme tančit s <A>venkovany,
 
-na návsi \Ch{Dmi}{vesnice} budeme se sm\Ch{B}{át,}\Ch{F}{ } \Ch{C}{mám} tě \Ch{F}{rád}\Ch{A}{.}
+na návsi <Dmi>vesnice budeme se sm<B>át,<F> <C>mám tě <F>rád<A>.
 
 \ks
 
-\zr   \kr
+\zr \kr
 
 \zs
 
@@ -34,7 +34,7 @@ podobáš se Evě i Marii, dneska mě zabijí.
 
 \ks
 
-\zr   \kr
+\zr \kr
 
 \zs
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Danse_Macabre.tex
@@ -1,6 +1,6 @@
 % -*-coding: utf-8 -*-
 
-\zp{Danse Macbre}{Jarek Nohavica}
+\zp{Danse Macabre}{Jarek Nohavica}
 \zr
 
 \Ch{Dmi}{Naj} \Ch{B}{na} na \Ch{Dmi}{naj} \Ch{B}{na} na \Ch{Dmi}{naj...  

--- a/tp-songs/01_folk/Jarek_Nohavica____Divoké_koně.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Divoké_koně.tex
@@ -10,7 +10,7 @@
 <Dmi>soumra<Ami>kem, 
 
 <Dmi>vzduch <Ami>těžký <Dmi>byl a divně <Ami>voněl 
-<G#dim>tabá-<F>kem. 
+<G#dim>tabá<F>kem. 
 
 <Dmi>vzduch <Ami>těžký <Dmi>byl a divně <Ami>voněl 
 <E7>tabá<Ami>kem. \ks

--- a/tp-songs/01_folk/Jarek_Nohavica____Divoké_koně.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Divoké_koně.tex
@@ -3,17 +3,17 @@
 \zp{Divoké koně}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Já viděl} \Ch{Dmi}{divoké} \Ch{Ami}{koně}, \Ch{C}{běželi} 
-\Ch{Dmi}{soumra}\Ch{Ami}{kem}, 
+<Ami>Já viděl <Dmi>divoké <Ami>koně, <C>běželi 
+<Dmi>soumra<Ami>kem, 
 
-\Ch{Ami}{já viděl} \Ch{Dmi}{divoké} \Ch{Ami}{koně}, \Ch{C}{běželi} 
-\Ch{Dmi}{soumra}\Ch{Ami}{kem}, 
+<Ami>já viděl <Dmi>divoké <Ami>koně, <C>běželi 
+<Dmi>soumra<Ami>kem, 
 
-\Ch{Dmi}{vzduch} \Ch{Ami}{těžký} \Ch{Dmi}{byl} a divně \Ch{Ami}{voněl} 
-\Ch{G#dim}{tabá-}\Ch{F}{kem}. 
+<Dmi>vzduch <Ami>těžký <Dmi>byl a divně <Ami>voněl 
+<G#dim>tabá-<F>kem. 
 
-\Ch{Dmi}{vzduch} \Ch{Ami}{těžký} \Ch{Dmi}{byl a} divně \Ch{Ami}{voněl} 
-\Ch{E7}{tabá}\Ch{Ami}{kem}.  \ks
+<Dmi>vzduch <Ami>těžký <Dmi>byl a divně <Ami>voněl 
+<E7>tabá<Ami>kem. \ks
 
 \zs
 /: Běželi, běžěli, bez uzdy a sedla,krajinou řek a hor, :/
@@ -47,5 +47,5 @@
 
 
 
-Já viděl divoké koně...  \kp
+Já viděl divoké koně... \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Dokud_se_zpívá.tex
@@ -3,13 +3,13 @@
 \zp{Dokud se zpívá}{Jarek Nohavica}
 
 \zs
-Z \Ch{C}{Těšína} \Ch{Emi}{vyjíždí} \Ch{Dmi7}{vlaky} co \Ch{F}{čtvrthodi}\Ch{C}{nu}, \Ch{Emi}{} \Ch{Dmi7}{} \Ch{G}{}
+Z <C>Těšína <Emi>vyjíždí <Dmi7>vlaky co <F>čtvrthodi<C>nu, <Emi> <Dmi7> <G>
 
-\Ch{C}{včera} jsem \Ch{Emi}{nespal} a \Ch{Dmi7}{ani dnes} \Ch{F}{nespoči}\Ch{C}{nu,} \Ch{Emi}{} \Ch{Dmi7}{} \Ch{G}{}
+<C>včera jsem <Emi>nespal a <Dmi7>ani dnes <F>nespoči<C>nu, <Emi> <Dmi7> <G>
 
-\Ch{F}{svatý} \Ch{G}{Medard}, můj \Ch{C}{patron}, ťuká si na če\Ch{G}{lo},
+<F>svatý <G>Medard, můj <C>patron, ťuká si na če<G>lo,
 
-ale \Ch{F}{dokud} se \Ch{G}{zpívá}, \Ch{F}{ještě} se \Ch{G}{neumře}\Ch{C}{lo.} \Ch{Emi}{} \Ch{Dmi7}{} \Ch{G}{} \Ch{C}{}
+ale <F>dokud se <G>zpívá, <F>ještě se <G>neumře<C>lo. <Emi> <Dmi7> <G> <C>
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Halelujá.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Halelujá.tex
@@ -2,22 +2,22 @@
 
 \zp{Halelujá}{Jarek Nohavica}
 
-\Ch{C}{Ha-}\Ch{F}{le-}\Ch{C}{lu-}\Ch{F}{já,} \Ch{C}{ha-}\Ch{G}{le-lu-}\Ch{C}{já.}
+<C>Ha-<F>le-<C>lu-<F>já, <C>ha-<G>le-lu-<C>já.
 
 \zr
-An\Ch{C}{dělé na kú}\Ch{Ami}{ru,} \Ch{G}{halelu}\Ch{C}{já,} v bělostném mundů\Ch{Ami}{ru,} \Ch{G}{halelu}\Ch{C}{já,}
+An<C>dělé na kú<Ami>ru, <G>halelu<C>já, v bělostném mundů<Ami>ru, <G>halelu<C>já,
 
-hrají na šalma\Ch{Ami}{je,} \Ch{G}{halelu}\Ch{C}{já,} že bránou do rá\Ch{Ami}{je} \Ch{G}{neprojdu} \Ch{C}{já.}
+hrají na šalma<Ami>je, <G>halelu<C>já, že bránou do rá<Ami>je <G>neprojdu <C>já.
 
 Nebeská honorace, halelujá, má totiž svoje informace, halelujá.
 
 Co chtějí, vědí o člověku, halelujá, mají na to kartotéku a v ní su já.
 
-\Ch{G}{Halelu}\Ch{C}{já.}
+<G>Halelu<C>já.
 \kr
 
 \zs
-\Ch{C}{Svatý Petr} \Ch{G}{to tam vede} \Ch{F9}{na osobním} \Ch{G}{oddělení,} \Ch{C}{} \Ch{G}{} \Ch{F9}{} \Ch{G}{}
+<C>Svatý Petr <G>to tam vede <F9>na osobním <G>oddělení, <C> <G> <F9> <G>
 
 nenechá se opít medem a nesnáší podplácení,
 
@@ -25,7 +25,7 @@ kouká shora a co spatří, zapíše hned do šanonu,
 
 každému, co právem patří, bez pardónu, bez pardónu.
 
-O\Ch{G}{ni to na mě} \Ch{C}{vědí,} \Ch{G}{} \Ch{F9}{}
+O<G>ni to na mě <C>vědí, <G> <F9>
 
 ti co nahoře sedí,
 
@@ -33,7 +33,7 @@ tam v modrém blankytu,
 
 andělé v hábitu.
 
-\Ch{G}{Halelu}\Ch{C}{já.}
+<G>Halelu<C>já.
 \ks
 
 \zr\kr
@@ -98,6 +98,6 @@ Halelujá.
 
 \zr\kr
 
-\Ch{F}{Halelu-,} \Ch{G}{halelu-,} \Ch{C}{hale}\Ch{F}{lu}\Ch{C}{já.}
+<F>Halelu-, <G>halelu-, <C>hale<F>lu<C>já.
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Hlídač_krav.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Hlídač_krav.tex
@@ -3,27 +3,27 @@
 \zp{Hlídač krav}{Jarek Nohavica}
 
 \zs
-\Ch{C}{Když} jsem byl malý, říkali mi naši:
+<C>Když jsem byl malý, říkali mi naši:
 
 \uv{Dobře se uč a jez chytrou kaši,
 
-\Ch{F}{až} jednou vyrosteš, \Ch{G}{budeš} doktorem \Ch{C}{práv}.
+<F>až jednou vyrosteš, <G>budeš doktorem <C>práv.
 
 Takový doktor sedí pěkně v suchu,
 
 bere velký peníze a škrábe se v uchu.}
 
-\Ch{F}{Já} jim ale na to řekl: \uv{\Ch{G}{Chci} být hlídačem \Ch{C}{krav}.}
+<F>Já jim ale na to řekl: \uv{<G>Chci být hlídačem <C>krav.}
 \ks
 
 \zr
-Já chci \Ch{C}{mít} čapku s bambulí nahoře,
+Já chci <C>mít čapku s bambulí nahoře,
 
 jíst kaštany a mýt se v lavoře,
 
-\Ch{F}{od} rána po celý \Ch{G}{den} zpívat si \Ch{C}{jen},
+<F>od rána po celý <G>den zpívat si <C>jen,
 
-zpívat si: pam pam pam... \Ch{F}{} \Ch{G}{} \Ch{C}{}
+zpívat si: pam pam pam... <F> <G> <C>
 \kr
 
 \zs
@@ -40,7 +40,7 @@ každý na mě hleděl jako na pytel blech,
 každý se mě opatrně tázal na moje zdraví.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Dnes už jsem starší a vím, co vím,
@@ -56,7 +56,7 @@ koukám nahoru na oblohu modravou,
 kde se mezi mraky honí moje strakaté krávy.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Hvězda.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Hvězda.tex
@@ -3,19 +3,19 @@
 \zp{Hvězda}{Jarek Nohavica}
 
 \zs
-\Ch{G}{Našel jsem} včera hvězdu, pět rudých cípů měla,
+<G>Našel jsem včera hvězdu, pět rudých cípů měla,
 
-\Ch{Ami}{někomu zřejmě spadla} z \Ch{D7}{ramene nebo} z \Ch{G}{čela,}
+<Ami>někomu zřejmě spadla z <D7>ramene nebo z <G>čela,
 
-\Ch{G}{někomu} zřejmě slítla, a on si toho ani nevšim',
+<G>někomu zřejmě slítla, a on si toho ani nevšim',
 
-\Ch{Ami}{tak je to} s každou láskou, \Ch{D7}{tak je to prostě} \Ch{G}{se vším.}
+<Ami>tak je to s každou láskou, <D7>tak je to prostě <G>se vším.
 \ks
 
 \zr
-\Ch{G}{Vzhlídl} jsem do vesmíru a viděl na obloze díru,
+<G>Vzhlídl jsem do vesmíru a viděl na obloze díru,
 
-\Ch{Ami}{boží trest} pro tebe, \Ch{D7}{kdo pyšnou rukou saháš} \Ch{G}{do nebe.}
+<Ami>boží trest pro tebe, <D7>kdo pyšnou rukou saháš <G>do nebe.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Jacek.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Jacek.tex
@@ -2,23 +2,23 @@
 
 \zp{Jacek}{Jarek Nohavica}
 \zs
-\Ch{G}{Na} druhém břehu řeky \Ch{D}{Olzy} žije Jacek, 
+<G>Na druhém břehu řeky <D>Olzy žije Jacek, 
 
-\Ch{C}{mám} k němu stejně blízko \Ch{G}{jak} on ke mně, 
+<C>mám k němu stejně blízko <G>jak on ke mně, 
 
-\Ch{G}{máváme} na sebe z \Ch{D}{říční} navigace, 
+<G>máváme na sebe z <D>říční navigace, 
 
-\Ch{C}{dva} spojenci a dvě \Ch{G}{spřátelené} země, 
+<C>dva spojenci a dvě <G>spřátelené země, 
 
-jak malí kluci hážem z \Ch{D}{břehů} žabky, 
+jak malí kluci hážem z <D>břehů žabky, 
 
-\Ch{C}{kdo} vyhraje, má z protěj\Ch{G}{šího} srandu, 
+<C>kdo vyhraje, má z protěj<G>šího srandu, 
 
-hlavama kroutí česko-\Ch{D}{polské} babky, 
+hlavama kroutí česko-<D>polské babky, 
 
-\Ch{C}{děláme} prostě vlastní \Ch{G}{propagandu}. 
+<C>děláme prostě vlastní <G>propagandu. 
 
-\Ch{G}{Na} na \Ch{D}{na} na \Ch{C}{na} na \Ch{G}{ná} na\Ch{D}{ na} \Ch{C}{náná}\Ch{G}{na} 
+<G>Na na <D>na na <C>na na <G>ná na<D> na <C>náná<G>na 
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Jdou_po_mně_jdou.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Jdou_po_mně_jdou.tex
@@ -3,11 +3,11 @@
 \zp{Jdou po mně, jdou}{Jarek Nohavica}
 
 \zs
-Býval jsem \Ch{D}{chudý} jak \Ch{G}{kostelní} \Ch{D}{myš},
-na půdě \Ch{F#mi}{půdy} jsem \Ch{Hmi}{míval} svou \Ch{A}{skrýš},
+Býval jsem <D>chudý jak <G>kostelní <D>myš,
+na půdě <F#mi>půdy jsem <Hmi>míval svou <A>skrýš,
 
-/: \Ch{G}{pak} jednou v \Ch{D}{létě} \Ch{A}{řek'} jsem si: \uv{\Ch{Hmi}{Ať,}
-\Ch{G}{svět} facku\Ch{D}{je tě,} a \Ch{G}{tak} mu to \Ch{D}{vrať}.} :/
+/: <G>pak jednou v <D>létě <A>řek' jsem si: \uv{<Hmi>Ať,
+<G>svět facku<D>je tě, a <G>tak mu to <D>vrať.} :/
 \ks
 
 \zs
@@ -19,11 +19,11 @@ tak jsem šel na to do National Bank. :/
 \ks
 
 \zr
-Jdou po mně, \Ch{D}{jdou}, \Ch{G}{jdou}, \Ch{D}{jdou},
-na každém \Ch{F#mi}{rohu} ma\Ch{Hmi}{jí fotku} \Ch{A}{mou},
+Jdou po mně, <D>jdou, <G>jdou, <D>jdou,
+na každém <F#mi>rohu ma<Hmi>jí fotku <A>mou,
 
-\Ch{G}{kdyby} mě \Ch{D}{chytli}, \Ch{A}{jó}, byl by \Ch{Hmi}{ring},
-\Ch{G}{tma} jako v \Ch{D}{pytli} je v \Ch{C}{celách} Sing-\Ch{G}{sing}. \Ch{A}{Jé,} \Ch{D}{jé.} \Ch{G}{}  \Ch{D}{}
+<G>kdyby mě <D>chytli, <A>jó, byl by <Hmi>ring,
+<G>tma jako v <D>pytli je v <C>celách Sing-<G>sing. <A>Jé, <D>jé. <G> <D>
 \kr
 
 \zs
@@ -42,7 +42,7 @@ tobě došlo zlato, mně trpělivost,
 tak jsem na cestě a chudý jak veš. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Klenotník Smith mi do očí lhal,

--- a/tp-songs/01_folk/Jarek_Nohavica____Já_žádám.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Já_žádám.tex
@@ -3,13 +3,13 @@
 \zp{Já žádám}{Jarek Nohavica}
 
 \zs
-Já žádám \Ch{A}{povolit} marihuanu,
+Já žádám <A>povolit marihuanu,
 
-já žádám \Ch{D}{zakázat} komunistickou stranu,
+já žádám <D>zakázat komunistickou stranu,
 
-já žádám \Ch{E}{zrušit} offside na modré čáře,
+já žádám <E>zrušit offside na modré čáře,
 
-já žádám \Ch{A}{vyškrtnout} Vánoce z kalendáře.
+já žádám <A>vyškrtnout Vánoce z kalendáře.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Když_mě_brali_za_vojáka.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Když_mě_brali_za_vojáka.tex
@@ -3,15 +3,15 @@
 \zp{Když mě brali za vojáka}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Když mě brali} za vo\Ch{C}{jáka,}
+<Ami>Když mě brali za vo<C>jáka,
 
-\Ch{G}{stříhali} mě doho\Ch{C}{la,}
+<G>stříhali mě doho<C>la,
 
-já \Ch{Dmi}{vypadal jsem} jako \Ch{Ami}{blbec,}
+já <Dmi>vypadal jsem jako <Ami>blbec,
 
-\Ch{E}{jak ti všichni} doko\Ch{F}{la,}
+<E>jak ti všichni doko<F>la,
 
-\Ch{G}{la,} \Ch{C}{la,} \Ch{G}{la,} \Ch{Ami}{jak ti všichni} \Ch{E}{doko}\Ch{Ami}{la.}
+<G>la, <C>la, <G>la, <Ami>jak ti všichni <E>doko<Ami>la.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Kometa.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Kometa.tex
@@ -3,11 +3,11 @@
 \zp{Kometa}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Spa}třil jsem kometu, oblohou letěla,
+<Ami>Spatřil jsem kometu, oblohou letěla,
 chtěl jsem jí zazpívat, ona mi zmizela,
 
-\Ch{Dmi}{zmi}zela jako laň \Ch{G7}{u le}sa v remízku,
-v \Ch{C}{očích} mi zbylo jen \Ch{E7}{pár} žlutých penízků.
+<Dmi>zmizela jako laň <G7>u lesa v remízku,
+v <C>očích mi zbylo jen <E7>pár žlutých penízků.
 \ks
 
 \zs
@@ -19,13 +19,13 @@ spatřil jsem kometu, chtěl jsem jí zazpívat.
 \ks
 
 \zr
-\Ch{Ami}{O vo}dě, o trávě, \Ch{Dmi}{o lese,}
+<Ami>O vodě, o trávě, <Dmi>o lese,
 
-\Ch{G7}{o smr}ti, se kterou smířit \Ch{C}{nejde} se,
+<G7>o smrti, se kterou smířit <C>nejde se,
 
-\Ch{Ami}{o lá}sce, o zradě, \Ch{Dmi}{o svě}tě
+<Ami>o lásce, o zradě, <Dmi>o světě
 
-\Ch{E}{a} o všech lidech, co \Ch{E7}{kdy žili} na téhle \Ch{Ami}{planetě}.
+<E>a o všech lidech, co <E7>kdy žili na téhle <Ami>planetě.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Kozel.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Kozel.tex
@@ -3,13 +3,13 @@
 \zp{Kozel}{Jarek Nohavica}
 
 \zs
-Byl jeden \Ch{G}{pán,} (byl jeden pán,) ten kozla \Ch{C}{měl,} (ten kozla měl,)
+Byl jeden <G>pán, (byl jeden pán,) ten kozla <C>měl, (ten kozla měl,)
 
-velice \Ch{D7}{si (velice si)} s ním rozu\Ch{G}{měl (s ním rozuměl).}
+velice <D7>si (velice si) s ním rozu<G>měl (s ním rozuměl).
 
-Měl ho moc rád, (měl ho moc rád,) opravdu \Ch{C}{moc,} (opravdu moc,)
+Měl ho moc rád, (měl ho moc rád,) opravdu <C>moc, (opravdu moc,)
 
-hladil mu \Ch{D7}{fous (hladil mu fous)} na dobrou \Ch{G}{noc} (na \Ch{D7}{dobrou} \Ch{G}{noc}).
+hladil mu <D7>fous (hladil mu fous) na dobrou <G>noc (na <D7>dobrou <G>noc).
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Margita.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Margita.tex
@@ -3,33 +3,33 @@
 \zp{Margita}{Jarek Nohavica}
 
 \zs
-\Ch{Emi}{Točí se, točí} \Ch{Ami}{kolo} \Ch{Emi}{dokola a až nás} \Ch{Hmi}{smrtka} \Ch{C}{zavolá,}
+<Emi>Točí se, točí <Ami>kolo <Emi>dokola a až nás <Hmi>smrtka <C>zavolá,
 
-tak \Ch{G}{vytáhneme} \Ch{Emi}{rance,}
+tak <G>vytáhneme <Emi>rance,
 
-sbalíme svý tě\Ch{Ami}{lesný} \Ch{Emi}{ostatky, srazíme} \Ch{Hmi}{podpat}\Ch{C}{ky}
+sbalíme svý tě<Ami>lesný <Emi>ostatky, srazíme <Hmi>podpat<C>ky
 
-a potom \Ch{G}{dáme se do} \Ch{Emi}{tance.}
+a potom <G>dáme se do <Emi>tance.
 
-\Ch{Ami}{Tančí se tradič}\Ch{H7}{ně} \Ch{Emi}{gavotta na konci} \Ch{Hmi}{živo}\Ch{C}{ta,}
+<Ami>Tančí se tradič<H7>ně <Emi>gavotta na konci <Hmi>živo<C>ta,
 
-na konci \Ch{G}{tohohle} \Ch{Emi}{plesu.}
+na konci <G>tohohle <Emi>plesu.
 
-Promiňte, že vám \Ch{Ami}{šlapu} \Ch{Emi}{na nohu, já za to} \Ch{Hmi}{nemo}\Ch{C}{hu,}
+Promiňte, že vám <Ami>šlapu <Emi>na nohu, já za to <Hmi>nemo<C>hu,
 
-já tady \Ch{G}{vlastně ani} \Ch{Emi}{nejsu.}
+já tady <G>vlastně ani <Emi>nejsu.
 \ks
 
 \zr
-\Ch{Ami}{A krásná Margita,} \Ch{Emi}{tanečnice smrti,}
+<Ami>A krásná Margita, <Emi>tanečnice smrti,
 
-\Ch{Ami}{má svetr vzoru} pepi\Ch{Emi}{ta a zadkem vrtí,}
+<Ami>má svetr vzoru pepi<Emi>ta a zadkem vrtí,
 
-\Ch{Ami}{začíná maškarní} \Ch{G}{ples,}
+<Ami>začíná maškarní <G>ples,
 
-kams' to \Ch{D}{vlez',} kams' to \Ch{Emi}{vlez',}
+kams' to <D>vlez', kams' to <Emi>vlez',
 
-kams' to \Ch{H7}{vlez',} kams' to \Ch{Emi}{vlez'?}
+kams' to <H7>vlez', kams' to <Emi>vlez'?
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Mařenka.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Mařenka.tex
@@ -3,13 +3,13 @@
 \zp{Mařenka}{Jarek Nohavica}
 
 \zs
-\Ch{Hmi}{Neplakej,} Mařenko, \Ch{D}{počkej} na mě,
+<Hmi>Neplakej, Mařenko, <D>počkej na mě,
 
-\Ch{A}{chtěl} jsem ti nabídnout \Ch{Hmi}{svoje rámě,}
+<A>chtěl jsem ti nabídnout <Hmi>svoje rámě,
 
-\Ch{G}{čeká} nás cesta \Ch{Emi}{trnovým} houštím,
+<G>čeká nás cesta <Emi>trnovým houštím,
 
-\Ch{F#}{já svoje} Mařenky \Ch{Hmi}{neopouštím.}
+<F#>já svoje Mařenky <Hmi>neopouštím.
 \ks
 
 \zs
@@ -55,7 +55,7 @@ přes rokle, výmoly, přes jámy, půjdeme a milost nad námi.
 
 Přes rokle, výmoly, přes jámy, půjdeme...
 
-\Ch{Hmi}{Hmm hmm} \Ch{D/A}{hmm hmm} \Ch{D}{hmm} \Ch{A}{hmm} \Ch{Hmi}{hm.}
+<Hmi>Hmm hmm <D/A>hmm hmm <D>hmm <A>hmm <Hmi>hm.
 \ks
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Mikymauz.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Mikymauz.tex
@@ -2,12 +2,12 @@
 
 \zp{Mikymauz}{Jarek Nohavica}
 \zs
-\Ch{Ami}{Ráno} mě probouzí \Ch{G}{tma}, sahám si na zápěs{tí},
-\Ch{F}{zda}li to \Ch{E}{ještě} tluče, \Ch{Dmi}{zdali} mám \Ch{E}{ještě} 
+<Ami>Ráno mě probouzí <G>tma, sahám si na zápěs{tí},
+<F>zdali to <E>ještě tluče, <Dmi>zdali mám <E>ještě 
 štěstí,
 
-\Ch{Ami}{nebo} je po mně a \Ch{G}{já} mám voskované bo{ty},
-\Ch{F}{rán}o co \Ch{E}{ráno} stejné \Ch{Dmi}{probuzení} \Ch{E}{do nico}ty. \Ch{Ami}{}
+<Ami>nebo je po mně a <G>já mám voskované bo{ty},
+<F>ráno co <E>ráno stejné <Dmi>probuzení <E>do nicoty. <Ami>
 \ks
 \zs
 Není co, není jak, není proč, není kam,
@@ -17,15 +17,15 @@ vyzáblý Don Quijote sedlá svou Rosinantu
 a Bůh je slepý řidič sedící u volantu.
 \ks
 \zr
-\Ch{E}{Zapínám} \Ch{F}{telefon} -- \Ch{Dmi}{záznamník} \Ch{E}{cizích} citů,
+<E>Zapínám <F>telefon -- <Dmi>záznamník <E>cizích citů,
 
-špatné zprávy \Ch{F}{chodí} jako \Ch{Dmi}{policie} \Ch{E}{za} úsvitu,
+špatné zprávy <F>chodí jako <Dmi>policie <E>za úsvitu,
 
-\Ch{Dmi}{jsem} napůl bdělý a \Ch{G7}{napůl} ještě v noční pauze,
+<Dmi>jsem napůl bdělý a <G7>napůl ještě v noční pauze,
 
-\Ch{C}{měl} bych se smát, ale \Ch{E}{mám} úsměv Mikymauze,
+<C>měl bych se smát, ale <E>mám úsměv Mikymauze,
 
-\Ch{Ami}{rána} bych \Ch{Ami/G}{zrušil.} \Ch{F}{} \Ch{E}{} \Ch{Ami}{}
+<Ami>rána bych <Ami/G>zrušil. <F> <E> <Ami>
 \kr
 \zs
 Dobrý muž v rádiu pouští Chick Coreu,

--- a/tp-songs/01_folk/Jarek_Nohavica____Milionář.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Milionář.tex
@@ -5,15 +5,15 @@
 \zp{Milionář}{Jarek Nohavica}
 
 \zs
-U nas v \Ch{D}{domě řika}\Ch{A}{ji mi Franta} \Ch{D}{Šiška,}
+U nas v <D>domě řika<A>ji mi Franta <D>Šiška,
 
-bo už od pohledu \Ch{G}{chytry sem jak} \Ch{D}{liška,}
+bo už od pohledu <G>chytry sem jak <D>liška,
 
-a když kery něco \Ch{Emi}{nevi nebo} \Ch{A}{když je na co} \Ch{D}{levy,}
+a když kery něco <Emi>nevi nebo <A>když je na co <D>levy,
 
-tak de za mnu a ja \Ch{A}{všecko najdu} v \Ch{D}{knižkach,}
+tak de za mnu a ja <A>všecko najdu v <D>knižkach,
 
-cha \Ch{Emi}{chá,} \Ch{A}{cha-ha-ha} \Ch{D}{chá,} tak de za mnu a ja \Ch{A}{všecko najdu} v \Ch{D}{knižkach.}
+cha <Emi>chá, <A>cha-ha-ha <D>chá, tak de za mnu a ja <A>všecko najdu v <D>knižkach.
 \ks
 
 \zs
@@ -117,9 +117,9 @@ Prvni třidu do Ostravy Intercity, v jidelňaku celu cestu valim kyty,
 
 a ta stovka, co mi zbude, to je přispěvek na chude, bo Ostrava je region razovity,
 
-a ta \Ch{D}{stovka,} co mi \Ch{G}{zbude,} to je \Ch{A}{přispěvek} na \Ch{D}{chude,}
+a ta <D>stovka, co mi <G>zbude, to je <A>přispěvek na <D>chude,
 
-bo Ostrava je re\Ch{A}{gion razo}\Ch{D}{vi}\Ch{A}{ty.} \Ch{D}{}
+bo Ostrava je re<A>gion razo<D>vi<A>ty. <D>
 \ks
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Možná_že_se_mýlím.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Možná_že_se_mýlím.tex
@@ -3,18 +3,18 @@
 \zp{Možná že se mýlím}{Jarek Nohavica}
 
 \zs
-Mám \Ch{C}{roz}estláno na posteli \Ch{Fadd9}{pro hosty,}
+Mám <C>rozestláno na posteli <Fadd9>pro hosty,
 
-zuby si \Ch{C}{čis}tím cizím zubním \Ch{Fadd9}{kartáčkem,}
+zuby si <C>čistím cizím zubním <Fadd9>kartáčkem,
 
-já, \Ch{C}{snůš}ka zděděných \Ch{Emi}{vlastností}
+já, <C>snůška zděděných <Emi>vlastností
 
-a \Ch{F}{obyv}atel \Ch{Dmi}{plane}ty \Ch{G}{Zem,}
+a <F>obyvatel <Dmi>planety <G>Zem,
 
-bláznivé \Ch{F}{Mark}étě zpívám druhý \Ch{C}{hlas,}
+bláznivé <F>Markétě zpívám druhý <C>hlas,
 
-jsem tady \Ch{Dmi}{na sv}ětě na krátký \Ch{F}{víke}nd na cestovní \Ch{C}{pas.} 
-\Ch{Fadd9}{} \Ch{C}{} \Ch{Fadd9}{}
+jsem tady <Dmi>na světě na krátký <F>víkend na cestovní <C>pas. 
+<Fadd9> <C> <Fadd9>
 \ks
 
 \zs
@@ -32,15 +32,15 @@ jsem tady na světě, dokud nevyprší můj čas.
 \ks
 
 \zr
-\Ch{C}{Možná,} že se \Ch{F}{mý}\Ch{C}{lím,} možná se \Ch{F}{mý}\Ch{C}{lím,}
+<C>Možná, že se <F>mý<C>lím, možná se <F>mý<C>lím,
 
-snad mi to \Ch{Emi}{dojde} léty, \Ch{F}{snad} mi to \Ch{C}{dojde} léty,
+snad mi to <Emi>dojde léty, <F>snad mi to <C>dojde léty,
 
-mám na to jenom \Ch{F}{chví}\Ch{C}{li,} dojít od startu k \Ch{F}{cí}\Ch{C}{li,}
+mám na to jenom <F>chví<C>li, dojít od startu k <F>cí<C>li,
 
-a tak si \Ch{Emi}{zpívám,} a tak se \Ch{F}{dívám,}
+a tak si <Emi>zpívám, a tak se <F>dívám,
 
-a tak si dávám \Ch{C}{do} trumpety. \Ch{Fadd9}{} \Ch{C}{} \Ch{Fadd9}{}
+a tak si dávám <C>do trumpety. <Fadd9> <C> <Fadd9>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Muzeum.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Muzeum.tex
@@ -3,21 +3,21 @@
 \zp{Muzeum}{Jarek Nohavica}
 
 \zs
-\Ch{C}{Ve} Slezském muzeu, v \Ch{G}{oddělení} \Ch{Ami}{třetihor}
+<C>Ve Slezském muzeu, v <G>oddělení <Ami>třetihor
 
-je bílý \Ch{F}{krokodýl} a \Ch{C}{medvěd} a liška a \Ch{G7}{kamenní} \Ch{C}{trilobiti}, \Ch{G7}{}
+je bílý <F>krokodýl a <C>medvěd a liška a <G7>kamenní <C>trilobiti, <G7>
 
-\Ch{C}{chodí} se tam jen tak, co \Ch{G}{noha} nohu \Ch{Ami}{mine},
+<C>chodí se tam jen tak, co <G>noha nohu <Ami>mine,
 
-abys viděl, jak ten \Ch{F}{život} plyne, \Ch{C}{jaké} je to všechno \Ch{G7}{pomíjivé} \Ch{C}{živobytí,}
+abys viděl, jak ten <F>život plyne, <C>jaké je to všechno <G7>pomíjivé <C>živobytí,
 
-\Ch{F}{pak} vyjdeš do parku a \Ch{C}{celou} noc se \Ch{F}{touláš} noční Opavou
+<F>pak vyjdeš do parku a <C>celou noc se <F>touláš noční Opavou
 
-a \Ch{B}{opájíš} se \Ch{F}{představou}, jaké to \Ch{C}{bude v} \Ch{F}{ráji}.
+a <B>opájíš se <F>představou, jaké to <C>bude v <F>ráji.
 
-V \Ch{C}{pět} třicet pět jednou z \Ch{G}{pravidelných} \Ch{Ami}{linek}
+V <C>pět třicet pět jednou z <G>pravidelných <Ami>linek
 
-sedm zastávek do \Ch{F}{Kateřinek}, \Ch{C}{ukončete} nástup, \Ch{G7}{dveře} se \Ch{C}{zavírají}.
+sedm zastávek do <F>Kateřinek, <C>ukončete nástup, <G7>dveře se <C>zavírají.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Osmá_barva_duhy.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Osmá_barva_duhy.tex
@@ -2,27 +2,27 @@
 
 \zp{Osmá barva duhy}{Jarek Nohavica}
 \zs
-\Ch{Ami}{Chladná} jsou \Ch{Dmi}{dubnová} \Ch{Ami}{rána,} \Ch{Dmi}{}
+<Ami>Chladná jsou <Dmi>dubnová <Ami>rána, <Dmi>
 
-\Ch{Ami}{ze slunce} je \Ch{Dmi}{vidět} jenom \Ch{C}{kou}\Ch{E7}{sek},
+<Ami>ze slunce je <Dmi>vidět jenom <C>kou<E7>sek,
 
-\Ch{Ami}{ve flašce} \Ch{Dmi}{od Cin}\Ch{Ami}{zana}\Ch{Dmi}{ }
+<Ami>ve flašce <Dmi>od Cin<Ami>zana<Dmi> 
 
-\Ch{Ami}{úhoři}, \Ch{G}{úhoři} \Ch{Ami}{třou} se.
+<Ami>úhoři, <G>úhoři <Ami>třou se.
 \ks
 \zr
-\Ch{Dmi}{Všichni} moji \Ch{Ami}{známí} teď \Ch{F}{spí}, \Ch{Dmi}{spí,} 
-\Ch{E7}{spí} doma s manželkami,
+<Dmi>Všichni moji <Ami>známí teď <F>spí, <Dmi>spí, 
+<E7>spí doma s manželkami,
 
-\Ch{Dmi}{zůstali} jsme \Ch{Ami}{sami} – \Ch{E7}{já} a \Ch{Ami}{já.}
+<Dmi>zůstali jsme <Ami>sami – <E7>já a <Ami>já.
 
 Města jsou jedno jako druhý, černá je osmá barva duhy,
 
-\Ch{Dmi}{černá} je barva, kterou \Ch{E7}{mám} teď nejradě\Ch{Ami}{ji,}
+<Dmi>černá je barva, kterou <E7>mám teď nejradě<Ami>ji,
 
 jó, je to bída, je to bída, hledal jsem ostrov jménem Atlantida
 
-\Ch{Dmi}{a našel} vody, vody, \Ch{E7}{vody}, vody, vody haba\Ch{Ami}{děj.}
+<Dmi>a našel vody, vody, <E7>vody, vody, vody haba<Ami>děj.
 \kr
 \zs
 Kdyby měl někdo z vás zájem,
@@ -31,7 +31,7 @@ uděláme velikánský mejdan,
 projdeme tam a zpět rájem
 a svatý Petr bude náš strejda.
 \ks
-\zr      \kr
+\zr \kr
 \zs
 Pod okny řve někdo: \uv{kémo},
 každý správný folkáč nosí vousy,

--- a/tp-songs/01_folk/Jarek_Nohavica____Ostravo_Ostravo.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Ostravo_Ostravo.tex
@@ -3,23 +3,23 @@
 \zp{Ostravo, Ostravo}{Jarek Nohavica}
 
 \zs
-\Ch{Dmi}{Ostravo,} Ostra\Ch{A7}{vo,}
+<Dmi>Ostravo, Ostra<A7>vo,
 
-město mezi městy, \Ch{Dmi}{hořké} \Ch{A7}{moje štěstí,}
+město mezi městy, <Dmi>hořké <A7>moje štěstí,
 
-\Ch{Dmi}{Ostravo,} Ostra\Ch{A7}{vo,}
+<Dmi>Ostravo, Ostra<A7>vo,
 
-černá hvězdo nad hla\Ch{Dmi}{vou.}
+černá hvězdo nad hla<Dmi>vou.
 \ks
 
 \zr
-\Ch{C}{Pán Bůh} rozdal jiným \Ch{F}{městům} všecku krásu,
+<C>Pán Bůh rozdal jiným <F>městům všecku krásu,
 
-\Ch{Gmi}{parníky na řekách} a \Ch{A7}{dámy všité do atlasu.}
+<Gmi>parníky na řekách a <A7>dámy všité do atlasu.
 
-\Ch{Dmi}{Ostravo,} srdce ru\Ch{A7}{dé,}
+<Dmi>Ostravo, srdce ru<A7>dé,
 
-zpečetěný osu\Ch{Dmi}{de.} \Ch{A7}{} \Ch{Dmi}{}
+zpečetěný osu<Dmi>de. <A7> <Dmi>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Pane_prezidente.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Pane_prezidente.tex
@@ -3,23 +3,23 @@
 \zp{Pane prezidente}{Jarek Nohavica}
 
 \zs
-Pane \Ch{D}{prezidente,} ústavní \Ch{Emi}{činiteli,}
+Pane <D>prezidente, ústavní <Emi>činiteli,
 
-píšu \Ch{A7}{vám dopis,} že moje děti na mě \Ch{D}{zapomněly.}
+píšu <A7>vám dopis, že moje děti na mě <D>zapomněly.
 
-Jde o syna Karla a mladší \Ch{Emi}{dceru Evu,}
+Jde o syna Karla a mladší <Emi>dceru Evu,
 
-rok už \Ch{A7}{nenapsali,} rok už nepřijeli \Ch{D}{na návštěvu.}
+rok už <A7>nenapsali, rok už nepřijeli <D>na návštěvu.
 \ks
 
 \zr
-Vy to \Ch{G}{pochopíte,} vy přece \Ch{Ami}{všechno víte,}
+Vy to <G>pochopíte, vy přece <Ami>všechno víte,
 
-vy se \Ch{D7}{poradíte,} vy to vyřešíte, vy mě \Ch{G}{zachráníte.}
+vy se <D7>poradíte, vy to vyřešíte, vy mě <G>zachráníte.
 
-Pane prezidente, já chci jen \Ch{Ami}{kousek štěstí,}
+Pane prezidente, já chci jen <Ami>kousek štěstí,
 
-pro co \Ch{D7}{jiného jsme} přeci zvonili klíčema \Ch{G}{na náměstí.} \Ch{A7}{}
+pro co <D7>jiného jsme přeci zvonili klíčema <G>na náměstí. <A7>
 \kr
 
 \zs
@@ -64,6 +64,6 @@ a vůbec všecko!}
 Ale vy mě pochopíte...
 \kr
 
-Pane \Ch{D}{prezidente!}
+Pane <D>prezidente!
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Petěrburg.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Petěrburg.tex
@@ -3,23 +3,23 @@
 \zp{Petěrburg}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Když} se snáší noc na střechy Petěrburgu,
+<Ami>Když se snáší noc na střechy Petěrburgu,
 
-\Ch{F}{padá} \Ch{E}{na} mě \Ch{Ami}{žal,}
+<F>padá <E>na mě <Ami>žal,
 
 zatoulaný pes nevzal si ani kůrku
 
-\Ch{F}{chleba}, kterou \Ch{E}{jsem} mu \Ch{Ami}{dal.}
+<F>chleba, kterou <E>jsem mu <Ami>dal.
 \ks
 \zr
-/: \Ch{C}{Lásku} moji \Ch{Dmi}{kníže} I\Ch{E}{gor} si bere,
+/: <C>Lásku moji <Dmi>kníže I<E>gor si bere,
 
 
-\Ch{F}{nad} sklenkou \Ch{Adim}{vodky} \Ch{H7}{hraju} si s \Ch{E}{revolverem,}
+<F>nad sklenkou <Adim>vodky <H7>hraju si s <E>revolverem,
 
-\Ch{Ami}{havran} usedá na střechy Petěrburgu,
+<Ami>havran usedá na střechy Petěrburgu,
 
-\Ch{F}{čert} a\Ch{E}{by} to \Ch{Ami}{spral}. :/
+<F>čert a<E>by to <Ami>spral. :/
 \kr
 \zs
 Nad obzorem letí ptáci slepí

--- a/tp-songs/01_folk/Jarek_Nohavica____Pijte_vodu.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Pijte_vodu.tex
@@ -2,17 +2,17 @@
 
 \zp{Pijte vodu}{Jarek Nohavica}
 \zr
-/: \Ch{C}{Pijte} vodu, pijte pitnou vodu, pijte vodu a \Ch{G}{nepijte} \Ch{C}{rum}! :/
+/: <C>Pijte vodu, pijte pitnou vodu, pijte vodu a <G>nepijte <C>rum! :/
 \kr
 
 \zs
-\Ch{C}{Jeden} smutný ajznboňák pil na pátém nástupišti 
-\Ch{G}{ajrko}\Ch{C}{ňak}.
+<C>Jeden smutný ajznboňák pil na pátém nástupišti 
+<G>ajrko<C>ňak.
 
-\Ch{C}{Huba} se mu slepila a diesel lokomotiva ho \Ch{G}{zabi}\Ch{C}{la}.
+<C>Huba se mu slepila a diesel lokomotiva ho <G>zabi<C>la.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 V rodině u Becherů pijou becherovku přímo ze džberů.
@@ -20,7 +20,7 @@ V rodině u Becherů pijou becherovku přímo ze džberů.
 Proto všichni Becheři mají trable s játrama a páteří.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Pil som vodku značky Gorbačov a potom povedal som všeličo a voľačo.
@@ -28,7 +28,7 @@ Pil som vodku značky Gorbačov a potom povedal som všeličo a voľačo.
 Vyfásol som za to tri roky, teraz pijem chlórované patoky.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Jesteśmy chłopci z Warszawy, jeżdżimy pociągiem za robotą do Ostrawy.
@@ -41,7 +41,7 @@ Cztery litry wódki a mnóstwo piw, po prostu bardzo fajny kolektyw.
 
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Jedna paní v Americe ztrapnila se převelice.
@@ -49,7 +49,7 @@ Jedna paní v Americe ztrapnila se převelice.
 Vypila na ex rum, poblila jim Bílý dům.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Pochod_marodů.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Pochod_marodů.tex
@@ -3,13 +3,13 @@
 \zp{Pochod marodů}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Krab}ička cigaret a \Ch{C}{do} kafe \Ch{G}{rum,} \Ch{F}{rum,} \Ch{Ami}{rum,}
+<Ami>Krabička cigaret a <C>do kafe <G>rum, <F>rum, <Ami>rum,
 
-dvě vodky a Fernet a teď, \Ch{C}{dok}tore, \Ch{G}{čum,} \Ch{F}{čum,} \Ch{Ami}{čum,}
+dvě vodky a Fernet a teď, <C>doktore, <G>čum, <F>čum, <Ami>čum,
 
-chra\Ch{Dmi}{pot v} hrud\Ch{F}{ním} ko\Ch{Ami}{ši, no} \Ch{Dmi}{to je} \Ch{F}{záž}i\Ch{E}{tek,}
+chra<Dmi>pot v hrud<F>ním ko<Ami>ši, no <Dmi>to je <F>záži<E>tek,
 
-\Ch{Ami}{my js}me kámoši řidi\Ch{C}{čů} sani\Ch{G}{tek,} -\Ch{F}{tek,} -\Ch{Ami}{tek.}
+<Ami>my jsme kámoši řidi<C>čů sani<G>tek, -<F>tek, -<Ami>tek.
 \ks
 
 \zs
@@ -23,17 +23,17 @@ je to vlastně fuk, žijem fajn, žijem fajn, fajn, fajn.
 \ks
 
 \zr
-\Ch{Ami}{Cirhó}za, \Ch{C}{trom}bóza, \Ch{G}{dáv}ivý \Ch{C}{kaš}el,
+<Ami>Cirhóza, <C>trombóza, <G>dávivý <C>kašel,
 
-\Ch{Dmi}{tuber}ku\Ch{Ami}{lóza} -- \Ch{E}{jó,} to je \Ch{Ami}{naše!}
+<Dmi>tuberku<Ami>lóza -- <E>jó, to je <Ami>naše!
 
-Neuróza, \Ch{C}{skle}róza, \Ch{G}{ohnu}tá \Ch{C}{záda,}
+Neuróza, <C>skleróza, <G>ohnutá <C>záda,
 
-\Ch{Dmi}{parad}on\Ch{Ami}{tóza,} no \Ch{E}{to} je pa\Ch{Ami}{ráda!}
+<Dmi>paradon<Ami>tóza, no <E>to je pa<Ami>ráda!
 
-Jsme \Ch{Dmi}{slabí} na tě\Ch{Ami}{le, ale} \Ch{G}{silní} na du\Ch{C}{chu,}
+Jsme <Dmi>slabí na tě<Ami>le, ale <G>silní na du<C>chu,
 
-\Ch{Dmi}{žijem} vese\Ch{Ami}{le,} \Ch{E}{juch}uchuchu\Ch{Ami}{chu!}
+<Dmi>žijem vese<Ami>le, <E>juchuchuchu<Ami>chu!
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Píseň_zhrzelého_trampa.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Píseň_zhrzelého_trampa.tex
@@ -3,10 +3,10 @@
 \zp{Píseň zhrzelého trampa}{Jarek Nohavica}
 
 \zs
-\Ch{C}{Poněvadž} nemám \Ch{G}{kanady} a \Ch{F}{neznám} písně \Ch{C}{z pamp},
+<C>Poněvadž nemám <G>kanady a <F>neznám písně <C>z pamp,
 \\
-\Ch{F}{ho}, ho, \Ch{C}{ho} -- a \Ch{G7}{neznám} písně z \Ch{C}{pamp,} 
-\Ch{G7}{}
+<F>ho, ho, <C>ho -- a <G7>neznám písně z <C>pamp, 
+<G7>
 
 vyloučili mě z osady, že prý jsem houby tramp...
 
@@ -16,24 +16,24 @@ Vyloučený z řad čundráků, ten frajer libový...
 \ks
 
 \zr
-\Ch{C}{Já} jsem \Ch{G}{ostuda} \Ch{Ami}{traperů,}
+<C>Já jsem <G>ostuda <Ami>traperů,
 
-\Ch{F}{já} mám rád \Ch{C}{operu},
+<F>já mám rád <C>operu,
 
-\Ch{G}{já mám rád} \Ch{C}{jazz-}\Ch{G7}{rock.}
+<G>já mám rád <C>jazz-<G7>rock.
 
-\Ch{C}{Chodím} \Ch{G}{po} světě \Ch{Ami}{bez nože,}
+<C>Chodím <G>po světě <Ami>bez nože,
 
-\Ch{F}{to prý} se \Ch{C}{nemože}, \Ch{G}{to} prý jsem \Ch{C}{cvok.} \Ch{C7}{}
+<F>to prý se <C>nemože, <G>to prý jsem <C>cvok. <C7>
 
-\Ch{F}{Já} jsem nikdy neplul na \Ch{C}{šífu}
+<F>Já jsem nikdy neplul na <C>šífu
 
-a všem \Ch{D7}{šerifům} jsem říkal: \uv{\Ch{G}{Ba ne}, pa\Ch{G7}{ne.}}
+a všem <D7>šerifům jsem říkal: \uv{<G>Ba ne, pa<G7>ne.}
 
-\Ch{C}{Já} jsem \Ch{G}{ostuda} \Ch{Ami}{trempů},
+<C>Já jsem <G>ostuda <Ami>trempů,
 
-\Ch{F}{Já} když \Ch{C}{chlempu}, tak v \Ch{G7}{autokem}\Ch{C}{pu.} \Ch{G}{} 
-\Ch{C}{}
+<F>Já když <C>chlempu, tak v <G7>autokem<C>pu. <G> 
+<C>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Sarajevo.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Sarajevo.tex
@@ -3,24 +3,24 @@
 \zp{Sarajevo}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Přes} haličské pláně \Ch{Dmi}{vane ví}tr zlý,
+<Ami>Přes haličské pláně <Dmi>vane vítr zlý,
 
-to \Ch{E7}{málo,} co jsme měli, nám \Ch{Ami}{vody} sebraly
+to <E7>málo, co jsme měli, nám <Ami>vody sebraly
 
-jako tažní ptáci, \Ch{Dmi}{jako ror}ýsi
+jako tažní ptáci, <Dmi>jako rorýsi
 
-\Ch{E7}{letí}me nad zemí, dva \Ch{Ami}{modré} dopisy.
+<E7>letíme nad zemí, dva <Ami>modré dopisy.
 \ks
 
 
 \zr
-\Ch{Ami}{Ještě} hoří oheň a \Ch{Dmi}{praská} dřevo,
+<Ami>Ještě hoří oheň a <Dmi>praská dřevo,
 
-\Ch{G7}{ale už} je čas jít \Ch{C}{spát,} \Ch{E7}{}
+<G7>ale už je čas jít <C>spát, <E7>
 
-\Ch{Ami}{tamhle} za kopcem je \Ch{Dmi}{Sarajevo,}
+<Ami>tamhle za kopcem je <Dmi>Sarajevo,
 
-tam \Ch{E7}{budeme} se zítra ráno \Ch{Ami}{brát.}
+tam <E7>budeme se zítra ráno <Ami>brát.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Strakapúd.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Strakapúd.tex
@@ -2,16 +2,16 @@
 
 \zp{Strakapúd}{Jarek Nohavica}
 
-\Ch{C}{} \Ch{F}{} \Ch{G}{}
+<C> <F> <G>
 
 \zs
-\Ch{C}{Vysvitlo} slunko, modrý \Ch{F}{strakapúd} k \Ch{G}{obloze} \Ch{C}{vzlétá} \Ch{F}{} \Ch{G}{}
+<C>Vysvitlo slunko, modrý <F>strakapúd k <G>obloze <C>vzlétá <F> <G>
 
-\Ch{C}{a ty} si krásná jako \Ch{F}{meruňka} \Ch{G}{uprostřed} \Ch{Ami}{léta.}
+<C>a ty si krásná jako <F>meruňka <G>uprostřed <Ami>léta.
 
-A ty si \Ch{F}{krásná} \Ch{G}{jako} réva v \Ch{C}{Boršicích,}
+A ty si <F>krásná <G>jako réva v <C>Boršicích,
 
-když zem se \Ch{F}{slévá} s \Ch{G}{oblohou} \Ch{C}{hořící.}
+když zem se <F>slévá s <G>oblohou <C>hořící.
 \ks
 
 \zs
@@ -34,11 +34,11 @@ a ty si {vroucí} {jako} láva {pod} Etnou,
 když sopka {vstává} {bázliví} {odlétnou.}
 \ks
 
-\Ch{C}{Jen} \Ch{F}{já} zůs\Ch{G}{tá}\Ch{C}{vám,}
+<C>Jen <F>já zůs<G>tá<C>vám,
 
-\Ch{C}{jen} \Ch{F}{já} zůs\Ch{G}{tá}\Ch{C}{vám}
+<C>jen <F>já zůs<G>tá<C>vám
 
-\Ch{F}{} \Ch{G}{} \Ch{C}{}
+<F> <G> <C>
 
 \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Těšínská.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Těšínská.tex
@@ -3,16 +3,16 @@
 \zp{Těšínská}{Jarek Nohavica}
 
 \zs
-\Ch{Ami}{Kdybych} se narodil \Ch{Dmi}{před} sto léty
-\Ch{F}{} v \Ch{E7}{tom}hle \Ch{Ami}{městě,} \Ch{Dmi}{} \Ch{F}{} \Ch{E7}{} \Ch{Ami}{}
+<Ami>Kdybych se narodil <Dmi>před sto léty
+<F> v <E7>tomhle <Ami>městě, <Dmi> <F> <E7> <Ami>
 
-\Ch{Ami}{u La}rišů na zahradě \Ch{Dmi}{trhal} bych květy \Ch{F}{}
-\Ch{E7}{své ne}\Ch{Ami}{věstě.} \Ch{Dmi}{} \Ch{F}{} \Ch{E7}{} \Ch{Ami}{}
+<Ami>u Larišů na zahradě <Dmi>trhal bych květy <F>
+<E7>své ne<Ami>věstě. <Dmi> <F> <E7> <Ami>
 
-\Ch{C}{Moje} nevěsta by \Ch{Dmi}{byla} dcera ševcova
-z \Ch{F}{domu} Kamińskich \Ch{C}{odněkud} ze Lvova,
+<C>Moje nevěsta by <Dmi>byla dcera ševcova
+z <F>domu Kamińskich <C>odněkud ze Lvova,
 
-kochał bym ja i \Ch{Dmi}{pieśćił} \Ch{F}{chy}\Ch{E7}{ba} lat \Ch{Ami}{dwieśćie}.
+kochał bym ja i <Dmi>pieśćił <F>chy<E7>ba lat <Ami>dwieśćie.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____Tři_čuníci.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Tři_čuníci.tex
@@ -3,13 +3,13 @@
 \zp{Tři čuníci}{Jarek Nohavica}
 
 \zs
-V \Ch{C}{řadě} za sebou tři čuníci jdou,
+V <C>řadě za sebou tři čuníci jdou,
 
-ťápají se v blátě cestou neces\Ch{Ami}{tou,}
+ťápají se v blátě cestou neces<Ami>tou,
 
-\Ch{Dmi}{kufry nemají,} cestu nezna\Ch{G7}{jí,}
+<Dmi>kufry nemají, cestu nezna<G7>jí,
 
-\Ch{Dmi}{vyšli prostě} do světa a \Ch{G7}{vesele} si zpívají:
+<Dmi>vyšli prostě do světa a <G7>vesele si zpívají:
 \ks
 
 \zr

--- a/tp-songs/01_folk/Jarek_Nohavica____Ukolébavka.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Ukolébavka.tex
@@ -3,36 +3,36 @@
 \zp{Ukolébavka}{Jarek Nohavica}
 
 \zs
-\Ch{G}{Den} už se \Ch{G/F#}{zešeřil},
+<G>Den už se <G/F#>zešeřil,
 
-\Ch{G/E}{už jste} si dost \Ch{G/F#}{užili.} \Ch{G}{}
+<G/E>už jste si dost <G/F#>užili. <G>
 
-Tak \Ch{Ami}{hajdy} do pe\Ch{Ami/G#}{řin}
+Tak <Ami>hajdy do pe<Ami/G#>řin
 
-a \Ch{Ami/G}{ne, abyste} tam moc \Ch{Ami/G#}{řádili.}\Ch{Ami}{}
+a <Ami/G>ne, abyste tam moc <Ami/G#>řádili.<Ami>
 
 Zítra je taky den, slunko mi to dneska slíbilo,
 
 přejte si hezký sen a kéž by se vám to splnilo.
 
-\Ch{G}{Na} na na, \Ch{Emi}{ná ná} ná \Ch{Hmi}{na na} ná \Ch{Emi}{ná,}
+<G>Na na na, <Emi>ná ná ná <Hmi>na na ná <Emi>ná,
 
-aby hůř \Ch{Ami}{nebylo}, to by nám \Ch{D7}{stačilo.}
+aby hůř <Ami>nebylo, to by nám <D7>stačilo.
 \ks
 
 \zr
-\Ch{G}{Hajduly}, \Ch{C}{dajduly}, \Ch{G}{aby} víčka 
-\Ch{D7}{sklapnu}\Ch{G}{ly,} 
+<G>Hajduly, <C>dajduly, <G>aby víčka 
+<D7>sklapnu<G>ly, 
 
 hajduly, dajdy, každý svou peřinu najdi.
 
-\Ch{G}{Ha}jajajajaja \Ch{D7}{ja} \Ch{G}{já},
+<G>Hajajajajaja <D7>ja <G>já,
 
-Kuba, Lenka, máma \Ch{D7}{a} \Ch{G}{já.}
+Kuba, Lenka, máma <D7>a <G>já.
 
-Dřív, než zítra slunce \Ch{C}{začne} \Ch{G}{hřát},
+Dřív, než zítra slunce <C>začne <G>hřát,
 
-dobrou \Ch{D7}{noc} a \Ch{G}{spát.}
+dobrou <D7>noc a <G>spát.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jarek_Nohavica____V_jednym_dumku.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____V_jednym_dumku.tex
@@ -3,9 +3,9 @@
 \zp{V jednym dumku na Zarubku}{Jarek Nohavica}
 
 \zs
-V \Ch{C}{jednym dumku} \Ch{G}{na Zarubku} \Ch{G7}{mjal raz chlopek} \Ch{C}{švarnu robku}
+V <C>jednym dumku <G>na Zarubku <G7>mjal raz chlopek <C>švarnu robku
 
-a ta robka \Ch{G}{teho chlopka} \Ch{G7}{rada nemja}\Ch{C}{la.}
+a ta robka <G>teho chlopka <G7>rada nemja<C>la.
 
 Bo ten jeji chlopek dobrotisko byl, on tej svoji robce všicko porobil,
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Zatanči.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Zatanči.tex
@@ -3,23 +3,23 @@
 \zp{Zatanči}{Jarek Nohavica}
 
 \zs
-\Ch{Emi}{Zatan}\Ch{G}{či}, má milá, \Ch{D}{zatanči} \Ch{Emi}{pro mé} oči,
+<Emi>Zatan<G>či, má milá, <D>zatanči <Emi>pro mé oči,
 
-zatan\Ch{G}{či} a vetkni \Ch{D}{nůž} do mých \Ch{Emi}{zad},
+zatan<G>či a vetkni <D>nůž do mých <Emi>zad,
 
-ať tvůj \Ch{G}{šat}, má milá, \Ch{D}{ať} tvůj šat \Ch{Emi}{na zemi} skončí,
+ať tvůj <G>šat, má milá, <D>ať tvůj šat <Emi>na zemi skončí,
 
-ať tvůj \Ch{G}{šat}, má milá, \Ch{D}{rázem} je s\Ch{Emi}{ňat}.
+ať tvůj <G>šat, má milá, <D>rázem je s<Emi>ňat.
 \ks
 
 \zr
-\Ch{Emi}{Zatan}\Ch{G}{či}, jako se \Ch{D}{okolo} \Ch{Emi}{ohně} tančí,
+<Emi>Zatan<G>či, jako se <D>okolo <Emi>ohně tančí,
 
-zatan\Ch{G}{či} jako \Ch{D}{na} vodě \Ch{Emi}{loď,}
+zatan<G>či jako <D>na vodě <Emi>loď,
 
-zatan\Ch{G}{či} jako to \Ch{D}{slunce} mezi \Ch{Emi}{pomeranči,}
+zatan<G>či jako to <D>slunce mezi <Emi>pomeranči,
 
-zatan\Ch{G}{či} a \Ch{D}{pak} ke mně \Ch{Emi}{pojď.}
+zatan<G>či a <D>pak ke mně <Emi>pojď.
 \kr
 
 \zs
@@ -32,7 +32,7 @@ obejmi, má milá, obejmi moje bedra,
 obejmi je pevně a mojí buď.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Nový den než začne, má milá, nežli začne,
@@ -44,9 +44,9 @@ zatanči, má milá, pro moje oči lačné,
 zatanči a já budu ti hrát.
 \ks
 
-\zr  \kr
+\zr \kr
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Jarek_Nohavica____Zatímco_se_koupeš.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Zatímco_se_koupeš.tex
@@ -3,13 +3,13 @@
 \zp{Zatímco se koupeš}{Jarek Nohavica}
 
 \zs
-Zatímco se \Ch{Hmi}{koupeš}, \Ch{D}{umýváš} si záda,
+Zatímco se <Hmi>koupeš, <D>umýváš si záda,
 
-\Ch{G}{na} největší \Ch{A7}{loupež} ve mně se \Ch{D}{střádá},
+<G>na největší <A7>loupež ve mně se <D>střádá,
 
-\Ch{Gdim}{tak, jako} se \Ch{Hmi}{dáváš} vodě,
+<Gdim>tak, jako se <Hmi>dáváš vodě,
 
-\Ch{Fdim}{vezmu} si tě \Ch{A7}{já, já} zloděj.
+<Fdim>vezmu si tě <A7>já, já zloděj.
 \ks
 
 \zs
@@ -23,13 +23,13 @@ slyším, jak se mydlíš pěnou.
 \ks
 
 \zr
-Nechej vodu \Ch{D}{vodou}, \Ch{G}{jen} ať si klidně \Ch{D}{teče},
+Nechej vodu <D>vodou, <G>jen ať si klidně <D>teče,
 
-chápej, že \Ch{Emi}{touha} je touha a \Ch{G}{čas} se pomalu \Ch{D}{vleče},
+chápej, že <Emi>touha je touha a <G>čas se pomalu <D>vleče,
 
-cigareta \Ch{Emi}{hasne}, káva \Ch{G}{stydne}, krev se \Ch{D}{pění},
+cigareta <Emi>hasne, káva <G>stydne, krev se <D>pění,
 
-bylo by to \Ch{Emi}{krásné}, kdyby srdce bylo \Ch{G}{klidné}, ale ono \Ch{D}{není}.
+bylo by to <Emi>krásné, kdyby srdce bylo <G>klidné, ale ono <D>není.
 \kr
 
 \zs
@@ -45,6 +45,6 @@ všechny peníze dal bych za odvahu.
 \zr
 \kr
 
-Hm \Ch{Emi}{hm,} \Ch{A7}{nebylo a} \Ch{D}{není}, hm \Ch{Emi}{hm,} \Ch{A7}{zatímco} se \Ch{D}{koupeš}...
+Hm <Emi>hm, <A7>nebylo a <D>není, hm <Emi>hm, <A7>zatímco se <D>koupeš...
 
 \kp

--- a/tp-songs/01_folk/Jarek_Nohavica____Zítra_ráno_v_pět.tex
+++ b/tp-songs/01_folk/Jarek_Nohavica____Zítra_ráno_v_pět.tex
@@ -3,20 +3,20 @@
 \zp{Zítra ráno v pět}{Jarek Nohavica}
 
 \zs
-Až mě \Ch{Emi}{zítra} ráno v pět
-\Ch{G}{ke zdi} postaví,
+Až mě <Emi>zítra ráno v pět
+<G>ke zdi postaví,
 
-ješ\Ch{C}{tě} si napos\Ch{D}{led}
-dám \Ch{G}{vodku} na zdra\Ch{E7}{ví,}
+ješ<C>tě si napos<D>led
+dám <G>vodku na zdra<E7>ví,
 
-z očí \Ch{Ami}{pásku} {strhnu} \Ch{D7}{si, to}
-abych \Ch{G}{viděl} na ne\Ch{Emi}{be}
+z očí <Ami>pásku {strhnu} <D7>si, to
+abych <G>viděl na ne<Emi>be
 
-a \Ch{Ami}{pak vzpomenu} \Ch{H7}{si,}
-\Ch{Emi}{lásko}, na te\Ch{E7}{be,}
-\Ch{Ami}{} \Ch{D}{} \Ch{G}{} \Ch{Emi}{}
+a <Ami>pak vzpomenu <H7>si,
+<Emi>lásko, na te<E7>be,
+<Ami> <D> <G> <Emi>
 
-a \Ch{Ami}{pak vzpomenu} \Ch{H7}{si na} te\Ch{Emi}{be.}
+a <Ami>pak vzpomenu <H7>si na te<Emi>be.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jaroslav_Ježek____Babička_Mary.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Babička_Mary.tex
@@ -3,39 +3,39 @@
 \zp{Babička Mary}{Jaroslav Ježek}
 
 \zs
-\Ch{Ami}{Štěchovická} laguna když dřímá v zadumaném stínu Kordylér, 
+<Ami>Štěchovická laguna když dřímá v zadumaném stínu Kordylér, 
 
-\Ch{Dmi}{pirát} zkrva\Ch{Ami}{venou} šerpu ždímá, \Ch{H7}{kapitán} pucuje revol\Ch{E}{ver.} 
-
-\bigskip
-
-\Ch{Ami}{Pikovická} rýžoviště zlata čeří se v příboji Sázavy, 
-
-\Ch{Dmi}{ale zato} \Ch{Ami}{krčmářova} chata \Ch{Dmi}{křepčí} rykem \Ch{E7}{chlapské} zába\Ch{Ami}{vy.} 
+<Dmi>pirát zkrva<Ami>venou šerpu ždímá, <H7>kapitán pucuje revol<E>ver. 
 
 \bigskip
 
-\Ch{G7}{Když} tu náhle -- co se \Ch{C}{děje?} \Ch{G7}{Divný} šelest houštím 
-\Ch{C}{spěje}, 
+<Ami>Pikovická rýžoviště zlata čeří se v příboji Sázavy, 
 
-\Ch{G7}{plch}, skunk? -- \Ch{C}{Vše} utíká \Ch{F}{po} stráni \Ch{F#dim}{od 
-Mední}\Ch{E}{ka}. 
+<Dmi>ale zato <Ami>krčmářova chata <Dmi>křepčí rykem <E7>chlapské zába<Ami>vy. 
 
 \bigskip
 
-\Ch{Ami}{Krčmář} zhasne, kovbojové ztichnou, pirát zděšen tvář si zakryje, 
+<G7>Když tu náhle -- co se <C>děje? <G7>Divný šelest houštím 
+<C>spěje, 
 
-\Ch{Dmi}{rudé} squaw se \Ch{Ami}{chvějí} a pak vzdychnou:
-\uv{\Ch{H7}{Blíží} se k nám postrach \Ch{E}{prérie.}}\Ch{G7}{} \ks
+<G7>plch, skunk? -- <C>Vše utíká <F>po stráni <F#dim>od 
+Mední<E>ka. 
+
+\bigskip
+
+<Ami>Krčmář zhasne, kovbojové ztichnou, pirát zděšen tvář si zakryje, 
+
+<Dmi>rudé squaw se <Ami>chvějí a pak vzdychnou:
+\uv{<H7>Blíží se k nám postrach <E>prérie.}<G7> \ks
 
 \zr
-\Ch{C}{Mary}, babička \Ch{D7}{Mary}, 
+<C>Mary, babička <D7>Mary, 
 
-dva kolťá\Ch{G7}{ky za pasem,} nad hlavou \Ch{C}{točí} lasem. \Ch{G7}
+dva kolťá<G7>ky za pasem, nad hlavou <C>točí lasem. <G7>
 
-Stoletá Mary, babička \Ch{D7}{Mary}, 
+Stoletá Mary, babička <D7>Mary, 
 
-ta zkrotí \Ch{G7}{křepce} hřebce, ať chce, či ne\Ch{C}{chce}.\Ch{E7}{} 
+ta zkrotí <G7>křepce hřebce, ať chce, či ne<C>chce.<E7> 
 \kr
 
 \zs

--- a/tp-songs/01_folk/Jaroslav_Ježek____Ezob_a_brabenec.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Ezob_a_brabenec.tex
@@ -3,37 +3,37 @@
 \zp{Ezob a brabenec}{Jaroslav Ježek}
 
 \zs
-\Ch{C}{Jednou} z \Ch{Emi}{lesa} \Ch{Ami}{domů} se \Ch{Ami7}{nesa,} \Ch{F}{mou}\Ch{G7}{drý} \Ch{C}{Ezop}\Ch{G7}{}
+<C>Jednou z <Emi>lesa <Ami>domů se <Ami7>nesa, <F>mou<G7>drý <C>Ezop<G7>
 
-\Ch{C}{potkal} \Ch{Emi}{brabce,} \Ch{Ami}{který} bra\Ch{Ami7}{bence} 
-\Ch{F}{má}\Ch{G7}{lem} \Ch{A7}{sezob.}
+<C>potkal <Emi>brabce, <Ami>který bra<Ami7>bence 
+<F>má<G7>lem <A7>sezob.
 
-\Ch{Dmi}{Brabenec} se \Ch{E}{chechtá,} \Ch{Dmi}{Ezop} se \Ch{D7}{hned} 
-\Ch{G7}{ptá,}
+<Dmi>Brabenec se <E>chechtá, <Dmi>Ezop se <D7>hned 
+<G7>ptá,
 
-\Ch{C}{čemu} \Ch{Emi}{že se} \Ch{Ami}{na trávě} v \Ch{Ami7}{lese} \Ch{F}{prá}\Ch{G}{vě} \Ch{Dmi}{řeh-}\Ch{G7}{tá}.
+<C>čemu <Emi>že se <Ami>na trávě v <Ami7>lese <F>prá<G>vě <Dmi>řeh-<G7>tá.
 \ks
 
 \zs
-\uv{\Ch{C}{Já,}} povídá \Ch{G7}{brabenec,} \uv{se taky \Ch{C}{rád}\Ch{B}{ hlasitě} \Ch{A7}{chechtám},
+\uv{<C>Já,} povídá <G7>brabenec, \uv{se taky <C>rád<B> hlasitě <A7>chechtám,
 
-chech\Ch{D7}{tám,} když pupe\Ch{G#7}{nec} \Ch{G7}{kyselinou} \Ch{C}{leptám.} \Ch{D7}{} \Ch{Dmi7}{} \Ch{G7}{} 
+chech<D7>tám, když pupe<G#7>nec <G7>kyselinou <C>leptám. <D7> <Dmi7> <G7> 
 
-\Ch{C}{Vím}}, totiž ten \Ch{G7}{brabenec,} \uv{mraveneč\Ch{C}{ník} \Ch{B}{že} 
-se mě \Ch{A7}{neptá},
+<C>Vím}, totiž ten <G7>brabenec, \uv{mraveneč<C>ník <B>že 
+se mě <A7>neptá,
 
-\Ch{D7}{neptá,} pozře mě, ať se \Ch{G#7}{chechtám} -- 
-\Ch{G7}{nechech}\Ch{C}{tám.}} \Ch{Dmi}{} \Ch{G7}{} \Ch{C}{} \ks
+<D7>neptá, pozře mě, ať se <G#7>chechtám -- 
+<G7>nechech<C>tám.} <Dmi> <G7> <C> \ks
 
 \zs
-\Ch{G#}{Kampak} by to \Ch{Es7}{došlo} třeba s \Ch{G#}{pouhou} 
-ponra\Ch{Es7}{vou,}  
+<G#>Kampak by to <Es7>došlo třeba s <G#>pouhou 
+ponra<Es7>vou, 
 
-\Ch{G}{kdyby} měla \Ch{D7}{plakat,} že je \Ch{Dmi}{ptačí} potra\Ch{G7}{vou}.
+<G>kdyby měla <D7>plakat, že je <Dmi>ptačí potra<G7>vou.
 
-\Ch{C}{Ty}, ač nejsi \Ch{G7}{brabenec}, se taky \Ch{C}{rád}\Ch{B}{ hlasitě} \Ch{A7}{chechtej},
+<C>Ty, ač nejsi <G7>brabenec, se taky <C>rád<B> hlasitě <A7>chechtej,
 
-chech\Ch{D7}{tej,} a na svou \Ch{G#7}{bídu} si \Ch{G7}{nezarep}\Ch{C}{tej}.
+chech<D7>tej, a na svou <G#7>bídu si <G7>nezarep<C>tej.
 \ks
 
 \kp

--- a/tp-songs/01_folk/Jaroslav_Ježek____Ezob_a_brabenec.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Ezob_a_brabenec.tex
@@ -11,7 +11,7 @@
 <Dmi>Brabenec se <E>chechtá, <Dmi>Ezop se <D7>hned 
 <G7>ptá,
 
-<C>čemu <Emi>že se <Ami>na trávě v <Ami7>lese <F>prá<G>vě <Dmi>řeh-<G7>tá.
+<C>čemu <Emi>že se <Ami>na trávě v <Ami7>lese <F>prá<G>vě <Dmi>řeh<G7>tá.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Jaroslav_Ježek____Nebe_na_zemi.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Nebe_na_zemi.tex
@@ -3,34 +3,34 @@
 \zp{Nebe na zemi}{Jaroslav Ježek}
 
 \zs
-\Ch{G}{Na} Nirvanu, na Olymp, na \Ch{Emi}{nebe} nevě\Ch{A7}{řím}, 
+<G>Na Nirvanu, na Olymp, na <Emi>nebe nevě<A7>řím, 
 
-\Ch{D7}{když} mě někdo pomlouvá, \Ch{G}{vždycky} \Ch{A7}{láte}\Ch{D7}{řím}. 
+<D7>když mě někdo pomlouvá, <G>vždycky <A7>láte<D7>řím. 
 
-\Ch{G}{Nestojím} o nekonečno s \Ch{Emi}{hvězdami} \Ch{A7}{všemi}, 
+<G>Nestojím o nekonečno s <Emi>hvězdami <A7>všemi, 
 
-\Ch{H7}{stačí} mi pár \Ch{F#7}{krásných} let \Ch{H7}{někde} na ze\Ch{D}{mi}. 
+<H7>stačí mi pár <F#7>krásných let <H7>někde na ze<D>mi. 
 \ks
 
 \zs
-\Ch{D+}{Když} já \Ch{G}{vám} \Ch{D+}{poví}\Ch{G}{dám}, \Ch{D+}{že je} \Ch{G}{nebe} \Ch{D+}{na ze}\Ch{G}{mi}, 
+<D+>Když já <G>vám <D+>poví<G>dám, <D+>že je <G>nebe <D+>na ze<G>mi, 
 
-pravdu \Ch{A7}{mám}, věřte mi, 
+pravdu <A7>mám, věřte mi, 
 
-za \Ch{D7}{život} \Ch{D9/G}{život} \Ch{D7}{dám}, i \Ch{D9/G}{když} 
-\Ch{D7}{nerad} \Ch{D9/G}{umí-}\Ch{D7}{rám,} 
+za <D7>život <D9/G>život <D7>dám, i <D9/G>když 
+<D7>nerad <D9/G>umí-<D7>rám, 
 
-\Ch{D+}{nejsem} \Ch{G}{sám,} \Ch{D+}{věřte} \Ch{G}{mi}.  \ks
+<D+>nejsem <G>sám, <D+>věřte <G>mi. \ks
 
 \zs
-Pro \Ch{G7}{toho}, \Ch{Hmi7}{kdo chce} \Ch{G7}{žít}, je na \Ch{C}{světě} 
-pl\Ch{G7}{no} \Ch{C}{krás} 
+Pro <G7>toho, <Hmi7>kdo chce <G7>žít, je na <C>světě 
+pl<G7>no <C>krás 
 
-a z těch \Ch{E7}{krás} nebe mít záleží \Ch{A7}{jenom} na \Ch{D7}{vás}. 
+a z těch <E7>krás nebe mít záleží <A7>jenom na <D7>vás. 
 
-\Ch{D+}{Jen} od \Ch{G}{vás}, \Ch{D+}{věřte} \Ch{G}{mi}, \Ch{D+}{záleží} \Ch{G}{kdy} \Ch{G7}{přijde} \Ch{E7}{čas}, 
+<D+>Jen od <G>vás, <D+>věřte <G>mi, <D+>záleží <G>kdy <G7>přijde <E7>čas, 
 
-kdy pro \Ch{A7}{nás} začne \Ch{D7}{nebe} \Ch{D9/G}{na ze}\Ch{G}{mi}.  \ks
+kdy pro <A7>nás začne <D7>nebe <D9/G>na ze<G>mi. \ks
 
 \kp
 

--- a/tp-songs/01_folk/Jaroslav_Ježek____Nebe_na_zemi.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Nebe_na_zemi.tex
@@ -18,7 +18,7 @@
 pravdu <A7>mám, věřte mi, 
 
 za <D7>život <D9/G>život <D7>dám, i <D9/G>když 
-<D7>nerad <D9/G>umí-<D7>rám, 
+<D7>nerad <D9/G>umí<D7>rám, 
 
 <D+>nejsem <G>sám, <D+>věřte <G>mi. \ks
 

--- a/tp-songs/01_folk/Jaroslav_Ježek____Svítá.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Svítá.tex
@@ -3,34 +3,34 @@
 \zp{Svítá}{Jaroslav Ježek}
 
 \zs
-\Ch{F}{Do srdce se ti} \Ch{E7}{dí-}\Ch{C#mi}{vám,} \Ch{F}{když pod oknem ti} \Ch{B+}{zpí}\Ch{D7}{vám} 
+<F>Do srdce se ti <E7>dí-<C#mi>vám, <F>když pod oknem ti <B+>zpí<D7>vám 
 
-\Ch{G9}{každou noc stejná} \Ch{F}{slo}\Ch{D7}{va,} \Ch{Gmi7}{zno-}\Ch{C+}{va} \Ch{F}{svou} sere\Ch{E7}{ná}\Ch{C+}{du.} 
+<G9>každou noc stejná <F>slo<D7>va, <Gmi7>zno-<C+>va <F>svou sere<E7>ná<C+>du. 
 
-\Ch{F}{Svou serenádu} \Ch{E7}{zpí}\Ch{C#mi7}{vám,} \Ch{F}{marně se k oknu} \Ch{D+}{dí-}\Ch{D7}{vám,} 
+<F>Svou serenádu <E7>zpí<C#mi7>vám, <F>marně se k oknu <D+>dí-<D7>vám, 
 
-\Ch{G7}{než zazpívám ji} \Ch{F}{jed-}\Ch{Dmi}{nou,} \Ch{G7}{hvěz}\Ch{G7+}{dy} \Ch{Gmi7}{zbled-}\Ch{Gdim}{nou.} 
+<G7>než zazpívám ji <F>jed-<Dmi>nou, <G7>hvěz<G7+>dy <Gmi7>zbled-<Gdim>nou. 
 \ks
 \zr
-\Ch{F}{Sví}\Ch{Dmi}{tá,} \Ch{Gmi}{} \Ch{Bmi6}{probuď se, už} \Ch{F}{sví}\Ch{Dmi}{tá,} \Ch{G7}{} 
+<F>Sví<Dmi>tá, <Gmi> <Bmi6>probuď se, už <F>sví<Dmi>tá, <G7> 
 
-zažeň chladný \Ch{C#7}{sen,} bude horký \Ch{C7}{den,} je čas procit\Ch{F}{nout.} 
+zažeň chladný <C#7>sen, bude horký <C7>den, je čas procit<F>nout. 
 
-\Ch{Cdim}{Nad} \Ch{Gmi7}{le-}\Ch{C#7}{sy} \Ch{F}{sví}\Ch{Dmi}{tá,} \Ch{Gmi}{}
-\Ch{Bmi6}{hvězdy blednou,} \Ch{F}{sví}\Ch{Dmi}{tá,} \Ch{G7}{} 
+<Cdim>Nad <Gmi7>le-<C#7>sy <F>sví<Dmi>tá, <Gmi>
+<Bmi6>hvězdy blednou, <F>sví<Dmi>tá, <G7> 
 
-Otevř' na můj \Ch{C#7}{hlas,} nastává už \Ch{C7}{čas,} 
+Otevř' na můj <C#7>hlas, nastává už <C7>čas, 
 
-chceš-li uprch\Ch{F}{nout} \Ch{B7}{se} \Ch{F}{mnou.} 
+chceš-li uprch<F>nout <B7>se <F>mnou. 
 \kr
 
 \zs
-\Ch{As}{Chvíli,} ještě malou \Ch{Es}{chvíli a bude den} \Ch{Fmi}{bílý,} 
+<As>Chvíli, ještě malou <Es>chvíli a bude den <Fmi>bílý, 
 
-\Ch{Fdim}{bude} \Ch{G7}{konec} \Ch{C}{do-}\Ch{Cdim}{bro-}\Ch{Gmi7}{druž-}\Ch{C#7}{ství.} 
+<Fdim>bude <G7>konec <C>do-<Cdim>bro-<Gmi7>druž-<C#7>ství. 
 
-\Ch{F}{Sví}\Ch{Dmi}{tá,} \Ch{Gmi}{} \Ch{Bmi6}{na východě} \Ch{F}{sví}\Ch{Dmi}{tá,} \Ch{G7}{každý příští} \Ch{C#7}{den} 
+<F>Sví<Dmi>tá, <Gmi> <Bmi6>na východě <F>sví<Dmi>tá, <G7>každý příští <C#7>den 
 
-bude jako \Ch{C7}{sen, chceš-li} uprch\Ch{F}{nout} \Ch{B7}{se} \Ch{F6}{mnou.} \Ch{C#}{} \Ch{Fmi6}{} \Ch{F}{}
+bude jako <C7>sen, chceš-li uprch<F>nout <B7>se <F6>mnou. <C#> <Fmi6> <F>
 \ks
 \kp

--- a/tp-songs/01_folk/Jaroslav_Ježek____Svítá.tex
+++ b/tp-songs/01_folk/Jaroslav_Ježek____Svítá.tex
@@ -3,20 +3,20 @@
 \zp{Svítá}{Jaroslav Ježek}
 
 \zs
-<F>Do srdce se ti <E7>dí-<C#mi>vám, <F>když pod oknem ti <B+>zpí<D7>vám 
+<F>Do srdce se ti <E7>dí<C#mi>vám, <F>když pod oknem ti <B+>zpí<D7>vám 
 
-<G9>každou noc stejná <F>slo<D7>va, <Gmi7>zno-<C+>va <F>svou sere<E7>ná<C+>du. 
+<G9>každou noc stejná <F>slo<D7>va, <Gmi7>zno<C+>va <F>svou sere<E7>ná<C+>du. 
 
-<F>Svou serenádu <E7>zpí<C#mi7>vám, <F>marně se k oknu <D+>dí-<D7>vám, 
+<F>Svou serenádu <E7>zpí<C#mi7>vám, <F>marně se k oknu <D+>dí<D7>vám, 
 
-<G7>než zazpívám ji <F>jed-<Dmi>nou, <G7>hvěz<G7+>dy <Gmi7>zbled-<Gdim>nou. 
+<G7>než zazpívám ji <F>jed<Dmi>nou, <G7>hvěz<G7+>dy <Gmi7>zbled<Gdim>nou. 
 \ks
 \zr
 <F>Sví<Dmi>tá, <Gmi> <Bmi6>probuď se, už <F>sví<Dmi>tá, <G7> 
 
 zažeň chladný <C#7>sen, bude horký <C7>den, je čas procit<F>nout. 
 
-<Cdim>Nad <Gmi7>le-<C#7>sy <F>sví<Dmi>tá, <Gmi>
+<Cdim>Nad <Gmi7>le<C#7>sy <F>sví<Dmi>tá, <Gmi>
 <Bmi6>hvězdy blednou, <F>sví<Dmi>tá, <G7> 
 
 Otevř' na můj <C#7>hlas, nastává už <C7>čas, 
@@ -27,7 +27,7 @@ chceš-li uprch<F>nout <B7>se <F>mnou.
 \zs
 <As>Chvíli, ještě malou <Es>chvíli a bude den <Fmi>bílý, 
 
-<Fdim>bude <G7>konec <C>do-<Cdim>bro-<Gmi7>druž-<C#7>ství. 
+<Fdim>bude <G7>konec <C>do<Cdim>bro<Gmi7>druž<C#7>ství. 
 
 <F>Sví<Dmi>tá, <Gmi> <Bmi6>na východě <F>sví<Dmi>tá, <G7>každý příští <C#7>den 
 

--- a/tp-songs/01_folk/Jaroslav_Uhlíř,_Zdeněk_Svěrák____Není_nutno.tex
+++ b/tp-songs/01_folk/Jaroslav_Uhlíř,_Zdeněk_Svěrák____Není_nutno.tex
@@ -3,9 +3,9 @@
 \zp{Není nutno}{Jaroslav Uhlíř, Zdeněk Svěrák}
 
 \zr
-\Ch{A}{Není} nutno, není nutno, aby bylo přímo vese\Ch{Hmi}{lo,}
+<A>Není nutno, není nutno, aby bylo přímo vese<Hmi>lo,
 
-\Ch{E7}{hlavně} nesmí býti smutno, natož aby se breče\Ch{A}{lo.} \Ch{E7}{}
+<E7>hlavně nesmí býti smutno, natož aby se breče<A>lo. <E7>
 \kr
 
 \zs
@@ -15,9 +15,9 @@ nemít žádné kamarády, tomu já říkám neštěstí.
 \ks
 
 \zs
-Nemít \Ch{F#mi}{prachy} -- \Ch{A}{nevadí,} nemít \Ch{F#mi}{srdce} -- \Ch{A}{vadí,}
+Nemít <F#mi>prachy -- <A>nevadí, nemít <F#mi>srdce -- <A>vadí,
 
-zažít \Ch{F#mi}{krachy} -- \Ch{A}{nevadí,} zažít \Ch{F#mi}{nudu} -- \Ch{D}{jó to} \Ch{E}{vadí.}
+zažít <F#mi>krachy -- <A>nevadí, zažít <F#mi>nudu -- <D>jó to <E>vadí.
 \ks
 
 

--- a/tp-songs/01_folk/Jaroslav_Uhlíř,_Zdeněk_Svěrák____Pramen_zdraví.tex
+++ b/tp-songs/01_folk/Jaroslav_Uhlíř,_Zdeněk_Svěrák____Pramen_zdraví.tex
@@ -3,31 +3,31 @@
 \zp{Pramen zdraví}{Jaroslav Uhlíř, Zdeněk Svěrák}
 
 \zs
-Každý \Ch{C}{den,} každý den k svači\Ch{Ami}{ně je}dině,
+Každý <C>den, každý den k svači<Ami>ně jedině,
 
-\Ch{F}{jedině} \Ch{G}{pram}en zdraví z \Ch{C}{Pos}ázaví. \Ch{G}{}
+<F>jedině <G>pramen zdraví z <C>Posázaví. <G>
 
-Chcete-\Ch{C}{li pr}ospěti dítě\Ch{Ami}{ti ble}dému,
+Chcete-<C>li prospěti dítě<Ami>ti bledému,
 
-\Ch{F}{kupte} mu \Ch{G}{pram}en zdraví z \Ch{C}{Posá}zaví. \Ch{G}{}
+<F>kupte mu <G>pramen zdraví z <C>Posázaví. <G>
 \ks
 
 \zr
-Výrobky \Ch{C}{mléčné,} / Každý den, každý den
+Výrobky <C>mléčné, / Každý den, každý den
 
-to je \Ch{Ami}{marné,} / k svačině jedině,
+to je <Ami>marné, / k svačině jedině,
 
-jsou blaho\Ch{F}{dárné} \Ch{G}{} / jedině pramen zdraví
+jsou blaho<F>dárné <G> / jedině pramen zdraví
 
-a \Ch{C}{věčné.} \Ch{G}{} / z Posázaví.
+a <C>věčné. <G> / z Posázaví.
 
-Výrobky \Ch{C}{mléčné,} / Chcete-li prospěti
+Výrobky <C>mléčné, / Chcete-li prospěti
 
-to je \Ch{Ami}{marné,} / dítěti bledému,
+to je <Ami>marné, / dítěti bledému,
 
-jsou blaho\Ch{F}{dárné} \Ch{G}{} / kupte mu pramen zdraví
+jsou blaho<F>dárné <G> / kupte mu pramen zdraví
 
-a \Ch{C}{věčné.} \Ch{G}{} / z Posázaví.
+a <C>věčné. <G> / z Posázaví.
 
 \kr
 

--- a/tp-songs/01_folk/Jiří_Schmitzer____Kaluž.tex
+++ b/tp-songs/01_folk/Jiří_Schmitzer____Kaluž.tex
@@ -3,16 +3,16 @@
 \zp{Kaluž}{Jiří Schmitzer}
 
 \zr
-\Ch{Dmi}{Ny, ny,} \Ch{C}{ny,} \Ch{Ami}{ny, ny...} \Ch{Dmi}{} \Ch{C}{} \Ch{Dmi}{}
+<Dmi>Ny, ny, <C>ny, <Ami>ny, ny... <Dmi> <C> <Dmi>
 \kr
 
 \zs
-\Ch{Dmi}{A je mi} dvacet let a \Ch{C}{já už se}
-\Ch{Ami}{ke kaluži} \Ch{Dmi}{loudám a} \Ch{C}{hned} mě napa\Ch{Dmi}{dá,}
+<Dmi>A je mi dvacet let a <C>já už se
+<Ami>ke kaluži <Dmi>loudám a <C>hned mě napa<Dmi>dá,
 
-\Ch{Dmi}{že těch} mých dvacet let,
-kdy \Ch{C}{já} jsem se \Ch{Ami}{ke kal}uži \Ch{Dmi}{blížil,}
-má \Ch{C}{kaluž} nera\Ch{Dmi}{da -- hej!}
+<Dmi>že těch mých dvacet let,
+kdy <C>já jsem se <Ami>ke kaluži <Dmi>blížil,
+má <C>kaluž nera<Dmi>da -- hej!
 \ks
 
 \zr \kr
@@ -49,17 +49,17 @@ kolik mám do smrti.
 \ks
 
 \zs
-\Ch{Dmi}{Teče} voda, teče strání
-\Ch{C}{a s}uchý list \Ch{Ami}{plave} na ní,
+<Dmi>Teče voda, teče strání
+<C>a suchý list <Ami>plave na ní,
 
-\Ch{Dmi}{teče} voda, teče strání,
-\Ch{C}{sám} sebe se \Ch{Dmi}{ptám,}
+<Dmi>teče voda, teče strání,
+<C>sám sebe se <Dmi>ptám,
 
-\Ch{Dmi}{jak ta} voda strání pádí,
-\Ch{C}{neza}staví \Ch{Ami}{ji sto} kádí ,
+<Dmi>jak ta voda strání pádí,
+<C>nezastaví <Ami>ji sto kádí ,
 
-\Ch{Dmi}{a ten} list, co plave na ní,
-\Ch{C}{nej}sem-li já \Ch{Dmi}{sám -- hej!}
+<Dmi>a ten list, co plave na ní,
+<C>nejsem-li já <Dmi>sám -- hej!
 \ks
 
 \zr \kr

--- a/tp-songs/01_folk/Kamelot____Amulet.tex
+++ b/tp-songs/01_folk/Kamelot____Amulet.tex
@@ -3,32 +3,32 @@
 \zp{Amulet}{Kamelot}
 
 \zs
-\Ch{G}{Zhasl} už oheň a jiskra líná
+<G>Zhasl už oheň a jiskra líná
 
-\Ch{C}{pomalu} vzlétla tmou,
+<C>pomalu vzlétla tmou,
 
-\Ch{G}{škrtl} jsem sirkou, co jediná zbyla,
+<G>škrtl jsem sirkou, co jediná zbyla,
 
-\Ch{C}{cigaretu} vyklepanou,
+<C>cigaretu vyklepanou,
 
-z lesa \Ch{Ami}{vyletěl} pták a krákoral tak,
+z lesa <Ami>vyletěl pták a krákoral tak,
 
-že \Ch{D}{vzpomínky} mé rozjitřil,
+že <D>vzpomínky mé rozjitřil,
 
-na \Ch{Ami}{znak pavouků}, co do klobouku
+na <Ami>znak pavouků, co do klobouku
 
-mi \Ch{D}{vyšila} holka z kusu mé šály v zavřeným kupé, když koleje hrály.
+mi <D>vyšila holka z kusu mé šály v zavřeným kupé, když koleje hrály.
 \ks
 
 
 \zr
-\Ch{G}{Můj} amu\Ch{G+}{let nez}kla\Ch{Emi}{mal} moji \Ch{G7}{pouť},
+<G>Můj amu<G+>let nezkla<Emi>mal moji <G7>pouť,
 
-jak \Ch{C}{anděl} při mně \Ch{Cmi}{stál}, když \Ch{Emi}{nemohl} jsem dál,\Ch{D7}{}
+jak <C>anděl při mně <Cmi>stál, když <Emi>nemohl jsem dál,<D7>
 
-\Ch{G}{vím}, cesty \Ch{G+}{mé} s tvými \Ch{Emi}{se nesej}\Ch{G7}{dou},
+<G>vím, cesty <G+>mé s tvými <Emi>se nesej<G7>dou,
 
-ty \Ch{C}{pevně} drží \Ch{Cmi}{čas a s} \Ch{Emi}{nimi} i nás.\Ch{D7}{}
+ty <C>pevně drží <Cmi>čas a s <Emi>nimi i nás.<D7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Kamelot____Cikáni.tex
+++ b/tp-songs/01_folk/Kamelot____Cikáni.tex
@@ -2,26 +2,26 @@
 
 \zp{Cikáni}{Kamelot}
 
-3× /: \Ch{Dmi}{} \Ch{C}{} \Ch{B}{} \Ch{A7}{} :/
+3× /: <Dmi> <C> <B> <A7> :/
 
 \zs
-\Ch{Dmi}{Rozjásaným} davem kráčím \Ch{C}{sám,}
+<Dmi>Rozjásaným davem kráčím <C>sám,
 
-staccato \Ch{B}{Es}tacada zní mi do \Ch{A7}{uší,}
+staccato <B>Estacada zní mi do <A7>uší,
 
-\Ch{Dmi}{ženy}, písně, víno ze všech \Ch{C}{stran,}
+<Dmi>ženy, písně, víno ze všech <C>stran,
 
-a dívka \Ch{B}{snědá} moje slzy osu\Ch{A7}{ší.}
+a dívka <B>snědá moje slzy osu<A7>ší.
 \ks
 
 \zr
-\Ch{Gmi}{Zpívali} \Ch{Abdim}{písně cik}án\Ch{Dmi}{ský,}
+<Gmi>Zpívali <Abdim>písně cikán<Dmi>ský,
 
-v \Ch{B}{očích} teplo \Ch{C}{a} ve tváři \Ch{Ami}{kámen,}
+v <B>očích teplo <C>a ve tváři <Ami>kámen,
 
-na \Ch{Gmi}{duš}ích \Ch{Abdim}{špínu mnoha} \Ch{Dmi}{dní}
+na <Gmi>duších <Abdim>špínu mnoha <Dmi>dní
 
-a \Ch{B}{lidí}, co \Ch{C}{povídají} \Ch{Dmi}{ámen.}
+a <B>lidí, co <C>povídají <Dmi>ámen.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Kamelot____Honolulu.tex
+++ b/tp-songs/01_folk/Kamelot____Honolulu.tex
@@ -4,11 +4,11 @@
 
 \zs
 
-\Ch{G}{Let}ecká \Ch{C}{linka} do rá\Ch{D}{je}, \Ch{C}{}
-k \Ch{G}{ostr}ovům \Ch{C}{slu}nné Hava\Ch{D}{je,} \Ch{C}{}
+<G>Letecká <C>linka do rá<D>je, <C>
+k <G>ostrovům <C>slunné Hava<D>je, <C>
 
-\Ch{G}{nabra}la \Ch{C}{kurs} vlastní \Ch{D}{osy},
-\Ch{C}{tam} holky \Ch{D}{plavky} neno\Ch{G}{sí}. \Ch{C}{} \Ch{D}{} \Ch{C}{}
+<G>nabrala <C>kurs vlastní <D>osy,
+<C>tam holky <D>plavky neno<G>sí. <C> <D> <C>
 \ks
 \zs
 Na pláži Beach Boys čekají,
@@ -18,12 +18,12 @@ na runway Boeing dosedá
 a slunce pálí, to se má.
 \ks
 \zr
-\Ch{D}{Ho}nolulu, \Ch{C}{uku}lulu, \Ch{G}{tohle} mám rád,
+<D>Honolulu, <C>ukululu, <G>tohle mám rád,
 
-\Ch{D}{wh}isku na ex, \Ch{C}{mul}atek sex si \Ch{G}{můžu} přát,
+<D>whisku na ex, <C>mulatek sex si <G>můžu přát,
 reggae, reggae, reggae.
 
-\Ch{D}{Ho}nolulu, \Ch{C}{uk}ululu. \Ch{G}{Hej}!
+<D>Honolulu, <C>ukululu. <G>Hej!
 \kr
 \zs
 Mulatka záda natřela,

--- a/tp-songs/01_folk/Kamelot____Krajina_větrných_mlýnů.tex
+++ b/tp-songs/01_folk/Kamelot____Krajina_větrných_mlýnů.tex
@@ -4,13 +4,13 @@
 
 
 \zs
-\Ch{Ami}{Ahoj} Pe\Ch{Fmaj7}{ggy,} \Ch{G}{jak} dlouho \Ch{Emi7}{jsem} tě nevi\Ch{Ami}{děl,} \Ch{Fmaj7}{} \Ch{G}{} \Ch{Emi7}{}
+<Ami>Ahoj Pe<Fmaj7>ggy, <G>jak dlouho <Emi7>jsem tě nevi<Ami>děl, <Fmaj7> <G> <Emi7>
 
-\Ch{Ami}{tají} le\Ch{Fmaj7}{dy,} \Ch{G}{vítr} by \Ch{Emi7}{novou} \Ch{Ami}{trávu} \Ch{Fmaj7}{sel,}  \Ch{G}{} \Ch{Emi7}{}
+<Ami>tají le<Fmaj7>dy, <G>vítr by <Emi7>novou <Ami>trávu <Fmaj7>sel, <G> <Emi7>
 
-\Ch{Dmi}{uvidím} \Ch{A+}{někdy} úsměv \Ch{F}{tvůj} \Ch{G}{}
+<Dmi>uvidím <A+>někdy úsměv <F>tvůj <G>
 
-a \Ch{C}{uslyším} smích, co \Ch{E7}{slyším} jak dřív?
+a <C>uslyším smích, co <E7>slyším jak dřív?
 \ks
 
 \zs
@@ -24,13 +24,13 @@ orla u zátoky, žiješ nudný roky.
 \ks
 
 \zr
-Je \Ch{F}{opuštěná} \Ch{G}{krajina} větrných \Ch{C}{mlýnů}
+Je <F>opuštěná <G>krajina větrných <C>mlýnů
 
-a \Ch{F}{nalezená} je \Ch{G}{pravda,} co jsem ti \Ch{C}{říkal. } \Ch{C7}{}
+a <F>nalezená je <G>pravda, co jsem ti <C>říkal. <C7>
 
-Je \Ch{F}{zahalená} \Ch{G}{do staré} pavučiny \Ch{C}{slibů,} \Ch{A7}{}
+Je <F>zahalená <G>do staré pavučiny <C>slibů, <A7>
 
-věrných \Ch{Dmi7}{kamarádství,} \Ch{G}{přísah} a souhla\Ch{Fmaj7}{sů.}
+věrných <Dmi7>kamarádství, <G>přísah a souhla<Fmaj7>sů.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Kamelot____S.O.S.tex
+++ b/tp-songs/01_folk/Kamelot____S.O.S.tex
@@ -3,23 +3,23 @@
 \zp{S.O.S.}{Kamelot}
 
 \zs
-\Ch{C#mi}{Zas už se} \Ch{H}{valí další} \Ch{A}{bouře nad} ze\Ch{G#mi}{mí,}
+<C#mi>Zas už se <H>valí další <A>bouře nad ze<G#mi>mí,
 
-\Ch{C#mi}{já mezi} \Ch{H}{krama zemřu} \Ch{A}{sám,}
+<C#mi>já mezi <H>krama zemřu <A>sám,
 
-\Ch{C#mi}{saně, psi} \Ch{H}{a můj stan jsou} v \Ch{A}{ledu pohřbe}\Ch{G#mi}{ný,}
+<C#mi>saně, psi <H>a můj stan jsou v <A>ledu pohřbe<G#mi>ný,
 
-\Ch{C#mi}{lidí se} \Ch{H}{už nedovo}\Ch{A}{lám.}
+<C#mi>lidí se <H>už nedovo<A>lám.
 \ks
 
 \zr
-\Ch{F#mi}{Příjem,} \Ch{H}{za polárním kruhem} volám \Ch{E}{S.O.S.}
+<F#mi>Příjem, <H>za polárním kruhem volám <E>S.O.S.
 
-a s \Ch{A}{nalepeným} uchem na rep\Ch{C#mi}{ráku čekám} \Ch{G#}{zprávu,}
+a s <A>nalepeným uchem na rep<C#mi>ráku čekám <G#>zprávu,
 
-\Ch{F#mi}{příjem,} \Ch{H}{uragán se} zbláznil, doma \Ch{E}{říjen,}
+<F#mi>příjem, <H>uragán se zbláznil, doma <E>říjen,
 
-mně \Ch{A}{led už oči} zasklil napo\Ch{C#}{řád.}
+mně <A>led už oči zasklil napo<C#>řád.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Kamelot____Vyznavači_ohňů.tex
+++ b/tp-songs/01_folk/Kamelot____Vyznavači_ohňů.tex
@@ -2,28 +2,28 @@
 
 \zp{Vyznavači ohňů}{Kamelot}
 \zs
-\Ch{Cmi}{Ujel} jim \Ch{G#}{vlak} a \Ch{B}{bylo} jim \Ch{Eb}{míň} snad o \Ch{G#}{deset} \Ch{Fmi7}{nežli} \Ch{Gmi7}{mně.} \Ch{G13}{}
+<Cmi>Ujel jim <G#>vlak a <B>bylo jim <Eb>míň snad o <G#>deset <Fmi7>nežli <Gmi7>mně. <G13>
 
 Hlavu pro muziku, ale nebylo to tím, že spala mu na klíně.
 
-\Ch{G#}{Půjčenej} battledress a \Ch{Eb}{pra}chy od \Ch{G#}{táty}, \Ch{Fmi7}{co ji} už tak \Ch{Gmi7}{dávno} nevi\Ch{G#}{děl}.
+<G#>Půjčenej battledress a <Eb>prachy od <G#>táty, <Fmi7>co ji už tak <Gmi7>dávno nevi<G#>děl.
 
 Za tratí, kde je ves, hrál vítr sonáty a já jim tajně záviděl.
 \ks
 \zr
-\Ch{Ami}{Vaga}bundům upsaní jak \Ch{Fmaj7}{řádu mnich}
+<Ami>Vagabundům upsaní jak <Fmaj7>řádu mnich
 
-a \Ch{C}{nad}osmrti \Ch{Dmi}{rozpů}lený \Ch{Ami}{kon}ce prs\Ch{E4}{tů,} \Ch{E}
+a <C>nadosmrti <Dmi>rozpůlený <Ami>konce prs<E4>tů, <E>
 
 
-\Ch{Ami}{vyznavači} ohňů na všech \Ch{Fmaj7}{nádražích}
+<Ami>vyznavači ohňů na všech <Fmaj7>nádražích
 
-čekají \Ch{C}{zel}enou, než \Ch{Dmi13}{pojedou,}
+čekají <C>zelenou, než <Dmi13>pojedou,
 
-\Ch{Ami}{než je} dálky sebe\Ch{E7}{rou.}
+<Ami>než je dálky sebe<E7>rou.
 \kr
 \zs
-Tichá noc se vetřela k nim  stejně jako tehdy k nám,
+Tichá noc se vetřela k nim stejně jako tehdy k nám,
 
 on ji políbil a sáhl do strun a hrál hity, které znám.
 

--- a/tp-songs/01_folk/Kamelot____Vzpomínka_na_kamaráda.tex
+++ b/tp-songs/01_folk/Kamelot____Vzpomínka_na_kamaráda.tex
@@ -2,34 +2,34 @@
 
 \zp{Vzpomínka na kamaráda}{Kamelot}
 
-/: \Ch{Emi}{} \Ch{C}{} \Ch{Ami}{} \Ch{H7}{} :/
+/: <Emi> <C> <Ami> <H7> :/
 
 \zs
-\Ch{Emi}{Lásko, nejsi má,} jsi vzdále\Ch{C}{ná až do smrti,}
+<Emi>Lásko, nejsi má, jsi vzdále<C>ná až do smrti,
 
-\Ch{Ami}{dávno nečekám,} že by mě \Ch{H7}{křídla labutí}
+<Ami>dávno nečekám, že by mě <H7>křídla labutí
 
-\Ch{Emi}{zamávaly z vodopádů} \Ch{C}{šedivýho dne,}
+<Emi>zamávaly z vodopádů <C>šedivýho dne,
 
-ze \Ch{Ami}{skály naděje} mi odle\Ch{H7}{tí, odle}\Ch{Emi}{tí.}
+ze <Ami>skály naděje mi odle<H7>tí, odle<Emi>tí.
 \ks
 
 \zr
-\Ch{Ami}{Zlá nemoc} jako černá \Ch{D}{tůň}
+<Ami>Zlá nemoc jako černá <D>tůň
 
-\Ch{G}{stavěla} mříž o něco \Ch{C}{spíš,}
+<G>stavěla mříž o něco <C>spíš,
 
-\Ch{Ami}{když hnal se} nocí bílej \Ch{H7}{kůň}
+<Ami>když hnal se nocí bílej <H7>kůň
 
-jak lítá \Ch{Emi}{saň, a tvoje} \Ch{E7}{dlaň}
+jak lítá <Emi>saň, a tvoje <E7>dlaň
 
-už byla ledo\Ch{Ami}{vá jak štíty} \Ch{D}{hor,}
+už byla ledo<Ami>vá jak štíty <D>hor,
 
-\Ch{G}{telegraf} srdce za ob\Ch{C}{zor}
+<G>telegraf srdce za ob<C>zor
 
-\Ch{Ami}{donesl skromné} posel\Ch{H7}{ství:}
+<Ami>donesl skromné posel<H7>ství:
 
-\uv{Chtěl bych \Ch{Emi}{žít.}} \Ch{C}{} \Ch{Ami}{} \Ch{H7}{}
+\uv{Chtěl bych <Emi>žít.} <C> <Ami> <H7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Kamelot____Zachraňte_koně.tex
+++ b/tp-songs/01_folk/Kamelot____Zachraňte_koně.tex
@@ -2,27 +2,27 @@
 
 \zp{Zachraňte koně}{Kamelot}
 
-/: \Ch{Emi7}{} \Ch{Ami7}{} \Ch{D}{} \Ch{G}{} \Ch{C}{} \Ch{H}{} :/
+/: <Emi7> <Ami7> <D> <G> <C> <H> :/
 
 \zs
 
-\Ch{Emi7}{Peklo} byl ráj, když hořela stáj, \Ch{Ami7}{příteli},
+<Emi7>Peklo byl ráj, když hořela stáj, <Ami7>příteli,
 
-\Ch{C}{věř mi}, koně \Ch{D}{pláčou}, poví\Ch{G}{dám}.\Ch{C}{} \Ch{H}{}
+<C>věř mi, koně <D>pláčou, poví<G>dám.<C> <H>
 
-To \Ch{Emi7}{byla půlnoc,} vtom křik o pomoc, už \Ch{Ami7}{letěly}
+To <Emi7>byla půlnoc, vtom křik o pomoc, už <Ami7>letěly
 
-\Ch{C}{hejna} kohou\Ch{H7}{tů a bůhví} \Ch{Emi}{kam}.
+<C>hejna kohou<H7>tů a bůhví <Emi>kam.
 \ks
 
 \zr
-\Ch{G}{Zachraňte} koně, \Ch{Hmi}{křičel} jsem tisíc\Ch{C}{krát},
+<G>Zachraňte koně, <Hmi>křičel jsem tisíc<C>krát,
 
-\Ch{G}{žil} jsem jen pro ně, \Ch{Hmi}{bránil} je nejvíc\Ch{C}{krát},
+<G>žil jsem jen pro ně, <Hmi>bránil je nejvíc<C>krát,
 
-než přišla \Ch{Ami}{chvíle}, kdy hřívy \Ch{C}{bílé}
+než přišla <Ami>chvíle, kdy hřívy <C>bílé
 
-pročesal \Ch{Ami}{plamen}, spálil na \Ch{H7}{troud}.
+pročesal <Ami>plamen, spálil na <H7>troud.
 \kr
 
 

--- a/tp-songs/01_folk/Karel_Kryl____Anděl.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Anděl.tex
@@ -3,26 +3,26 @@
 \zp{Anděl}{Karel Kryl}
 
 \zs
-Z \Ch{G}{rozmláce}\Ch{Emi}{nýho} kostela
-v \Ch{G}{krabici} s \Ch{D7}{kusem} mýdla
+Z <G>rozmláce<Emi>nýho kostela
+v <G>krabici s <D7>kusem mýdla
 
-\Ch{G}{přinesl} \Ch{Emi}{jsem} si anděla,
-\Ch{G}{polámali} \Ch{D7}{mu} křídla. \Ch{G}{}
+<G>přinesl <Emi>jsem si anděla,
+<G>polámali <D7>mu křídla. <G>
 
-\Ch{G}{Díval} se \Ch{Emi}{na mě} oddaně,
-\Ch{G}{já} měl jsem \Ch{D7}{trochu} trému,
+<G>Díval se <Emi>na mě oddaně,
+<G>já měl jsem <D7>trochu trému,
 
-\Ch{G}{tak} vtiskl \Ch{Emi}{jsem} mu do dlaně 
-\Ch{G}{lahvičku} \Ch{D7}{od} parfému. \Ch{G}{}
+<G>tak vtiskl <Emi>jsem mu do dlaně 
+<G>lahvičku <D7>od parfému. <G>
 \ks
 \zr
-\Ch{G}{A pr}oto \Ch{Emi}{prosím,} věř mi,
-\Ch{G}{chtěl} jsem ho \Ch{D7}{žádat,}
+<G>A proto <Emi>prosím, věř mi,
+<G>chtěl jsem ho <D7>žádat,
 
-\Ch{G}{aby} mi \Ch{Emi}{mezi} dveřmi
-\Ch{G}{pomohl} \Ch{D7}{hádat,}
+<G>aby mi <Emi>mezi dveřmi
+<G>pomohl <D7>hádat,
 
-/: \Ch{G}{co} mě čeká \Ch{Emi}{} \Ch{D7}{a nemi}\Ch{G}{ne.} :/
+/: <G>co mě čeká <Emi> <D7>a nemi<G>ne. :/
 \kr
 \zs
 Pak hlídali jsme oblohu, pozorujíce ptáky,

--- a/tp-songs/01_folk/Karel_Kryl____Bratříčku_zavírej_vrátka.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Bratříčku_zavírej_vrátka.tex
@@ -3,11 +3,11 @@
 \zp{Bratříčku, zavírej vrátka}{Karel Kryl}
 
 \zs
-\Ch{Emi}{Bratříčku,} nevzlykej, to nejsou \Ch{G}{bubáci,}
+<Emi>Bratříčku, nevzlykej, to nejsou <G>bubáci,
 
-\Ch{D}{vždyť} už jsi velikej, to jsou jen \Ch{H7}{vojáci,}
+<D>vždyť už jsi velikej, to jsou jen <H7>vojáci,
 
-\Ch{C}{přijeli} v hranatých železných maringot\Ch{H7}{kách.}
+<C>přijeli v hranatých železných maringot<H7>kách.
 
 Se slzou na víčku hledíme na sebe:
 
@@ -17,13 +17,13 @@ na cestách klikatých, bratříčku v polobotkách.}
 \ks
 
 \zr
-\Ch{Emi}{Prší} \Ch{Hmi}{a} \Ch{Emi}{venku} \Ch{Hmi}{se} \Ch{Emi}{setmě}\Ch{Hmi}{lo,} \Ch{Emi}{} \Ch{Hmi}{}
+<Emi>Prší <Hmi>a <Emi>venku <Hmi>se <Emi>setmě<Hmi>lo, <Emi> <Hmi>
 
-\Ch{Emi}{tato} \Ch{Hmi}{noc} \Ch{Emi}{nebu}\Ch{Hmi}{de} \Ch{Emi}{krát}\Ch{Hmi}{ká,} \Ch{Emi}{} \Ch{Hmi}{}
+<Emi>tato <Hmi>noc <Emi>nebu<Hmi>de <Emi>krát<Hmi>ká, <Emi> <Hmi>
 
-\Ch{Emi}{berán}\Ch{Hmi}{ka} \Ch{C}{vlku se} \Ch{Emi}{zachtělo} --
+<Emi>berán<Hmi>ka <C>vlku se <Emi>zachtělo --
 
-\Ch{C}{bratříč}\Ch{Emi}{ku,} (Rec:) zavřel jsi \Ch{H7}{vrátka?}
+<C>bratříč<Emi>ku, (Rec:) zavřel jsi <H7>vrátka?
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Divný_kníže.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Divný_kníže.tex
@@ -3,13 +3,13 @@
 \zp{Divný kníže}{Karel Kryl}
 
 \zs
-\Ch{Ami}{Jel krajem divný} \Ch{C}{kníže,} \Ch{Ami}{} a \Ch{G}{chrpy povad}\Ch{Ami}{ly,}
+<Ami>Jel krajem divný <C>kníže, <Ami> a <G>chrpy povad<Ami>ly,
 
-když z prstů koval \Ch{C}{mříže} \Ch{Ami}{a z paží zábrad}\Ch{E}{lí,}
+když z prstů koval <C>mříže <Ami>a z paží zábrad<E>lí,
 
-/: on z \Ch{Ami}{vlasů pletl} \Ch{G}{dráty,} měl \Ch{Ami}{kasematy} z \Ch{G}{dlaní} \Ch{F}{} \Ch{Emi}{}
+/: on z <Ami>vlasů pletl <G>dráty, měl <Ami>kasematy z <G>dlaní <F> <Emi>
 
-\Ch{Ami}{a hadry za bro}\Ch{G}{káty,} \Ch{Ami}{} zlá \Ch{Emi}{slova místo} \Ch{Ami}{zbraní.} :/
+<Ami>a hadry za bro<G>káty, <Ami> zlá <Emi>slova místo <Ami>zbraní. :/
 \ks
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Habet.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Habet.tex
@@ -3,23 +3,23 @@
 \zp{Habet}{Karel Kryl}
 
 \zs
-\Ch{Emi}{Dvě hvězdy} v Malém voze \Ch{D}{svítí ještě} \Ch{Emi}{zrána,}
+<Emi>Dvě hvězdy v Malém voze <D>svítí ještě <Emi>zrána,
 
-\Ch{G}{vidí,} jak po obloze \Ch{D}{přeletěla} \Ch{G}{vrána,}
+<G>vidí, jak po obloze <D>přeletěla <G>vrána,
 
-\Ch{D}{rybáři} vstávají a \Ch{Emi}{rozhazují} \Ch{Hmi}{sítě}
+<D>rybáři vstávají a <Emi>rozhazují <Hmi>sítě
 
-\Ch{Emi}{a hvězdy} \Ch{D}{zpívají,} když \Ch{Emi}{narodí se} \Ch{D}{dí}\Ch{Emi}{tě.}
+<Emi>a hvězdy <D>zpívají, když <Emi>narodí se <D>dí<Emi>tě.
 \ks
 
 \zr
-\uv{\Ch{Emi}{Ave}} \Ch{G}{padalo} z \Ch{D}{nebe jako mana,}
+\uv{<Emi>Ave} <G>padalo z <D>nebe jako mana,
 
-\uv{Ave,} znělo to \Ch{Emi}{trochu jako} \Ch{H7}{hrana,}
+\uv{Ave,} znělo to <Emi>trochu jako <H7>hrana,
 
-\uv{\Ch{Emi}{Ave,}} \Ch{G}{to značí} \uv{\Ch{D}{vítejte,} vy \Ch{H7}{mladí,}}
+\uv{<Emi>Ave,} <G>to značí \uv{<D>vítejte, vy <H7>mladí,}
 
-\Ch{Emi}{a ruce hladí,} \Ch{Hmi}{a ruce} \Ch{Emi}{hladí.}
+<Emi>a ruce hladí, <Hmi>a ruce <Emi>hladí.
 
 Ave, la la la..., Ave, la la la...,
 

--- a/tp-songs/01_folk/Karel_Kryl____Hle_jak_se_perou.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Hle_jak_se_perou.tex
@@ -2,26 +2,26 @@
 
 \zp{Hle, jak se perou}{Karel Kryl}
 
-\Ch{Emi}{} \Ch{D}{} \Ch{Emi}{} \Ch{H7}{} \Ch{Emi}{}
+<Emi> <D> <Emi> <H7> <Emi>
 
 \zs
-Tak \Ch{Emi}{hle, jak se} \Ch{D}{perou, jen} \Ch{Emi}{pohleďte} \Ch{D}{na ně,}
+Tak <Emi>hle, jak se <D>perou, jen <Emi>pohleďte <D>na ně,
 
-jak \Ch{Emi}{úplatky} \Ch{D}{berou} a \Ch{G}{svrbí} je \Ch{Ami}{dlaně,}
+jak <Emi>úplatky <D>berou a <G>svrbí je <Ami>dlaně,
 
-tak \Ch{Emi}{pohleďte} \Ch{C}{na ně,} jak \Ch{D}{zatančí} \Ch{Emi}{tance,}
+tak <Emi>pohleďte <C>na ně, jak <D>zatančí <Emi>tance,
 
-když \Ch{D}{namísto} \Ch{Emi}{daně jim} \Ch{H7}{dají kus} \Ch{Emi}{žvance.}
+když <D>namísto <Emi>daně jim <H7>dají kus <Emi>žvance.
 \ks
 
 \zr
-\Ch{C}{Pít,} \Ch{D}{klít,} \Ch{G}{rouhat} se \Ch{Emi}{víře,}
+<C>Pít, <D>klít, <G>rouhat se <Emi>víře,
 
-\Ch{G}{pak} sedět v \Ch{Emi}{díře} \Ch{D}{nějaký} \Ch{Emi}{rok,}
+<G>pak sedět v <Emi>díře <D>nějaký <Emi>rok,
 
-\Ch{C}{klít,} \Ch{D}{pít,} \Ch{G}{co hrdlo} \Ch{Emi}{ráčí,}
+<C>klít, <D>pít, <G>co hrdlo <Emi>ráčí,
 
-\Ch{G}{vždyť osud} \Ch{Emi}{stáčí už} \Ch{D}{poslední} \Ch{Emi}{lok.}
+<G>vždyť osud <Emi>stáčí už <D>poslední <Emi>lok.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Karavana_mraků.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Karavana_mraků.tex
@@ -3,23 +3,23 @@
 \zp{Karavana mraků}{Karel Kryl}
 
 \zs
-\Ch{D}{Slunce je} zlatou skobou \Ch{Hmi}{na vobloze} přibitý,
+<D>Slunce je zlatou skobou <Hmi>na vobloze přibitý,
 
-\Ch{G}{pod sluncem} \Ch{A}{sedlo kože}\Ch{D}{ný,} \Ch{A7}{}
+<G>pod sluncem <A>sedlo kože<D>ný, <A7>
 
-\Ch{D}{pod sedlem} kůň, pod koněm \Ch{Hmi}{moje boty rozbitý}
+<D>pod sedlem kůň, pod koněm <Hmi>moje boty rozbitý
 
-\Ch{G}{a starý} \Ch{A}{ruce sedře}\Ch{D}{ný.}
+<G>a starý <A>ruce sedře<D>ný.
 \ks
 
 \zr
-\Ch{D7}{Dopředu} \Ch{G}{jít} s tou \Ch{A}{karavanou} \Ch{Hmi}{mraků,}
+<D7>Dopředu <G>jít s tou <A>karavanou <Hmi>mraků,
 
-schovat svou \Ch{G}{pleš} pod \Ch{A}{stetson} děra\Ch{Hmi}{vý,}
+schovat svou <G>pleš pod <A>stetson děra<Hmi>vý,
 
-/: jen kousek \Ch{Emi}{jít, jen} \Ch{A7}{chvíli,} \Ch{Hmi}{do soumra}\Ch{Emi}{ku,}
+/: jen kousek <Emi>jít, jen <A7>chvíli, <Hmi>do soumra<Emi>ku,
 
-až tam, kde \Ch{Hmi}{svítí město,} \Ch{F#}{město běla}\Ch{Hmi}{vý.} :/ \Ch{A7}{}
+až tam, kde <Hmi>svítí město, <F#>město běla<Hmi>vý. :/ <A7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Král_a_klaun.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Král_a_klaun.tex
@@ -2,27 +2,27 @@
 
 \zp{Král a klaun}{Karel Kryl}
 
-\Ch{G}{} \Ch{C}{} \Ch{G}{} \Ch{C}{} \Ch{G}{} \Ch{C}{} \Ch{D}{}
+<G> <C> <G> <C> <G> <C> <D>
 
 
 \zs
-\Ch{D}{Král} \Ch{C}{do boje} \Ch{G}{táh',} \Ch{C}{} \Ch{G}{do} \Ch{C}{veliké} \Ch{G}{dálky,} \Ch{C}{}
+<D>Král <C>do boje <G>táh', <C> <G>do <C>veliké <G>dálky, <C>
 
-a s ním do té \Ch{G}{války} \Ch{D7}{jel na mezku} \Ch{G}{klaun.}
+a s ním do té <G>války <D7>jel na mezku <G>klaun.
 
-\Ch{D}{Než} \Ch{C}{hledí si} \Ch{G}{stáh',} \Ch{C}{} \Ch{G}{tak} z \Ch{C}{výrazu} \Ch{G}{tváře} \Ch{C}{}
+<D>Než <C>hledí si <G>stáh', <C> <G>tak z <C>výrazu <G>tváře <C>
 
-bys nepoznal \Ch{G}{lháře,} \Ch{D7}{co zakrývá} \Ch{G}{strach.}
+bys nepoznal <G>lháře, <D7>co zakrývá <G>strach.
 \ks
 
 \zr
-\Ch{D7}{Tiše šeptal při té hrůze:} \uv{\Ch{G}{Inter} arma silent Musæ,}
+<D7>Tiše šeptal při té hrůze: \uv{<G>Inter arma silent Musæ,}
 
-\Ch{A}{místo zvonku cinkal brně}\Ch{D7}{ním.} \Ch{C#7}{} \Ch{D7}{}
+<A>místo zvonku cinkal brně<D7>ním. <C#7> <D7>
 
-Král \Ch{C}{do boje} \Ch{G}{táh',} \Ch{C}{} \Ch{G}{do} \Ch{C}{veliké} \Ch{G}{dálky,} \Ch{C}{}
+Král <C>do boje <G>táh', <C> <G>do <C>veliké <G>dálky, <C>
 
-a s ním do té \Ch{G}{války} \Ch{D7}{jel na mezku} \Ch{G}{klaun.} \Ch{H}{} \Ch{C}{} \Ch{G}{} \Ch{A7}{}
+a s ním do té <G>války <D7>jel na mezku <G>klaun. <H> <C> <G> <A7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Lilie.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Lilie.tex
@@ -3,20 +3,20 @@
 \zp{Lilie}{Karel Kryl}
 
 \zs
-\Ch{Ami}{Než zavřel bránu,} oděl se do oceli \Ch{F}{} \Ch{E}{} a zhasil \Ch{Ami}{svíci.} \Ch{E}{}
+<Ami>Než zavřel bránu, oděl se do oceli <F> <E> a zhasil <Ami>svíci. <E>
 
-\Ch{Ami}{bylo už k ránu,} políbil na posteli \Ch{F}{} \Ch{E}{} svou ženu \Ch{Ami}{spící.} \Ch{G}{}
+<Ami>bylo už k ránu, políbil na posteli <F> <E> svou ženu <Ami>spící. <G>
 
-/: \Ch{C}{Spala jak víla,} \Ch{G}{jen vlasy halily ji,}
+/: <C>Spala jak víla, <G>jen vlasy halily ji,
 
-\Ch{Ami}{jak zlatá žíla,} \Ch{F}{jak jitra} v \Ch{E}{Kastilii,}
+<Ami>jak zlatá žíla, <F>jak jitra v <E>Kastilii,
 
-\Ch{Ami}{něžná a bílá,} jak rosa na lilii,
+<Ami>něžná a bílá, jak rosa na lilii,
 
-\Ch{F}{} \Ch{E}{} jak luna \Ch{Ami}{bdící.} :/
+<F> <E> jak luna <Ami>bdící. :/
 \ks
 
-\Ch{Ami}{} \Ch{F}{} \Ch{E}{} \Ch{Ami}{} \Ch{F}{} \Ch{E}{}
+<Ami> <F> <E> <Ami> <F> <E>
 
 \zs
 Jen mraky šedé a ohně na pahorcích -- svědkové němí,
@@ -28,7 +28,7 @@ lilie bledé svítily na praporcích, když táhli zemí.
 a krev se leskne, když padla na lilie kapkami třemi. :/
 \ks
 
-\Ch{Ami}{} \Ch{F}{} \Ch{E}{} \Ch{Ami}{} \Ch{F}{} \Ch{E}{}
+<Ami> <F> <E> <Ami> <F> <E>
 
 \zs
 Dozrály trnky, zvon zvoní na neděli a čas se vleče.
@@ -40,6 +40,6 @@ Rezavé skvrnky zůstaly na čepeli u jílce meče.
 lilie bílé s rudými krůpějemi trhají vkleče. :/
 \ks
 
-\Ch{Ami}{} \Ch{F}{} \Ch{E}{} \Ch{Ami}{} \Ch{F}{} \Ch{E}{}
+<Ami> <F> <E> <Ami> <F> <E>
 
 \kp

--- a/tp-songs/01_folk/Karel_Kryl____Lásko.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Lásko.tex
@@ -3,27 +3,27 @@
 \zp{Lásko}{Karel Kryl}
 
 \zs
-\Ch{Ami}{Pár} zbytků pro krysy na misce od guláše,
+<Ami>Pár zbytků pro krysy na misce od guláše,
 
-\Ch{E}{milostný} dopisy s parti\Ch{Dmi}{í} \Ch{E}{mariáše,}
+<E>milostný dopisy s parti<Dmi>í <E>mariáše,
 
-\Ch{Dmi}{před} cestou dalekou zpocený boty zujem
+<Dmi>před cestou dalekou zpocený boty zujem
 
-\Ch{C}{a} potom pod dekou \Ch{E}{sníme}, když onanujem.
+<C>a potom pod dekou <E>sníme, když onanujem.
 \ks
 
 \zr
-\Ch{Ami}{Lásko}, \Ch{G}{zavři} se do pokoje,
+<Ami>Lásko, <G>zavři se do pokoje,
 
-\Ch{Ami}{lásko}, \Ch{G}{válka} je holka moje,
+<Ami>lásko, <G>válka je holka moje,
 
-s \Ch{C}{ní} se \Ch{G}{milu}\Ch{Ami}{ji, kd}yž \Ch{G}{noci} si \Ch{Ami}{krátím.} \Ch{E}{}
+s <C>ní se <G>milu<Ami>ji, když <G>noci si <Ami>krátím. <E>
 
-\Ch{Ami}{Lásko}, \Ch{G}{slunce} máš na vějíři,
+<Ami>Lásko, <G>slunce máš na vějíři,
 
-\Ch{Ami}{lásko}, \Ch{G}{dvě} třešně na talíři,
+<Ami>lásko, <G>dvě třešně na talíři,
 
-\Ch{C}{ty} ti \Ch{G}{daru}\Ch{Ami}{ji, až} \Ch{Emi}{jednou} se \Ch{Ami}{vrátím.}\Ch{E}{}
+<C>ty ti <G>daru<Ami>ji, až <Emi>jednou se <Ami>vrátím.<E>
 \kr
 
 \zs
@@ -36,7 +36,7 @@ v opasku u boku nabitou parabelu,
 zpíváme do kroku pár metrů od bordelu.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Pár zbytků pro krysy a taška na patrony,
@@ -48,11 +48,11 @@ není čas na spaní, smrtka nám drtí palce,
 nežli se zchlastaní svalíme na kavalce.
 \ks
 
-\zr  \kr
+\zr \kr
 
-Rec: \Ch{E}{Levá}, dva!
+Rec: <E>Levá, dva!
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Karel_Kryl____Morituri_te_salutant.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Morituri_te_salutant.tex
@@ -3,13 +3,13 @@
 \zp{Morituri te salutant}{Karel Kryl}
 
 \zs
-Cesta je \Ch{Ami}{prach} a \Ch{G}{šterk} a \Ch{Dmi}{udu}saná \Ch{Ami}{hlína}
+Cesta je <Ami>prach a <G>šterk a <Dmi>udusaná <Ami>hlína
 
-\Ch{C}{a} šedé \Ch{F}{šmouhy} \Ch{G7}{kreslí} do vla\Ch{C}{sů}
+<C>a šedé <F>šmouhy <G7>kreslí do vla<C>sů
 
-/: a z hvězdných \Ch{Dmi}{drah} má \Ch{G}{šperk,} co \Ch{C}{kamením} se \Ch{E}{spíná,}
+/: a z hvězdných <Dmi>drah má <G>šperk, co <C>kamením se <E>spíná,
 
-\Ch{Ami}{a pírka} \Ch{G}{touhy} z \Ch{Emi}{křídel} pega\Ch{Ami}{sů.} :/
+<Ami>a pírka <G>touhy z <Emi>křídel pega<Ami>sů. :/
 \ks
 
 \zs
@@ -21,17 +21,17 @@ dvě křehké snítky rudých gladiol. :/
 \ks
 
 \zr
-Seržante, \Ch{G}{písek} je bílý jak paže Daniely.
+Seržante, <G>písek je bílý jak paže Daniely.
 
-\Ch{Ami}{Počkejte} chvíli, mé oči uviděly
+<Ami>Počkejte chvíli, mé oči uviděly
 
-\Ch{G7}{tu} strašně dávnou vteřinu zapomnění...
+<G7>tu strašně dávnou vteřinu zapomnění...
 
-\Ch{Ami}{Seržante}, mávnou \Ch{G7}{a bu}dem zasvěceni!
+<Ami>Seržante, mávnou <G7>a budem zasvěceni!
 
-\Ch{C}{Morituri} te salutant!
+<C>Morituri te salutant!
 
-\Ch{E}{Mori}turi te salutant!
+<E>Morituri te salutant!
 \kr
 
 \zr
@@ -50,6 +50,6 @@ mosazná včelka od vlkodlaka,
 a děsně velká bílá oblaka. :/
 \kr
 
-\zr   \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Karel_Kryl____Nevidomá_dívka.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Nevidomá_dívka.tex
@@ -3,13 +3,13 @@
 \zp{Nevidomá dívka}{Karel Kryl}
 
 \zs
-V \Ch{C}{zahradě} \Ch{Dmi}{za cihlovou} \Ch{C}{zídkou,} \Ch{Dmi}{}
+V <C>zahradě <Dmi>za cihlovou <C>zídkou, <Dmi>
 
-\Ch{C}{popsanou} v \Ch{Dmi}{slavných výro}\Ch{C}{čích,} \Ch{Dmi}{}
+<C>popsanou v <Dmi>slavných výro<C>čích, <Dmi>
 
-\Ch{C}{sedává} \Ch{Dmi}{na podzim} \Ch{E}{na trávě} \Ch{Ami}{před besídkou}
+<C>sedává <Dmi>na podzim <E>na trávě <Ami>před besídkou
 
-\Ch{F}{děvčátko} s \Ch{G}{páskou} na o\Ch{E}{čích.}
+<F>děvčátko s <G>páskou na o<E>čích.
 \ks
 
 \zs
@@ -19,15 +19,15 @@ pak pošle polibek po chmýří na bodláku na vymyšlenou adresu.
 \ks
 
 \zr
-Prosím vás, \Ch{Ami}{nechte ji,} ach, \Ch{Dmi}{nechte ji,}
+Prosím vás, <Ami>nechte ji, ach, <Dmi>nechte ji,
 
-\Ch{Ami}{tu nevidomou} \Ch{G}{dívku,}
+<Ami>tu nevidomou <G>dívku,
 
-\Ch{Dmi}{prosím vás,} \Ch{G}{nechte ji si} \Ch{E}{hrát,}
+<Dmi>prosím vás, <G>nechte ji si <E>hrát,
 
-\Ch{Dmi}{vždyť možná} hraje si \Ch{Ami}{na slunce} s nebesy,
+<Dmi>vždyť možná hraje si <Ami>na slunce s nebesy,
 
-\Ch{F}{jež nikdy} neuvidí, \Ch{G}{ač} ji bude \Ch{E}{hřát.}
+<F>jež nikdy neuvidí, <G>ač ji bude <E>hřát.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Píseň_neznámého_vojína.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Píseň_neznámého_vojína.tex
@@ -5,23 +5,23 @@
 Rec: Zpráva z tisku: \uv{Obě delegace položily pak věnce na hrob Neznámého vojína.} A co na to Neznámý vojín?
 
 \zs
-V \Ch{Ami}{čele} klaka, pak ctnostné rodiny a náruč chryzan\Ch{E7}{tém},
+V <Ami>čele klaka, pak ctnostné rodiny a náruč chryzan<E7>tém,
 
-černá saka a žena hrdiny pod paží s aman\Ch{Ami}{tem},\Ch{E7}{}
+černá saka a žena hrdiny pod paží s aman<Ami>tem,<E7>
 
-\Ch{Ami}{kytky} v dlaních a pásky smuteční civí tu před \Ch{E7}{branou},
+<Ami>kytky v dlaních a pásky smuteční civí tu před <E7>branou,
 
-ulpěl na nich pach síně taneční s bolestí sehra\Ch{Ami}{nou}.
+ulpěl na nich pach síně taneční s bolestí sehra<Ami>nou.
 \ks
 
 \zr
-Co tady \Ch{F}{čumíte}? Vlezte mi \Ch{G}{někam}!
+Co tady <F>čumíte? Vlezte mi <G>někam!
 
-Copak si \Ch{Ami}{myslíte}, že na to \Ch{G}{čekám}?
+Copak si <Ami>myslíte, že na to <G>čekám?
 
-Co tady \Ch{Ami}{civíte}? Táhněte \Ch{G7}{domů}!
+Co tady <Ami>civíte? Táhněte <G7>domů!
 
-\Ch{Ami}{Pomníky} stavíte, \Ch{F}{prosím} vás, \Ch{E7}{komu}? \Ch{Ami}{} \Ch{E}{}
+<Ami>Pomníky stavíte, <F>prosím vás, <E7>komu? <Ami> <E>
 \kr
 
 \zs
@@ -59,9 +59,9 @@ Kolik vám platějí za tenhle nápad?
 
 Táhněte raději s děvkama chrápat!
 
-Co mi to \Ch{Ami}{říkáte}? Že šel bych \Ch{G}{zas}? \Ch{G7}{Rád}?
+Co mi to <Ami>říkáte? Že šel bych <G>zas? <G7>Rád?
 
-\Ch{Ami}{Odpověď} čekáte? \Ch{F}{Nasrat}, jo, \Ch{E}{nasrat}! \Ch{Ami}{} \Ch{Ami6}{}
+<Ami>Odpověď čekáte? <F>Nasrat, jo, <E>nasrat! <Ami> <Ami6>
 \kr
 
 \kp

--- a/tp-songs/01_folk/Karel_Kryl____Salome.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Salome.tex
@@ -3,37 +3,37 @@
 \zp{Salome}{Karel Kryl}
 
 \zs
-\Ch{Ami}{Něžná i proradná,} \Ch{C}{krutá i bezradná,}
+<Ami>Něžná i proradná, <C>krutá i bezradná,
 
-\Ch{G}{plamen i červánek,} ďábel i beránek,
+<G>plamen i červánek, ďábel i beránek,
 
-\Ch{E}{cukr i sůl.}
+<E>cukr i sůl.
 
-\Ch{Ami}{U vůně hřebíčku,} \Ch{C}{u rytmu střevíčků}
+<Ami>U vůně hřebíčku, <C>u rytmu střevíčků
 
-\Ch{G}{císař dnes myslí byl,} za tanec přislíbil
+<G>císař dnes myslí byl, za tanec přislíbil
 
-\Ch{E}{království půl.}
+<E>království půl.
 \ks
 
 \zr
-\Ch{Ami}{Salo}\Ch{E}{me,} \Ch{Ami}{noc už je na sklonku,}
+<Ami>Salo<E>me, <Ami>noc už je na sklonku,
 
-\Ch{C}{Salome,} podobna's úponku,
+<C>Salome, podobna's úponku,
 
-\Ch{G}{podobna} kytaře pro svého vladaře,
+<G>podobna kytaře pro svého vladaře,
 
-\Ch{E}{Salome,} tančíš.
+<E>Salome, tančíš.
 
-\Ch{Ami}{Salo}\Ch{E}{me,} \Ch{Ami}{sťali už Křtitele,}
+<Ami>Salo<E>me, <Ami>sťali už Křtitele,
 
-\Ch{C}{Salome,} zasměj se vesele,
+<C>Salome, zasměj se vesele,
 
-\Ch{G}{točíš} se ve víru, ústa jak upíru
+<G>točíš se ve víru, ústa jak upíru
 
-\Ch{E}{krví ti planou.}
+<E>krví ti planou.
 
-Salome, la la \Ch{Ami}{} \Ch{C}{} \Ch{F}{} \Ch{E}{} \Ch{Ami}{} \Ch{C}{} \Ch{E}{}
+Salome, la la <Ami> <C> <F> <E> <Ami> <C> <E>
 \kr
 
 \zs
@@ -51,7 +51,7 @@ Salome, trochu jsi pobledla, Salome, v koutku jsi usedla.
 
 Víčka máš šedivá, nikdo se nedívá, Salome, pláčeš?
 
-La la... \Ch{Ami}{} \Ch{E}{} \Ch{Ami}{}
+La la... <Ami> <E> <Ami>
 \kr
 
 \kp

--- a/tp-songs/01_folk/Karel_Kryl____Veličenstvo_kat.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Veličenstvo_kat.tex
@@ -2,14 +2,14 @@
 
 \zp{Veličenstvo Kat}{Karel Kryl}
 
-\Ch{Ami}{}	\Ch{G}{}	\Ch{Ami}{}	\Ch{E7}{}
+<Ami>	<G>	<Ami>	<E7>
 
 \zs
-\Ch{Ami}{V ponurém} osvětlení \Ch{G}{gotického} \Ch{Ami}{sálu}
-\Ch{C}{kupčíci} vyděšení \Ch{Dmi}{hledí} do mi\Ch{E}{sálů}
+<Ami>V ponurém osvětlení <G>gotického <Ami>sálu
+<C>kupčíci vyděšení <Dmi>hledí do mi<E>sálů
 
-\Ch{Ami}{a hou}fec \Ch{F}{mordýřů} si \Ch{G}{žádá pože}\Ch{C}{hná}\Ch{G}{ní,}
-/: \Ch{Dmi}{vždyť} první z \Ch{Ami}{rytířů} je \Ch{E7}{Veličenstvo} \Ch{Ami}{Kat.} :/
+<Ami>a houfec <F>mordýřů si <G>žádá pože<C>hná<G>ní,
+/: <Dmi>vždyť první z <Ami>rytířů je <E7>Veličenstvo <Ami>Kat. :/
 \ks
 
 \zs
@@ -21,11 +21,11 @@ pach síry z hmoždířů se valí k rudé kápi
 \ks
 
 \zr
-\Ch{C}{Na} korouhvi \Ch{G}{státu} \Ch{F}{je} emblém s \Ch{G7}{gilo}tinou,
-z \Ch{C}{ostnatého} \Ch{G}{drátu} \Ch{F}{páchne} to \Ch{G}{shnilotinou,}
+<C>Na korouhvi <G>státu <F>je emblém s <G7>gilotinou,
+z <C>ostnatého <G>drátu <F>páchne to <G>shnilotinou,
 
-v \Ch{Dmi}{kraji} hnízdí hejno krkav\Ch{Ami}{čí,}
-\Ch{Dmi}{lidu} vládne mistr poprav\Ch{E}{čí.}\Ch{E7}{}
+v <Dmi>kraji hnízdí hejno krkav<Ami>čí,
+<Dmi>lidu vládne mistr poprav<E>čí.<E7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Veličenstvo_kat____2pages.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Veličenstvo_kat____2pages.tex
@@ -2,16 +2,16 @@
 
 \zp{Veličenstvo Kat}{Karel Kryl}
 
-\Ch{Ami}{}	\Ch{G}{}	\Ch{Ami}{}	\Ch{E7}{}
+<Ami>	<G>	<Ami>	<E7>
 
 \zs
-\Ch{Ami}{V ponurém} osvětlení \Ch{G}{gotického} \Ch{Ami}{sálu}
+<Ami>V ponurém osvětlení <G>gotického <Ami>sálu
 
-\Ch{C}{kupčíci} vyděšení \Ch{Dmi}{hledí} do mi\Ch{E}{sálů}
+<C>kupčíci vyděšení <Dmi>hledí do mi<E>sálů
 
-\Ch{Ami}{a hou}fec \Ch{F}{mordýřů} si \Ch{G}{žádá pože}\Ch{C}{hná}\Ch{G}{ní,}
+<Ami>a houfec <F>mordýřů si <G>žádá pože<C>hná<G>ní,
 
-/: \Ch{Dmi}{vždyť} první z \Ch{Ami}{rytířů} je \Ch{E7}{Veličenstvo} \Ch{Ami}{Kat.} :/
+/: <Dmi>vždyť první z <Ami>rytířů je <E7>Veličenstvo <Ami>Kat. :/
 \ks
 
 \zs
@@ -25,13 +25,13 @@ pach síry z hmoždířů se valí k rudé kápi
 \ks
 
 \zr
-\Ch{C}{Na} korouhvi \Ch{G}{státu} \Ch{F}{je} emblém s \Ch{G7}{gilo}tinou,
+<C>Na korouhvi <G>státu <F>je emblém s <G7>gilotinou,
 
-z \Ch{C}{ostnatého} \Ch{G}{drátu} \Ch{F}{páchne} to \Ch{G}{shnilotinou,}
+z <C>ostnatého <G>drátu <F>páchne to <G>shnilotinou,
 
-v \Ch{Dmi}{kraji} hnízdí hejno krkav\Ch{Ami}{čí,}
+v <Dmi>kraji hnízdí hejno krkav<Ami>čí,
 
-\Ch{Dmi}{lidu} vládne mistr poprav\Ch{E}{čí.}\Ch{E7}{}
+<Dmi>lidu vládne mistr poprav<E>čí.<E7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Kryl____Zkouška_dospělosti.tex
+++ b/tp-songs/01_folk/Karel_Kryl____Zkouška_dospělosti.tex
@@ -3,9 +3,9 @@
 \zp{Zkouška dospělosti}{Karel Kryl}
 
 \zs
-V \Ch{Ami}{nedělním} oblečení \Ch{F}{nast}oupíš před komisi,
+V <Ami>nedělním oblečení <F>nastoupíš před komisi,
 
-\Ch{G}{stud}ené vysvědčení \Ch{E}{vez}me, co bylo kdysi.
+<G>studené vysvědčení <E>vezme, co bylo kdysi.
 \ks
 
 \zs
@@ -15,9 +15,9 @@ a lež, co první směnka úvěru pro dospělé.
 \ks
 
 \zr
-\Ch{C}{Opil}í od radosti \Ch{G}{si} sami trochu lžeme,
+<C>Opilí od radosti <G>si sami trochu lžeme,
 
-\Ch{F}{že} zkouškou dospělosti \Ch{E}{opra}vdu dospějeme.
+<F>že zkouškou dospělosti <E>opravdu dospějeme.
 \kr
 
 \zr

--- a/tp-songs/01_folk/Karel_Plíhal____Dvě_spálený_srdce.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Dvě_spálený_srdce.tex
@@ -3,13 +3,13 @@
 \zp{Dvě spálený srdce (Nagasaki, Hirošima)}{Karel Plíhal}
 
 \zs
-\Ch{C}{Tramvají} \Ch{G}{dvojkou} \Ch{F}{jezdíval} jsem \Ch{G}{do Žide}\Ch{C}{nic,} \Ch{G}{} \Ch{F}{} \Ch{G}{}
+<C>Tramvají <G>dvojkou <F>jezdíval jsem <G>do Žide<C>nic, <G> <F> <G>
 
-z \Ch{C}{tak veliký} \Ch{G}{lásky} \Ch{F}{většinou} \Ch{G}{nezbyde} \Ch{Ami}{nic,}
+z <C>tak veliký <G>lásky <F>většinou <G>nezbyde <Ami>nic,
 
-z \Ch{F}{takový} \Ch{C}{lásky} \Ch{F}{jsou kruhy} \Ch{C}{pod oči}\Ch{G}{ma}
+z <F>takový <C>lásky <F>jsou kruhy <C>pod oči<G>ma
 
-a \Ch{C}{dvě spálený} \Ch{G}{srdce} -- \Ch{F}{Nagasaki,} \Ch{G}{Hirošima.} \Ch{C}{} \Ch{G}{} \Ch{F}{} \Ch{G}{}
+a <C>dvě spálený <G>srdce -- <F>Nagasaki, <G>Hirošima. <C> <G> <F> <G>
 \ks
 
 \zs

--- a/tp-songs/01_folk/Karel_Plíhal____Kluziště.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Kluziště.tex
@@ -3,29 +3,29 @@
 \zp{Kluziště}{Karel Plíhal}
 
 \zs
-\Ch{C}{Strejč}ek \Ch{Emi7/H}{kovář} \Ch{Ami7}{chytil} \Ch{C/G}{kleště}, 
-\Ch{Fmaj7}{uštíp'} z \Ch{C}{noční} \Ch{Fmaj7}{oblo-}\Ch{G}{hy}
+<C>Strejček <Emi7/H>kovář <Ami7>chytil <C/G>kleště, 
+<Fmaj7>uštíp' z <C>noční <Fmaj7>oblo-<G>hy
 
-\Ch{C}{jedn}u \Ch{Emi7/H}{malou} \Ch{Ami7}{kapku} \Ch{C/G}{deště,} 
-\Ch{Fmaj7}{ta mu} \Ch{C}{spadla} \Ch{Fmaj7}{pod no}\Ch{G}{hy,}
+<C>jednu <Emi7/H>malou <Ami7>kapku <C/G>deště, 
+<Fmaj7>ta mu <C>spadla <Fmaj7>pod no<G>hy,
 
-\Ch{C}{nejd}řív \Ch{Emi7/H}{ale} \Ch{Ami7}{chytil} \Ch{C/G}{slinu,} 
-\Ch{Fmaj7}{tak šáh'} \Ch{C}{kamsi} \Ch{Fmaj7}{pro pi}\Ch{G}{vo,}
+<C>nejdřív <Emi7/H>ale <Ami7>chytil <C/G>slinu, 
+<Fmaj7>tak šáh' <C>kamsi <Fmaj7>pro pi<G>vo,
 
-\Ch{C}{pak} při\Ch{Emi7/H}{táhl} \Ch{Ami7}{kovad}\Ch{C/G}{linu} \Ch{Fmaj7}{a 
-ob-}\Ch{C}{rovský} \Ch{Fmaj7}{kladi-} \Ch{G}{vo.}
+<C>pak při<Emi7/H>táhl <Ami7>kovad<C/G>linu <Fmaj7>a 
+ob-<C>rovský <Fmaj7>kladi- <G>vo.
 \ks
 
 \zr
-Zatím \Ch{C}{tři} bílé \Ch{Emi7/H}{vrány} \Ch{Ami7}{pěkně za} se\Ch{C/G}{bou}
+Zatím <C>tři bílé <Emi7/H>vrány <Ami7>pěkně za se<C/G>bou
 
-kolem \Ch{Fmaj7}{jdou, ně}kam \Ch{C}{jdou,} do ryt\Ch{D7}{mu se} 
-kýva\Ch{G}{jí,}
+kolem <Fmaj7>jdou, někam <C>jdou, do ryt<D7>mu se 
+kýva<G>jí,
 
-tyhle \Ch{C}{tři b}ílé \Ch{Emi7/H}{vrány} \Ch{Ami7}{pěkně za} se\Ch{C/G}{bou}
+tyhle <C>tři bílé <Emi7/H>vrány <Ami7>pěkně za se<C/G>bou
 
-kolem \Ch{Fmaj7}{jdou, něk}am \Ch{C}{jdou, ne}do\Ch{Fmaj7}{jdou, 
-ned}o\Ch{C}{jdou.}
+kolem <Fmaj7>jdou, někam <C>jdou, nedo<Fmaj7>jdou, 
+nedo<C>jdou.
 \kr
 
 \zs
@@ -49,7 +49,7 @@ kdesi v dálce rozmazaně strejda kovář odchází,
 
 do kalhot si čistí ruce umazané od sazí.
 \ks
-\Ch{C}{} \Ch{Emi7/H}{} \Ch{Ami7}{} \Ch{C/G}{} \Ch{Fmaj7}{} \Ch{C}{} \Ch{D7}{} \Ch{G}{} \Ch{C}{}\Ch{Emi7/H}{} \Ch{Ami7}{} \Ch{C/G}{} \Ch{ Fmaj7}{} \Ch{C}{} \Ch{Fmaj7}{} \Ch{C}{}
+<C> <Emi7/H> <Ami7> <C/G> <Fmaj7> <C> <D7> <G> <C><Emi7/H> <Ami7> <C/G> < Fmaj7> <C> <Fmaj7> <C>
 
 
 \kp

--- a/tp-songs/01_folk/Karel_Plíhal____Kluziště.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Kluziště.tex
@@ -4,7 +4,7 @@
 
 \zs
 <C>Strejček <Emi7/H>kovář <Ami7>chytil <C/G>kleště, 
-<Fmaj7>uštíp' z <C>noční <Fmaj7>oblo-<G>hy
+<Fmaj7>uštíp' z <C>noční <Fmaj7>oblo<G>hy
 
 <C>jednu <Emi7/H>malou <Ami7>kapku <C/G>deště, 
 <Fmaj7>ta mu <C>spadla <Fmaj7>pod no<G>hy,
@@ -13,7 +13,7 @@
 <Fmaj7>tak šáh' <C>kamsi <Fmaj7>pro pi<G>vo,
 
 <C>pak při<Emi7/H>táhl <Ami7>kovad<C/G>linu <Fmaj7>a 
-ob-<C>rovský <Fmaj7>kladi- <G>vo.
+ob<C>rovský <Fmaj7>kladi<G>vo.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Karel_Plíhal____Myš.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Myš.tex
@@ -3,24 +3,24 @@
 \zp{Myš}{Karel Plíhal}
 
 \zr
-\Ch{Fmaj7}{Vrátná} z \Ch{Hmi7}{dívčích} ko\Ch{Cmi7}{lejí} v \Ch{D9}{klidu} 
-dole \Ch{Gmi7}{jí}
+<Fmaj7>Vrátná z <Hmi7>dívčích ko<Cmi7>lejí v <D9>klidu 
+dole <Gmi7>jí
 
-a čte si \Ch{Hmi7}{starej} Mladej \Ch{Gmi7}{svět,} \Ch{C7}{}
+a čte si <Hmi7>starej Mladej <Gmi7>svět, <C7>
 
-a \Ch{Fmaj7}{právě} \Ch{Hmi7}{o pár} pater \Ch{Cmi7}{výš} \Ch{D9}{sedí} velká \Ch{Gmi7}{myš}--
+a <Fmaj7>právě <Hmi7>o pár pater <Cmi7>výš <D9>sedí velká <Gmi7>myš--
 
-u dveří \Ch{C7}{dvě} stě dvacet \Ch{Fmaj7}{pět.}
+u dveří <C7>dvě stě dvacet <Fmaj7>pět.
 \kr
 
 \zs
-\Ch{C}{Jistá} Věra Nováková \Ch{Bmaj7}{šla se pr}ávě \Ch{C}{koupat},
+<C>Jistá Věra Nováková <Bmaj7>šla se právě <C>koupat,
 
-večer chce jít do vinárny \Ch{Bmaj7}{slaný mandle} \Ch{C}{chřoupat},
+večer chce jít do vinárny <Bmaj7>slaný mandle <C>chřoupat,
 
-u kasáren vyzvedne si \Ch{Bmaj7}{desátníka} \Ch{C}{Oldu},
+u kasáren vyzvedne si <Bmaj7>desátníka <C>Oldu,
 
-protože je patnáctýho, \Ch{Bmaj7}{a tudíž} den \Ch{C}{žoldu}. \Ch{C7}{}
+protože je patnáctýho, <Bmaj7>a tudíž den <C>žoldu. <C7>
 \ks
 
 \zr \kr
@@ -35,7 +35,7 @@ Olda bude marně čekat na hysterku Věrku,
 zamčela se s kámoškou na dvěstě dvacet čtverku.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Karel_Plíhal____Nosorožec.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Nosorožec.tex
@@ -3,23 +3,23 @@
 \zp{Nosorožec}{Karel Plíhal}
 
 \zs
-\Ch{Ami}{Přiv}edl jsem domů Božce \Ch{Dmi}{nádhe}rnýho \Ch{Ami}{nosorožce,}
+<Ami>Přivedl jsem domů Božce <Dmi>nádhernýho <Ami>nosorožce,
 
-\Ch{Dmi}{originál} \Ch{Ami}{tlustok}ožce, \Ch{D#dim}{koupil} jsem ho 
-v \Ch{H7}{hospodě}
+<Dmi>originál <Ami>tlustokožce, <D#dim>koupil jsem ho 
+v <H7>hospodě
 
-\Ch{Ami}{za dva} rumy a dvě vodky, \Ch{Dmi}{připadal} mi \Ch{Ami}{velmi} 
+<Ami>za dva rumy a dvě vodky, <Dmi>připadal mi <Ami>velmi 
 krotký,
 
-\Ch{Dmi}{pošlapal} mi \Ch{Ami}{polob}otky, \Ch{H7}{ale} jinak v \Ch{Ami}{pohodě.}
+<Dmi>pošlapal mi <Ami>polobotky, <H7>ale jinak v <Ami>pohodě.
 
-\Ch{Dmi}{Vznik}ly menší \Ch{Ami}{potí}že \Ch{H7}{při} nástupu \Ch{Ami}{do zd}viže,
+<Dmi>Vznikly menší <Ami>potíže <H7>při nástupu <Ami>do zdviže,
 
-\Ch{Dmi}{při výs}tupu \Ch{Ami}{ze zd}viže \Ch{D#dim}{už nám} to šlo \Ch{H7}{lehce.}
+<Dmi>při výstupu <Ami>ze zdviže <D#dim>už nám to šlo <H7>lehce.
 
-\Ch{Ami}{Vznikly} větší potíže, \Ch{Dmi}{když} Božena v \Ch{Ami}{negližé,}
+<Ami>Vznikly větší potíže, <Dmi>když Božena v <Ami>negližé,
 
-\Ch{Dmi}{když Božena} v \Ch{Ami}{negližé} \Ch{E7}{řvala, že ho} \Ch{Ami}{nechce.}
+<Dmi>když Božena v <Ami>negližé <E7>řvala, že ho <Ami>nechce.
 \ks
 
 \zs
@@ -41,9 +41,9 @@ a zamčela a trucuje, tak si to taky slízli.
 \ks
 
 \zs
-\Ch{Ami}{Tak tu} sedím se sousedem, s \Ch{Dmi}{nosor}ožcem \Ch{Ami}{a s medv}ědem,
+<Ami>Tak tu sedím se sousedem, s <Dmi>nosorožcem <Ami>a s medvědem,
 
-\Ch{Dmi}{nadáv}áme \Ch{Ami}{jako} jeden \Ch{H7}{na ty} naše \Ch{Ami}{slepice.}
+<Dmi>nadáváme <Ami>jako jeden <H7>na ty naše <Ami>slepice.
 \ks
 
 \kp

--- a/tp-songs/01_folk/Karel_Plíhal____Námořnická.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Námořnická.tex
@@ -3,24 +3,24 @@
 \zp{Námořnická}{Karel Plíhal}
 
 \zs
-\Ch{D}{Mal}ičký námořník v \Ch{G}{krabi}čce od mýdla
+<D>Maličký námořník v <G>krabičce od mýdla
 
-\Ch{D}{vydal} se \Ch{A7}{např}íč \Ch{D}{vanou,}
+<D>vydal se <A7>napříč <D>vanou,
 
-bez mapy, buzoly, \Ch{G}{vese}l a kormidla
+bez mapy, buzoly, <G>vesel a kormidla
 
-\Ch{D}{pluje} za \Ch{A7}{krásnou} Jan\Ch{D}{ou.}
+<D>pluje za <A7>krásnou Jan<D>ou.
 \ks
 
 \zr
-\Ch{F#mi7}{Za modrým} \Ch{Hmi7}{obzorem}
-\Ch{F#mi7}{dva mysy} \Ch{Hmi7}{naděje}
+<F#mi7>Za modrým <Hmi7>obzorem
+<F#mi7>dva mysy <Hmi7>naděje
 
-\Ch{E}{lákají} odvážné \Ch{A7}{kluky,}
+<E>lákají odvážné <A7>kluky,
 
-\Ch{D}{snad} právě na něho \Ch{G}{štěstí} se usměje,
+<D>snad právě na něho <G>štěstí se usměje,
 
-\Ch{D}{cíl} má už \Ch{A7}{na do}sah \Ch{D}{ruky.}
+<D>cíl má už <A7>na dosah <D>ruky.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Karel_Plíhal____Podzimní.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Podzimní.tex
@@ -3,21 +3,21 @@
 \zp{Podzimní}{Karel Plíhal}
 
 \zs
-\Ch{A}{Podzimní} obloha dala se \Ch{D}{do gala,}
+<A>Podzimní obloha dala se <D>do gala,
 
-\Ch{E}{večerní} vánek se do vlasů \Ch{A}{vplétá.}
+<E>večerní vánek se do vlasů <A>vplétá.
 
-A po tý obloze na křídle \Ch{D}{rogala}
+A po tý obloze na křídle <D>rogala
 
-s \Ch{E}{tím vánkem} ve vlasech Markéta \Ch{A}{létá.}
+s <E>tím vánkem ve vlasech Markéta <A>létá.
 
-Nebe je modrý jako mý \Ch{D}{džíny,}
+Nebe je modrý jako mý <D>džíny,
 
-\Ch{E}{tak jsme si} zpívali s klukama \Ch{A}{za mlada.}
+<E>tak jsme si zpívali s klukama <A>za mlada.
 
-Zmizely smutky a podzimní \Ch{D}{splíny,}
+Zmizely smutky a podzimní <D>splíny,
 
-\Ch{E}{prostě} to všechno, co Markéta \Ch{A}{nerada.}
+<E>prostě to všechno, co Markéta <A>nerada.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Karel_Plíhal____Ráda_se_miluje.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Ráda_se_miluje.tex
@@ -3,23 +3,23 @@
 \zp{Ráda se miluje}{Karel Plíhal}
 
 \zr
-\Ch{Ami}{Ráda} se miluje, \Ch{G}{ráda} \Ch{C}{jí,}
+<Ami>Ráda se miluje, <G>ráda <C>jí,
 
-\Ch{F}{ráda} si \Ch{Emi}{jenom} tak \Ch{Ami}{zpívá,}
+<F>ráda si <Emi>jenom tak <Ami>zpívá,
 
-vrabci se na plotě \Ch{G}{háda}\Ch{C}{jí,}
+vrabci se na plotě <G>háda<C>jí,
 
-\Ch{F}{kolik} že \Ch{Emi}{času} jí \Ch{Ami}{zbývá.}
+<F>kolik že <Emi>času jí <Ami>zbývá.
 \kr
 
 \zs
-\Ch{F}{Než} vítr dostrká k \Ch{C}{útesu} \Ch{F}{tu její} legrační 
-\Ch{C}{bár}\Ch{E}{ku}
+<F>Než vítr dostrká k <C>útesu <F>tu její legrační 
+<C>bár<E>ku
 
-a \Ch{Ami}{Pámbu} si ve svým \Ch{G}{note}\Ch{C}{su} \Ch{F}{udělá} \Ch{Emi}{jen další} \Ch{Ami}{čárku.}
+a <Ami>Pámbu si ve svým <G>note<C>su <F>udělá <Emi>jen další <Ami>čárku.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Psáno je v nebeské režii, a to hned na první stránce,
@@ -27,14 +27,14 @@ Psáno je v nebeské režii, a to hned na první stránce,
 že naše duše nás přežijí v jinačí tělesný schránce.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Úplně na konci paseky, tam, kde se ozvěna tříští,
 
-sedí šnek ve snacku pro šneky -- snad její podoba příští.     \ks
+sedí šnek ve snacku pro šneky -- snad její podoba příští. \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Karel_Plíhal____Sprej.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Sprej.tex
@@ -3,17 +3,17 @@
 \zp{Sprej}{Karel Plíhal}
 
 \zr
-  \Ch{G}{Dej mi můj sprej,} jdu pařit na ko\Ch{D}{lej,}
-  \Ch{Ami}{je tam holek} \Ch{C}{spousta} a \Ch{D}{každá} druhá \Ch{G}{šoustá,}
+ <G>Dej mi můj sprej, jdu pařit na ko<D>lej,
+ <Ami>je tam holek <C>spousta a <D>každá druhá <G>šoustá,
 	
-  dej mi můj sprej, jdu pařit na ko\Ch{D}{lej,}
-  \Ch{Ami}{je tam holek} \Ch{C}{spousta} a \Ch{D}{jsem} nadrže\Ch{G}{nej.}
+ dej mi můj sprej, jdu pařit na ko<D>lej,
+ <Ami>je tam holek <C>spousta a <D>jsem nadrže<G>nej.
 \kr
 
 \zs
-  V \Ch{G7}{levý kapse} \Ch{C}{rum} a v \Ch{A7}{pravý} sedum \Ch{D}{gum}
+ V <G7>levý kapse <C>rum a v <A7>pravý sedum <D>gum
 
-  a \Ch{G7}{desky Toma} \Ch{C}{Waitse} a \Ch{A7}{umytý} mam \Ch{D}{vejce.}
+ a <G7>desky Toma <C>Waitse a <A7>umytý mam <D>vejce.
 \ks
 
 \zr \kr

--- a/tp-songs/01_folk/Karel_Plíhal____Trubadúrská.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Trubadúrská.tex
@@ -6,7 +6,7 @@
 <Ami>Od hradu <Emi>ke hradu <Ami>putujem,
 <C>zpíváme <G>a holky <E7>muchlujem.
 
-/: <Ami>Dřív ji<Ami/G>nam <Fmaj7>neje-<Fmaj7/F#>dem,
+/: <Ami>Dřív ji<Ami/G>nam <Fmaj7>neje<Fmaj7/F#>dem,
 <Ami>dokud tu <Emi>poslední <Ami>nesvedem. :/
 \ks
 
@@ -23,10 +23,10 @@ ctihodných měšťanů z radnice. :/
 pan <Fmaj7>kníže <D9/F#>pozval <G>kejklíře,
 
 <G>hop hej, je <C>vese<Emi7/H>lo,
-dnes <Fmaj7>víta-<Emi>ní jsme <Ami>hosti.
+dnes <Fmaj7>víta<Emi>ní jsme <Ami>hosti.
 
 <G>Hop hej, je <C>vese<Emi7/H>lo,
-ač <Fmaj7>neda-<D9/F#>li nám <G>talíře,
+ač <Fmaj7>neda<D9/F#>li nám <G>talíře,
 
 <G>hop hej, je <C>vese<Emi7/H>lo,
 pod <Fmaj7>stůl nám <Emi>hážou <Ami>kosti.

--- a/tp-songs/01_folk/Karel_Plíhal____Trubadúrská.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Trubadúrská.tex
@@ -3,11 +3,11 @@
 \zp{Trubadúrská}{Karel Plíhal}
 
 \zs
-\Ch{Ami}{Od hradu} \Ch{Emi}{ke hradu} \Ch{Ami}{putujem,}
-\Ch{C}{zpíváme} \Ch{G}{a} holky \Ch{E7}{muchlujem.}
+<Ami>Od hradu <Emi>ke hradu <Ami>putujem,
+<C>zpíváme <G>a holky <E7>muchlujem.
 
-/: \Ch{Ami}{Dřív} ji\Ch{Ami/G}{nam} \Ch{Fmaj7}{neje-}\Ch{Fmaj7/F#}{dem,}
-\Ch{Ami}{dokud} tu \Ch{Emi}{poslední} \Ch{Ami}{nesvedem.} :/
+/: <Ami>Dřív ji<Ami/G>nam <Fmaj7>neje-<Fmaj7/F#>dem,
+<Ami>dokud tu <Emi>poslední <Ami>nesvedem. :/
 \ks
 
 \zs
@@ -19,17 +19,17 @@ ctihodných měšťanů z radnice. :/
 \ks
 
 \zr
-\Ch{G}{Hop} hej, je \Ch{C}{vese}\Ch{Emi7/H}{lo,
-pan} \Ch{Fmaj7}{kníže} \Ch{D9/F#}{pozval} \Ch{G}{kejklíře,}
+<G>Hop hej, je <C>vese<Emi7/H>lo,
+pan <Fmaj7>kníže <D9/F#>pozval <G>kejklíře,
 
-\Ch{G}{hop} hej, je \Ch{C}{vese}\Ch{Emi7/H}{lo,
-dnes} \Ch{Fmaj7}{víta-}\Ch{Emi}{ní jsme} \Ch{Ami}{hosti.}
+<G>hop hej, je <C>vese<Emi7/H>lo,
+dnes <Fmaj7>víta-<Emi>ní jsme <Ami>hosti.
 
-\Ch{G}{Hop} hej, je \Ch{C}{vese}\Ch{Emi7/H}{lo,
-ač} \Ch{Fmaj7}{neda-}\Ch{D9/F#}{li nám} \Ch{G}{talíře,}
+<G>Hop hej, je <C>vese<Emi7/H>lo,
+ač <Fmaj7>neda-<D9/F#>li nám <G>talíře,
 
-\Ch{G}{hop} hej, je \Ch{C}{vese}\Ch{Emi7/H}{lo,
-pod} \Ch{Fmaj7}{stůl nám} \Ch{Emi}{hážou} \Ch{Ami}{kosti}.
+<G>hop hej, je <C>vese<Emi7/H>lo,
+pod <Fmaj7>stůl nám <Emi>hážou <Ami>kosti.
 \kr
 
 \zs
@@ -48,7 +48,7 @@ A doufáme, že lidi pochopí,
 když brečí v hospodě u piva. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Ale jako bys lil vodu přes cedník,
@@ -69,7 +69,7 @@ Kdo to je tam u kůlu,
 borec, za nás si otvíral papulu.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 = 1.

--- a/tp-songs/01_folk/Karel_Plíhal____Vstávej_holka.tex
+++ b/tp-songs/01_folk/Karel_Plíhal____Vstávej_holka.tex
@@ -3,21 +3,21 @@
 \zp{Vstávej, holka}{Karel Plíhal}
 
 \zs
-\Ch{D}{Vstávej,} holka, \Ch{Emi7}{bude} \Ch{F#mi7}{ráno,}
+<D>Vstávej, holka, <Emi7>bude <F#mi7>ráno,
 
-\Ch{Emi7}{kalný jako} \Ch{A}{Metu}\Ch{D}{je.}
+<Emi7>kalný jako <A>Metu<D>je.
 
-Zahraju ti \Ch{Emi7}{na pi}\Ch{F#mi7}{áno,}
+Zahraju ti <Emi7>na pi<F#mi7>áno,
 
-\Ch{Emi7}{jen co zjistím,} \Ch{A}{kde tu} \Ch{D}{je.}
+<Emi7>jen co zjistím, <A>kde tu <D>je.
 
-\Ch{Hmi}{Jedno stojí} \Ch{Emi}{tamhle v} \Ch{Hmi}{koutě} \Ch{Emi}{}
+<Hmi>Jedno stojí <Emi>tamhle v <Hmi>koutě <Emi>
 
-\Ch{A7}{bez pedálů,} \Ch{D}{bez klá}\Ch{A7}{ves.}
+<A7>bez pedálů, <D>bez klá<A7>ves.
 
-V \Ch{D}{tomhle jednou} \Ch{Emi7}{pove}\Ch{F#mi7}{zou tě}
+V <D>tomhle jednou <Emi7>pove<F#mi7>zou tě
 
-\Ch{Emi7}{funebráci} \Ch{A}{přes ná}\Ch{D}{ves.}
+<Emi7>funebráci <A>přes ná<D>ves.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Lístek____Skály_kvetou.tex
+++ b/tp-songs/01_folk/Lístek____Skály_kvetou.tex
@@ -3,9 +3,9 @@
 \zp{Skály kvetou}{Lístek}
 
 \zs
-Světlo \Ch{Ami}{hoří, dokud} \Ch{D}{slabou} svíčku \Ch{C}{vánek} neu\Ch{D}{hasí,}
+Světlo <Ami>hoří, dokud <D>slabou svíčku <C>vánek neu<D>hasí,
 
-skály \Ch{Ami}{kvetou} jarním \Ch{D}{táním} pota\Ch{Ami}{jí.} \Ch{D}{}
+skály <Ami>kvetou jarním <D>táním pota<Ami>jí. <D>
 
 Tak já tebe, milá má, stále rád mám, já rád mám,
 

--- a/tp-songs/01_folk/Marsyas____Marsyas_a_Apollón.tex
+++ b/tp-songs/01_folk/Marsyas____Marsyas_a_Apollón.tex
@@ -3,19 +3,19 @@
 \zp{Marsyas a Apollón}{Marsyas}
 
 \zs
-\Ch{D}{Ta} krásná dívka, \Ch{Emi}{co se} bojí o \Ch{A}{svoji} \Ch{Asus4}{krásu,}
+<D>Ta krásná dívka, <Emi>co se bojí o <A>svoji <Asus4>krásu,
 
-\Ch{D}{Athéna} \Ch{Emi7}{jméno} má \Ch{G}{za} starých \Ch{D}{dávných} časů,
+<D>Athéna <Emi7>jméno má <G>za starých <D>dávných časů,
 
-\Ch{D}{odhodí} flétnu, \Ch{Emi}{hrát} nejde s \Ch{A}{nehybnou} \Ch{Asus4}{tváří,}
+<D>odhodí flétnu, <Emi>hrát nejde s <A>nehybnou <Asus4>tváří,
 
-\Ch{D}{ten}, kdo ji \Ch{Emi7}{najde} dřív, {tomu} se \Ch{D}{přání} zmaří.
+<D>ten, kdo ji <Emi7>najde dřív, {tomu} se <D>přání zmaří.
 \ks
 
 \zr
-\Ch{Hmi}{Tak} i Marsyas \Ch{A}{zmámen} flétnou \Ch{Hmi}{věří}, že \Ch{G}{musí} přetnout
+<Hmi>Tak i Marsyas <A>zmámen flétnou <Hmi>věří, že <G>musí přetnout
 
-/: \Ch{D}{jedno} pravidlo, \Ch{Emi}{sázku} a \Ch{G}{hrát} \Ch{D}{líp} \Ch{A}{než} \Ch{D}{bůh.} :/
+/: <D>jedno pravidlo, <Emi>sázku a <G>hrát <D>líp <A>než <D>bůh. :/
 \kr
 
 \zs

--- a/tp-songs/01_folk/Michal_Tučný____Pověste_ho_vejš.tex
+++ b/tp-songs/01_folk/Michal_Tučný____Pověste_ho_vejš.tex
@@ -3,11 +3,11 @@
 \zp{Pověste ho vejš}{Michal Tučný}
 \zs
 
-Pověste ho \Ch{Ami}{vejš}, ať se houpá,
-pověste ho \Ch{C}{vejš}, ať má \Ch{G}{dost}.
+Pověste ho <Ami>vejš, ať se houpá,
+pověste ho <C>vejš, ať má <G>dost.
 
-Pověste ho \Ch{Dmi}{vejš}, ať se \Ch{Ami}{houpá},
-že tu \Ch{G}{byl} nezvanej \Ch{Ami}{host}.
+Pověste ho <Dmi>vejš, ať se <Ami>houpá,
+že tu <G>byl nezvanej <Ami>host.
 
 \ks
 \zs
@@ -25,16 +25,16 @@ Pověste ho za El Paso,
 za Snídani v trávě a Lodní zvon,
 
 za to že neoplýval krásou,
-že měl \Ch{F}{country} rád a že se \Ch{E}{uměl} smát i \Ch{Ami}{vám}.
+že měl <F>country rád a že se <E>uměl smát i <Ami>vám.
 
 \ks
 \zr
 
-Nad hla\Ch{C}{vou} mi slunce \Ch{G}{pálí,}
-konec \Ch{Dmi}{můj} nic neod\Ch{C}{dá}\Ch{G}{lí,}
+Nad hla<C>vou mi slunce <G>pálí,
+konec <Dmi>můj nic neod<C>dá<G>lí,
 
-do svých \Ch{C}{snů} se dívám z \Ch{G}{dáli}
-a do \Ch{Dmi}{uší mi} stále zní tahle \Ch{E}{moje} píseň poslední.
+do svých <C>snů se dívám z <G>dáli
+a do <Dmi>uší mi stále zní tahle <E>moje píseň poslední.
 
 \kr
 \zs
@@ -46,7 +46,7 @@ za to, že nikdy nevydržel
 na jednom místě stát.
 
 \ks
-\zr    \kr
+\zr \kr
 \zs
 
 Pověste ho vejš...

--- a/tp-songs/01_folk/Michal_Tučný____Všichni_jsou_už_v_Mexiku.tex
+++ b/tp-songs/01_folk/Michal_Tučný____Všichni_jsou_už_v_Mexiku.tex
@@ -3,10 +3,10 @@
 \zp{Všichni jsou už v Mexiku}{Michal Tučný}
 
 \zs
-\Ch{G}{Kde} jen jsou a kde sem já, \Ch{D}{proč} všechno končí, co začíná?
+<G>Kde jen jsou a kde sem já, <D>proč všechno končí, co začíná?
 
-\Ch{Emi}{Smůla} se na mě \Ch{A}{lepí} ze zvyku \Ch{D}{a vš}ichni jsou už 
-v \Ch{D7}{Mexiku.}
+<Emi>Smůla se na mě <A>lepí ze zvyku <D>a všichni jsou už 
+v <D7>Mexiku.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Miroslav_Donutil____Ten_báječnej_mužskej_svět.tex
+++ b/tp-songs/01_folk/Miroslav_Donutil____Ten_báječnej_mužskej_svět.tex
@@ -3,9 +3,9 @@
 \zp{Ten báječnej mužskej svět}{Miroslav Donutil}
 
 \zs
-Správnej \Ch{C}{chlap} se ženskejm jeví vždycky \Ch{G}{trochu} jako kluk,
+Správnej <C>chlap se ženskejm jeví vždycky <G>trochu jako kluk,
 
-ale \Ch{F}{žádná} ženská \Ch{C}{neví,} že \Ch{F}{je} nám to vlastně \Ch{C}{fuk.}
+ale <F>žádná ženská <C>neví, že <F>je nám to vlastně <C>fuk.
 
 Od kolébky do důchodu máme tendenci si hrát,
 
@@ -13,9 +13,9 @@ máme hračky bez návodu a chceme je prozkoumat.
 \ks
 
 \zr
-Ten \Ch{C}{báječnej} mužskej svět, ten bá\Ch{G}{ječnej} mužskej svět
+Ten <C>báječnej mužskej svět, ten bá<G>ječnej mužskej svět
 
-nepo\Ch{F}{chopí} nikdy \Ch{C}{ženský,} ten \Ch{F}{báječnej} mužskej \Ch{C}{svět.}
+nepo<F>chopí nikdy <C>ženský, ten <F>báječnej mužskej <C>svět.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Nerez____Tisíc_dnů_mezi_námi.tex
+++ b/tp-songs/01_folk/Nerez____Tisíc_dnů_mezi_námi.tex
@@ -12,7 +12,7 @@ den za dnem si na nit navlékáš korálky s vůní našich dlaní.
 \zr
 Světlo a <F#mi>tma, tak <C#mi7>to <Cmi>jsem <Hmi>já,
 
-zhasni a <F#mi>dělej, co se dělat <C#mi>mů-<Hmi>že.
+zhasni a <F#mi>dělej, co se dělat <C#mi>mů<Hmi>že.
 
 Světlo a tma, tak to jsem já,
 
@@ -30,7 +30,7 @@ pátý týden ve vzduchu plavou.
 \zr \kr
 
 \zs
-<Hmi>Ti-<G>síc dnů <F#mi>mezi <Hmi>námi
+<Hmi>Ti<G>síc dnů <F#mi>mezi <Hmi>námi
 jako nekonečno nevypadá,
 
 našel jsem tě kdysi ve stohu slámy,

--- a/tp-songs/01_folk/Nerez____Tisíc_dnů_mezi_námi.tex
+++ b/tp-songs/01_folk/Nerez____Tisíc_dnů_mezi_námi.tex
@@ -3,16 +3,16 @@
 \zp{Tisíc dnů mezi námi}{Nerez}
 
 \zs
-\Ch{Hmi}{Ocelově} \Ch{Emi}{modrou} \Ch{Hmi9}{masku} máš,
-\Ch{F#mi7}{pátý} \Ch{C#mi7}{týden} se ti \Ch{Hmi7}{bráním,}
+<Hmi>Ocelově <Emi>modrou <Hmi9>masku máš,
+<F#mi7>pátý <C#mi7>týden se ti <Hmi7>bráním,
 
 den za dnem si na nit navlékáš korálky s vůní našich dlaní.
 \ks
 
 \zr
-Světlo a \Ch{F#mi}{tma,} tak \Ch{C#mi7}{to} \Ch{Cmi}{jsem} \Ch{Hmi}{já,}
+Světlo a <F#mi>tma, tak <C#mi7>to <Cmi>jsem <Hmi>já,
 
-zhasni a \Ch{F#mi}{dělej}, co se dělat \Ch{C#mi}{mů-}\Ch{Hmi}{že.}
+zhasni a <F#mi>dělej, co se dělat <C#mi>mů-<Hmi>že.
 
 Světlo a tma, tak to jsem já,
 
@@ -27,10 +27,10 @@ zatržená jména v kalendáři
 pátý týden ve vzduchu plavou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
-\Ch{Hmi}{Ti-}\Ch{G}{síc dnů} \Ch{F#mi}{mezi} \Ch{Hmi}{námi}
+<Hmi>Ti-<G>síc dnů <F#mi>mezi <Hmi>námi
 jako nekonečno nevypadá,
 
 našel jsem tě kdysi ve stohu slámy,

--- a/tp-songs/01_folk/Nezmaři____Bodláky_ve_vlasech.tex
+++ b/tp-songs/01_folk/Nezmaři____Bodláky_ve_vlasech.tex
@@ -3,13 +3,13 @@
 \zp{Bodláky ve vlasech}{Nezmaři}
 
 \zs
-Do vla\Ch{G}{sů} bláznivej \Ch{Emi}{kluk mi} \Ch{Ami}{bodláky} \Ch{D}{dával,} 
+Do vla<G>sů bláznivej <Emi>kluk mi <Ami>bodláky <D>dával, 
 
-\Ch{Emi}{za tuhle} \Ch{C}{kytku} pak \Ch{F}{všechno} chtěl \Ch{D}{mít,}
+<Emi>za tuhle <C>kytku pak <F>všechno chtěl <D>mít,
 
-svateb\Ch{G}{ní} menu\Ch{D}{et mi} \Ch{Ami}{na stýblo} \Ch{H7}{hrával,} 
+svateb<G>ní menu<D>et mi <Ami>na stýblo <H7>hrával, 
 
-\Ch{C}{že} prej se \Ch{D}{musíme} \Ch{G}{vzít.} \Ch{D7}{}
+<C>že prej se <D>musíme <G>vzít. <D7>
 \ks
 
 \zs
@@ -23,14 +23,14 @@ na tichou poštu si hrát.
 \ks
 
 \zr
-\Ch{Emi}{Bez} bolesti divný \Ch{D}{trápení}, \Ch{Emi}{suchej} pramen těžko \Ch{D}{pít},
+<Emi>Bez bolesti divný <D>trápení, <Emi>suchej pramen těžko <D>pít,
 
-\Ch{G}{zbytečně} \Ch{C}{slova} do \Ch{Cdim}{kamení} \Ch{H7}{sít}.
+<G>zbytečně <C>slova do <Cdim>kamení <H7>sít.
 
-\Ch{G7}{Na} košili našich \Ch{C}{zvyků}, \Ch{F}{vlajou} nitě od 
-knof\Ch{B}{líků},
+<G7>Na košili našich <C>zvyků, <F>vlajou nitě od 
+knof<B>líků,
 
-\Ch{Eb}{jeden} je \uv{\Ch{C}{muset}} a \Ch{Eb}{druhej} je \uv{\Ch{G}{chtít.}}  \Ch{G7}{}
+<Eb>jeden je \uv{<C>muset} a <Eb>druhej je \uv{<G>chtít.} <G7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Nezmaři____Hej_člověče_boží.tex
+++ b/tp-songs/01_folk/Nezmaři____Hej_člověče_boží.tex
@@ -3,17 +3,17 @@
 \zp{Hej, člověče boží}{Nezmaři}
 
 \zs
-\Ch{Ami}{Hej, člo}\Ch{Emi}{veče bo}\Ch{Ami}{ží,}
+<Ami>Hej, člo<Emi>veče bo<Ami>ží,
 
-\Ch{C}{zahodil} \Ch{G}{jsi bo}\Ch{C}{ty,}
+<C>zahodil <G>jsi bo<C>ty,
 
-\Ch{Ami}{jakpak bez} \Ch{Emi}{nich půjdeš} \Ch{Ami}{dál?}
+<Ami>jakpak bez <Emi>nich půjdeš <Ami>dál?
 
-\Ch{F}{Touhletou} \Ch{G}{dobou} sně\Ch{Ami}{ží.}
+<F>Touhletou <G>dobou sně<Ami>ží.
 
-\Ch{C}{Nehřeje} \Ch{G}{tě slun}\Ch{C}{ce,}
+<C>Nehřeje <G>tě slun<C>ce,
 
-\Ch{Ami}{mám o} \Ch{Emi}{tebe} \Ch{Ami}{strach.}
+<Ami>mám o <Emi>tebe <Ami>strach.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Nezmaři____Pisek.tex
+++ b/tp-songs/01_folk/Nezmaři____Pisek.tex
@@ -3,20 +3,20 @@
 \zp{Písek}{Nezmaři}
 
 \zs
-Jako \Ch{Ami}{pí-}\Ch{D}{sek} \Ch{G}{přesíváš} mě \Ch{E7}{mezi} prsty,
-\Ch{Dmi}{stejně} ti \Ch{E7}{dlaně} prázdný \Ch{Ami}{zůs-}\Ch{G}{ta}\Ch{C}{nou,} 
+Jako <Ami>pí-<D>sek <G>přesíváš mě <E7>mezi prsty,
+<Dmi>stejně ti <E7>dlaně prázdný <Ami>zůs-<G>ta<C>nou, 
 
-ani \Ch{Dmi}{vodu} nepřeliješ \Ch{G}{sítem,}
-někdy je \Ch{C}{strašně} \Ch{Emi}{málo} \Ch{Ami}{chtít,}
+ani <Dmi>vodu nepřeliješ <G>sítem,
+někdy je <C>strašně <Emi>málo <Ami>chtít,
 
-\Ch{Dmi}{já nejsem} z těch, co po \Ch{E7}{těžký} ráně
-\Ch{Ami}{ne-}\Ch{G}{vsta}\Ch{C}{nou.}
+<Dmi>já nejsem z těch, co po <E7>těžký ráně
+<Ami>ne-<G>vsta<C>nou.
 
-Ani \Ch{Dmi}{vodu} nepřeliješ \Ch{G}{sítem,}
-někdy je \Ch{C}{strašně} \Ch{Emi}{málo} \Ch{Ami}{chtít,} 
+Ani <Dmi>vodu nepřeliješ <G>sítem,
+někdy je <C>strašně <Emi>málo <Ami>chtít, 
 
-\Ch{Dmi}{já nejsem} z těch, co po \Ch{E7}{těžký} ráně
-\Ch{Ami}{ne-}\Ch{E7}{vsta}\Ch{Ami}{nou.} \ks
+<Dmi>já nejsem z těch, co po <E7>těžký ráně
+<Ami>ne-<E7>vsta<Ami>nou. \ks
 
 \zs
 Pevnou vůlí taky příliš neoplýváš, zdá se, že nemíníš mě vážně brát. 
@@ -27,7 +27,7 @@ a za čím se to vlastně máme stále hnát?
 
 Kolik času nám to ještě schází, nebo je všechen dávno pryč, 
 
-a za čím se to vlastně máme stále \Ch{F}{hnát}? 
+a za čím se to vlastně máme stále <F>hnát? 
 \ks
 
 \zs

--- a/tp-songs/01_folk/Nezmaři____Pisek.tex
+++ b/tp-songs/01_folk/Nezmaři____Pisek.tex
@@ -3,20 +3,20 @@
 \zp{Písek}{Nezmaři}
 
 \zs
-Jako <Ami>pí-<D>sek <G>přesíváš mě <E7>mezi prsty,
-<Dmi>stejně ti <E7>dlaně prázdný <Ami>zůs-<G>ta<C>nou, 
+Jako <Ami>pí<D>sek <G>přesíváš mě <E7>mezi prsty,
+<Dmi>stejně ti <E7>dlaně prázdný <Ami>zůs<G>ta<C>nou, 
 
 ani <Dmi>vodu nepřeliješ <G>sítem,
 někdy je <C>strašně <Emi>málo <Ami>chtít,
 
 <Dmi>já nejsem z těch, co po <E7>těžký ráně
-<Ami>ne-<G>vsta<C>nou.
+<Ami>ne<G>vsta<C>nou.
 
 Ani <Dmi>vodu nepřeliješ <G>sítem,
 někdy je <C>strašně <Emi>málo <Ami>chtít, 
 
 <Dmi>já nejsem z těch, co po <E7>těžký ráně
-<Ami>ne-<E7>vsta<Ami>nou. \ks
+<Ami>ne<E7>vsta<Ami>nou. \ks
 
 \zs
 Pevnou vůlí taky příliš neoplýváš, zdá se, že nemíníš mě vážně brát. 

--- a/tp-songs/01_folk/Nezmaři____Ráno_bylo_stejný.tex
+++ b/tp-songs/01_folk/Nezmaři____Ráno_bylo_stejný.tex
@@ -3,13 +3,13 @@
 \zp{Ráno bylo stejný}{Nezmaři}
 
 \zs
-\Ch{G}{Stál} na zastávce s vypůj\Ch{Hmi}{čenou} kyta\Ch{D}{rou,}
+<G>Stál na zastávce s vypůj<Hmi>čenou kyta<D>rou,
 
-v \Ch{Ami}{druhý ruce} holku, to \Ch{D}{zavazadlo} \Ch{G}{svý,}
+v <Ami>druhý ruce holku, to <D>zavazadlo <G>svý,
 
-\Ch{Emi}{a tý} holce v sáčku řek': \uv{\Ch{D}{Dobrýtro}, miláčku,
+<Emi>a tý holce v sáčku řek': \uv{<D>Dobrýtro, miláčku,
 
-\Ch{C}{podívej} se \Ch{G}{do} dáli, \Ch{E7}{uvidíš} dvě smutný kole\Ch{Ami}{je}  \Ch{D7}{na} silni\Ch{G}{ci}.}
+<C>podívej se <G>do dáli, <E7>uvidíš dvě smutný kole<Ami>je <D7>na silni<G>ci.}
 \ks
 
 \zs
@@ -23,13 +23,13 @@ dívali se do dáli, viděli dvě smutný koleje na silnici.
 \ks
 
 \zr
-\Ch{D}{Ráno} bylo stejný, \Ch{C}{nesváteč}\Ch{G}{ní,} \Ch{C}{} \Ch{G}{}
+<D>Ráno bylo stejný, <C>nesváteč<G>ní, <C> <G>
 
-\Ch{D}{na} tvářích počasí \Ch{C}{proměnli}\Ch{G}{vý,} \Ch{C}{} \Ch{G}{}
+<D>na tvářích počasí <C>proměnli<G>vý, <C> <G>
 
-\Ch{D}{rádio} hlásilo: \uv{\Ch{C}{Na} blatech \Ch{G}{svítá,}}
+<D>rádio hlásilo: \uv{<C>Na blatech <G>svítá,}
 
-\Ch{E7}{každej} byl tak trochu \Ch{Ami7}{sám,} \Ch{D7}{hm}.\Ch{G}{}
+<E7>každej byl tak trochu <Ami7>sám, <D7>hm.<G>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Pacifik____Malý_velký_muž.tex
+++ b/tp-songs/01_folk/Pacifik____Malý_velký_muž.tex
@@ -3,31 +3,31 @@
 \zp{Malý velký muž}{Pacifik}
 
 \zs
-Dokud \Ch{Emi}{tráva} bude růst,
-řeky potečou a \Ch{C}{stoupat} bude dým,
+Dokud <Emi>tráva bude růst,
+řeky potečou a <C>stoupat bude dým,
 
-léta utečou a \Ch{D}{kam} padne tvůj stín,
-země tvá bude \Ch{Emi}{tvou}.
+léta utečou a <D>kam padne tvůj stín,
+země tvá bude <Emi>tvou.
 
-Dokud \Ch{Ami}{noci} střídá den,
-vítr bude vát a \Ch{G}{mraky} poplujou,
+Dokud <Ami>noci střídá den,
+vítr bude vát a <G>mraky poplujou,
 
-slunce bude hřát a \Ch{H7}{tak,} jak léta jdou,
-země tvá bude \Ch{Emi}{tvou}.
+slunce bude hřát a <H7>tak, jak léta jdou,
+země tvá bude <Emi>tvou.
 \ks
 
 \zr
-Jen \Ch{G}{Malý} velký muž tolik dobře věděl,
+Jen <G>Malý velký muž tolik dobře věděl,
 
-\Ch{Emi}{co je} ostrý nůž, smutek prázdných sedel,
+<Emi>co je ostrý nůž, smutek prázdných sedel,
 
-\Ch{C}{Malý} velký muž čekal svý zna\Ch{D}{mení}.
+<C>Malý velký muž čekal svý zna<D>mení.
 
-Jen \Ch{G}{Malý} velký muž žehnal ohni sílu
+Jen <G>Malý velký muž žehnal ohni sílu
 
-s \Ch{Emi}{novou} nadějí, v očích slepou víru,
+s <Emi>novou nadějí, v očích slepou víru,
 
-\Ch{C}{přesto} pohřbil \Ch{D}{sen}, velký sen o Wounded \Ch{Emi}{Knee}.
+<C>přesto pohřbil <D>sen, velký sen o Wounded <Emi>Knee.
 \kr
 
 \zs
@@ -44,7 +44,7 @@ ono prokletí, co padlo na tvou zem,
 na tvou zem ztracenou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Dokud tráva bude růst,
@@ -60,7 +60,7 @@ skalní ozvěna, už nevrátí tvou zem
 silný proud nadějí.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Pacifik____Velrybářská_výprava.tex
+++ b/tp-songs/01_folk/Pacifik____Velrybářská_výprava.tex
@@ -3,19 +3,19 @@
 \zp{Velrybářská výprava}{Pacifik}
 
 \zs
-\Ch{E}{Jednou} plác mě \Ch{A}{přes rameno} \Ch{H7}{Johnny}, zvanej \Ch{E}{Knecht:}
+<E>Jednou plác mě <A>přes rameno <H7>Johnny, zvanej <E>Knecht:
 
-\uv{\Ch{C#mi}{Mám pro tebe}, \Ch{F#mi}{hochu,} v pácu \Ch{H7}{moc fajnovej} \Ch{E}{kšeft!}}
+\uv{<C#mi>Mám pro tebe, <F#mi>hochu, v pácu <H7>moc fajnovej <E>kšeft!}
 
-Objednal hned \Ch{A}{litr rumu} \Ch{H7}{a pak} nežně \Ch{E}{řval:}
+Objednal hned <A>litr rumu <H7>a pak nežně <E>řval:
 
-\uv{\Ch{C#mi}{Sbal, se jedem} \Ch{F#mi}{na velryby}, \Ch{H7}{prej až} za po\Ch{E}{lár.}}
+\uv{<C#mi>Sbal, se jedem <F#mi>na velryby, <H7>prej až za po<E>lár.}
 \ks
 
 \zr
-Výprava \Ch{E}{velrybářská} \Ch{A}{kolem} Grónska \Ch{H7}{nezdařila} \Ch{E}{se,}
+Výprava <E>velrybářská <A>kolem Grónska <H7>nezdařila <E>se,
 
-protože \Ch{C#mi}{nejeli jsme} \Ch{F#mi}{na velryby}, \Ch{H7}{ale na} mro\Ch{E}{že.}
+protože <C#mi>nejeli jsme <F#mi>na velryby, <H7>ale na mro<E>že.
 \kr
 
 \zs
@@ -26,7 +26,7 @@ vypluli jsme časně zrána, směr severní pól,
 dřív, než přístav zmizel z očí, každej byl namol.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Na loď padla jinovatka, s ní třeskutej mráz,
@@ -36,7 +36,7 @@ Na pobreží místo ženskejch mávaj tučňáci,
 v tomhle kraji beztak nemáš žádnou legraci.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Když jsme domů připluli, už psal se příští rok,
@@ -46,7 +46,7 @@ starej rejdař povídá, že nedá ani flok:
 tuhle práci zaplatil by asi jenom cvok.}
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Tohleto nám neměl říkat, teď to dobře ví,
@@ -56,6 +56,6 @@ Z paluby pak slanej vítr jeho tělo smet,
 máme velryb plný zuby, na to vezmi jed.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Pavel_Dobeš____Jarmila.tex
+++ b/tp-songs/01_folk/Pavel_Dobeš____Jarmila.tex
@@ -3,21 +3,21 @@
 \zp{Jarmila}{Pavel Dobeš}
 
 \zs
-\Ch{A}{Jarmila} vždycky mi \Ch{C#mi}{radila,}
+<A>Jarmila vždycky mi <C#mi>radila,
 
-abych \Ch{E7}{pracovní} dobu dodr\Ch{A}{žel,} \Ch{E7}{}
+abych <E7>pracovní dobu dodr<A>žel, <E7>
 
-\Ch{A}{dneska} mně ale \Ch{C#mi}{náramně}
+<A>dneska mně ale <C#mi>náramně
 
-táhlo \Ch{E7}{domů,} a tak jsem prostě \Ch{A}{šel.}
+táhlo <E7>domů, a tak jsem prostě <A>šel.
 
-\Ch{F#mi}{Jarmila má} totiž dneska narozeniny,
+<F#mi>Jarmila má totiž dneska narozeniny,
 
-\Ch{E7}{proto} jsem dnes přišel dříve o dvě hodiny,
+<E7>proto jsem dnes přišel dříve o dvě hodiny,
 
-na stole \Ch{A}{sklenice,} smích slyšet z \Ch{C#mi}{ložnice,}
+na stole <A>sklenice, smích slyšet z <C#mi>ložnice,
 
-v předsíni \Ch{E7}{stojí} pánské střeví\Ch{A}{ce.} \Ch{E7}{}
+v předsíni <E7>stojí pánské střeví<A>ce. <E7>
 \ks
 
 \zs

--- a/tp-songs/01_folk/Pavel_Dobeš____Něco_o_lásce.tex
+++ b/tp-songs/01_folk/Pavel_Dobeš____Něco_o_lásce.tex
@@ -3,43 +3,43 @@
 \zp{Něco o lásce}{Pavel Dobeš}
 
 \zs
-\Ch{C}{Za} ledovou \Ch{F}{horou} a černými \Ch{C}{lesy}
+<C>Za ledovou <F>horou a černými <C>lesy
 
-je stříbrná \Ch{F}{řeka} a za ní \Ch{C}{kdesi}
+je stříbrná <F>řeka a za ní <C>kdesi
 
-stojí \Ch{F}{domek} bez ad\Ch{C}{resy} a bez \Ch{G}{de}\Ch{Dmi}{chu,}
+stojí <F>domek bez ad<C>resy a bez <G>de<Dmi>chu,
 
-\Ch{F}{bydlí} v něm -- nechci říkat \uv{\Ch{C}{víla}},
+<F>bydlí v něm -- nechci říkat \uv{<C>víla},
 
-ale co \Ch{F}{na} tom, i kdyby \Ch{C}{byla,}
+ale co <F>na tom, i kdyby <C>byla,
 
-\Ch{F}{před} lidmi se trošku \Ch{C}{skryla}
+<F>před lidmi se trošku <C>skryla
 
-a \Ch{Dmi}{víme} o ní \Ch{G}{hlavně} z dosle\Ch{C}{chu.}
+a <Dmi>víme o ní <G>hlavně z dosle<C>chu.
 \ks
 
 \zr
-Že lidi r\Ch{Dmi}{ozumné} blbnout \Ch{G}{nutí}
+Že lidi r<Dmi>ozumné blbnout <G>nutí
 
-a není n\Ch{C}{a} ni nejm\Ch{C/H}{enší} spolehn\Ch{Ami}{utí,}
+a není n<C>a ni nejm<C/H>enší spolehn<Ami>utí,
 
-\Ch{Dmi}{co ji zrovna} napad\Ch{G}{ne, to} udě\Ch{C}{lá}: \Ch{C/H}{} \Ch{Ami}{}
+<Dmi>co ji zrovna napad<G>ne, to udě<C>lá: <C/H> <Ami>
 
-z puberťáků \Ch{Dmi}{chlapy} a z chlapů puber\Ch{G}{ťáky},
+z puberťáků <Dmi>chlapy a z chlapů puber<G>ťáky,
 
-o ženských \Ch{C}{nemluvím}, \Ch{C/H}{tam} to platí \Ch{Ami}{taky},
+o ženských <C>nemluvím, <C/H>tam to platí <Ami>taky,
 
-a \Ch{Dmi}{urážlivá} je a \Ch{G}{hořkosladkokyse}\Ch{C}{lá}.
+a <Dmi>urážlivá je a <G>hořkosladkokyse<C>lá.
 \kr
 
 \zs
-Genetičtí \Ch{Dmi}{inženýři} \Ch{G}{lámou} její \Ch{C}{kód,}\Ch{C/H}{} \Ch{Ami}{}
+Genetičtí <Dmi>inženýři <G>lámou její <C>kód,<C/H> <Ami>
 
-po Praze se \Ch{Dmi}{o nich šíří,} \Ch{G}{že} jezdí tramva\Ch{C}{jí,} \Ch{C/H}{} \Ch{Ami}{}
+po Praze se <Dmi>o nich šíří, <G>že jezdí tramva<C>jí, <C/H> <Ami>
 
-strkají \Ch{Dmi}{hlavy} \Ch{G}{pod} vodo\Ch{C}{vod} \Ch{C/H}{} \Ch{Ami}{}
+strkají <Dmi>hlavy <G>pod vodo<C>vod <C/H> <Ami>
 
-a pak i \Ch{Dmi}{oni nakonec} p\Ch{G}{odléha}\Ch{C}{jí.}
+a pak i <Dmi>oni nakonec p<G>odléha<C>jí.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Pavel_Dobeš____Pražce.tex
+++ b/tp-songs/01_folk/Pavel_Dobeš____Pražce.tex
@@ -3,12 +3,12 @@
 \zp{Pražce}{Pavel Dobeš}
 
 \zs
-\Ch{C}{Házím} tornu na svý záda, feldflašku a \Ch{G7}{sumky,}
+<C>Házím tornu na svý záda, feldflašku a <G7>sumky,
 
 navštívím dnes kamaráda z železniční průmky,
 
-vždyť je \Ch{C}{jaro,} zapni si kšandy,
-pozdravuj \Ch{G7}{vlaštovky} a muziko, ty \Ch{C}{hraj.}
+vždyť je <C>jaro, zapni si kšandy,
+pozdravuj <G7>vlaštovky a muziko, ty <C>hraj.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Pavel_Roth____Zahrada_ticha.tex
+++ b/tp-songs/01_folk/Pavel_Roth____Zahrada_ticha.tex
@@ -3,9 +3,9 @@
 \zp{Zahrada ticha}{Pavel Roth}
 
 \zs
-Je tam brána zdobe\Ch{D}{ná,} cestu oteví\Ch{Emi}{rá,}
+Je tam brána zdobe<D>ná, cestu oteví<Emi>rá,
 
-zahradu zele\Ch{C}{nou,} \Ch{G}{všechno} připomí\Ch{D}{ná.}
+zahradu zele<C>nou, <G>všechno připomí<D>ná.
 \ks
 \zs
 Jako dým závojů mlhou upředených,

--- a/tp-songs/01_folk/Poutníci____Hotel_Hillary.tex
+++ b/tp-songs/01_folk/Poutníci____Hotel_Hillary.tex
@@ -3,25 +3,25 @@
 \zp{Hotel Hillary}{Poutníci}
 
 \zs
-Tvař se \Ch{Ami}{trochu} nostalgicky, už tě nikdy nepotkám, \Ch{G}{}
+Tvař se <Ami>trochu nostalgicky, už tě nikdy nepotkám, <G>
 
-\Ch{F}{máš} to jistý \Ch{G}{provždycky}, nastav \Ch{Ami}{uši vzpomínkám,}
+<F>máš to jistý <G>provždycky, nastav <Ami>uši vzpomínkám,
 
-jak tě znám, i v tuhle chvíli měl bys řeči peprný,  \Ch{G}{}
+jak tě znám, i v tuhle chvíli měl bys řeči peprný, <G>
 
-jak \Ch{F}{tenkrát}, když nám \Ch{G}{tvrdili}, že je \Ch{Ami}{vítr} stříbrný.  \Ch{G}{}
+jak <F>tenkrát, když nám <G>tvrdili, že je <Ami>vítr stříbrný. <G>
 \ks
 
 \zr
-A \Ch{F}{tváře} měli kožený, my jim zdrhli z průvodu,
+A <F>tváře měli kožený, my jim zdrhli z průvodu,
 
-zaho\Ch{Dmi}{dili lampióny} a \Ch{D}{našli} hospodu,
+zaho<Dmi>dili lampióny a <D>našli hospodu,
 
-ale \Ch{F}{taky} Jacquese Brela a s ním smutek z cizích vin
+ale <F>taky Jacquese Brela a s ním smutek z cizích vin
 
-a \Ch{Dmi}{žádostivost} těla a pak \Ch{D}{radost} z volovin,
+a <Dmi>žádostivost těla a pak <D>radost z volovin,
 
-a ta nám \Ch{Ami}{zbejvá}.
+a ta nám <Ami>zbejvá.
 \kr
 
 \zs
@@ -34,7 +34,7 @@ slavný sliby jsme už znali, i to, jak se neplní,
 a cenzoři nám kázali o správným umění.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 A tak válčím s nostalgií, bují ve mně jako mech

--- a/tp-songs/01_folk/Poutníci____Panenka.tex
+++ b/tp-songs/01_folk/Poutníci____Panenka.tex
@@ -2,24 +2,24 @@
 
 \zp{Panenka}{Poutníci}
 
-\Ch{G}{} \Ch{D}{} \Ch{G}{} \Ch{D}{} \Ch{D}{} \Ch{A7}{} \Ch{D}{}
+<G> <D> <G> <D> <D> <A7> <D>
 
 \zs
-Co \Ch{D}{skrýváš} za \Ch{G}{víčky} a \Ch{D}{plameny} \Ch{G}{svíčky,}
+Co <D>skrýváš za <G>víčky a <D>plameny <G>svíčky,
 
-snad \Ch{D}{houf} bílejch holubic nebo jen \Ch{A}{žal?}
+snad <D>houf bílejch holubic nebo jen <A>žal?
 
-Tak \Ch{G}{odplul} ten \Ch{D}{prvý} den \Ch{G}{zmáčený} \Ch{D}{krví,}
+Tak <G>odplul ten <D>prvý den <G>zmáčený <D>krví,
 
-ani pouťovou panenku \Ch{A}{nezane}\Ch{D}{chal.}
+ani pouťovou panenku <A>nezane<D>chal.
 \ks
 
 \zr
-\Ch{D}{Otev}ři \Ch{G}{oči,} ty \Ch{D}{uspěcha}\Ch{A}{ná} \Ch{G}{dámo} \Ch{D}{uplaka}\Ch{A}{ná,}
+<D>Otevři <G>oči, ty <D>uspěcha<A>ná <G>dámo <D>uplaka<A>ná,
 
-\Ch{G}{otevři} \Ch{D}{oči,} ta \Ch{G}{hloupá} noc \Ch{D}{končí}
+<G>otevři <D>oči, ta <G>hloupá noc <D>končí
 
-a mír je \Ch{A}{mezi} ná\Ch{D}{ma.}
+a mír je <A>mezi ná<D>ma.
 \kr
 
 \zs
@@ -32,7 +32,7 @@ a na bílou kůži ti napíšu tuší,
 že dámou jsi byla a zůstáváš dál.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Rangers____Inženýrská.tex
+++ b/tp-songs/01_folk/Rangers____Inženýrská.tex
@@ -3,13 +3,13 @@
 \zp{Inženýrská}{Rangers}
 
 \zs
-Já \Ch{C}{studoval} a studoval a budoucnost si budoval,
+Já <C>studoval a studoval a budoucnost si budoval,
 
-má máma chtěla, aby ze mě zeměměřič \Ch{G}{byl,}
+má máma chtěla, aby ze mě zeměměřič <G>byl,
 
-však v \Ch{F}{běhu} věcí nastal zlom, já došel jsem si pro diplom,
+však v <F>běhu věcí nastal zlom, já došel jsem si pro diplom,
 
-teď už mě hřeje v kapse, čímž se \Ch{G}{splnil} mámin \Ch{C}{cíl.} \Ch{G}{}
+teď už mě hřeje v kapse, čímž se <G>splnil mámin <C>cíl. <G>
 \ks
 
 \zs
@@ -23,13 +23,13 @@ a nikdy nepochopím to perpetuum mobile?
 \ks
 
 \zr
-\Ch{C}{Prom}ovaní inženýři, sínus, kosínus, deskriptíva,
+<C>Promovaní inženýři, sínus, kosínus, deskriptíva,
 
-\Ch{G}{prom}ovaní inženýři, kdo je tu inženýr, ať s námi zpívá,
+<G>promovaní inženýři, kdo je tu inženýr, ať s námi zpívá,
 
-\Ch{C}{prom}ovaní inženýři, sínus, kosínus, deskriptíva,
+<C>promovaní inženýři, sínus, kosínus, deskriptíva,
 
-\Ch{G}{prom}ovaní inženýři, hlavy studova\Ch{C}{né.}
+<G>promovaní inženýři, hlavy studova<C>né.
 \kr
 
 \zs
@@ -55,7 +55,7 @@ tak přesto, že jsme vzdělaní, teď plivneme si do dlaní
 a budem všichni hrát a zpívat, kolik nás tu je.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Samson_a_jeho_parta____Hrneček.tex
+++ b/tp-songs/01_folk/Samson_a_jeho_parta____Hrneček.tex
@@ -3,31 +3,31 @@
 \zp{Hrneček}{Samson a jeho parta}
 
 \zs
-Přečti mi \Ch{G}{pohádku} z hrnečku \Ch{H#maj7}{od kafe}
-a ať je \Ch{G}{v ní něco} \Ch{H#maj7}{hezkýho.}
+Přečti mi <G>pohádku z hrnečku <H#maj7>od kafe
+a ať je <G>v ní něco <H#maj7>hezkýho.
 
-A ať jsem \Ch{G}{v pořádku}, ať mě svět \Ch{H#maj7}{nerafe}
-a ať \Ch{G}{mám hodnýho} \Ch{H#maj7}{mužskýho.}
+A ať jsem <G>v pořádku, ať mě svět <H#maj7>nerafe
+a ať <G>mám hodnýho <H#maj7>mužskýho.
 
-Ať se mi \Ch{Ami}{zadaří a ať mě} \Ch{D7}{nemlátí,}
-ať mi ten \Ch{Ami}{lógr už svět v koláč} \Ch{D7}{obrátí.}
+Ať se mi <Ami>zadaří a ať mě <D7>nemlátí,
+ať mi ten <Ami>lógr už svět v koláč <D7>obrátí.
 
-Ať mi v něm \Ch{G}{dopřeje} mandle a \Ch{H#maj7}{hrozinky,}
-prosím tě, \Ch{G}{uděj se,} štěstíčko \Ch{H#maj7}{malinký.}
+Ať mi v něm <G>dopřeje mandle a <H#maj7>hrozinky,
+prosím tě, <G>uděj se, štěstíčko <H#maj7>malinký.
 \ks
 
 \zr
-Do dveří \Ch{Ami}{kopou, když} chtějí \Ch{D7}{za ně,}
+Do dveří <Ami>kopou, když chtějí <D7>za ně,
 
-ti s velkou \Ch{G}{stopou,} co šetří \Ch{H#maj7}{dlaně.}
+ti s velkou <G>stopou, co šetří <H#maj7>dlaně.
 
-Na dveře \Ch{Ami}{buší, když} chtějí \Ch{D7}{vstoupit,}
+Na dveře <Ami>buší, když chtějí <D7>vstoupit,
 
-pěvci bez \Ch{G}{uší, hluční} a \Ch{H#maj7}{hloupí.}
+pěvci bez <G>uší, hluční a <H#maj7>hloupí.
 
-Zaťuká \Ch{Ami}{lehce,} kdo hledá \Ch{D7}{teplo,}
+Zaťuká <Ami>lehce, kdo hledá <D7>teplo,
 
-zaťuká \Ch{Ami}{lehce a} \Ch{D7}{nic víc} \Ch{G}{nechce.}
+zaťuká <Ami>lehce a <D7>nic víc <G>nechce.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Samson_a_jeho_parta____Katce.tex
+++ b/tp-songs/01_folk/Samson_a_jeho_parta____Katce.tex
@@ -3,13 +3,13 @@
 \zp{Katce}{Samson a jeho parta}
 
 \zs
-\Ch{D9}{Chtěl} bych králem \Ch{Dmaj7/C}{být} \Ch{D9/C}{aspoň} chvíli \Ch{Dmaj7/C}{krátkou,} 
+<D9>Chtěl bych králem <Dmaj7/C>být <D9/C>aspoň chvíli <Dmaj7/C>krátkou, 
 
-\Ch{D9}{dal} bych nara\Ch{Dmaj7/C}{zit} \Ch{D9/C}{mince} s malou \Ch{D9}{Katkou}, 
+<D9>dal bych nara<Dmaj7/C>zit <D9/C>mince s malou <D9>Katkou, 
 
-\Ch{Emi}{žlutý} jako \Ch{A7}{lán} v \Ch{Emi}{odpoledním} \Ch{A7}{žáru}, 
+<Emi>žlutý jako <A7>lán v <Emi>odpoledním <A7>žáru, 
 
-\Ch{D9}{jsem} však jenom \Ch{Dmaj7/C}{kmán,} co \Ch{D9/C}{brnká} na ky\Ch{D9}{taru.} \Ch{Emi}{} \Ch{A7}{} \ks
+<D9>jsem však jenom <Dmaj7/C>kmán, co <D9/C>brnká na ky<D9>taru. <Emi> <A7> \ks
 
 \zs
 Být tak pilotem, znám to jenom z knížky,
@@ -22,19 +22,19 @@ a já ji mám rád, u Svazarmu skáče.
 \ks
 
 \zr
-\Ch{D6}{Na} vodu \Ch{D}{zrcátka} \Ch{D6}{pouští}
+<D6>Na vodu <D>zrcátka <D6>pouští
 
-\Ch{D}{sl}\Ch{D6}{unce,} než sk\Ch{D}{ryje} ho \Ch{D6}{mrak,} \Ch{D}{} 
+<D>sl<D6>unce, než sk<D>ryje ho <D6>mrak, <D> 
 
-\Ch{D6}{kluci} se sch\Ch{D}{ovali} v \Ch{D6}{houští} 
+<D6>kluci se sch<D>ovali v <D6>houští 
 
-\Ch{D}{a} \Ch{D6}{holky} se \Ch{D}{koupou} jen \Ch{D6}{tak.} \Ch{D}{} 
+<D>a <D6>holky se <D>koupou jen <D6>tak. <D> 
 
-\Ch{Emi}{Takhle} si maluju \Ch{A7}{léto}, \Ch{D}{zima} když nechce být \Ch{Cdim}{krátkou}, 
+<Emi>Takhle si maluju <A7>léto, <D>zima když nechce být <Cdim>krátkou, 
 
-\Ch{Emi}{přemýšlím}, zdali \Ch{Emi/F}{půjde} \Ch{Emi/G}{to,} 
+<Emi>přemýšlím, zdali <Emi/F>půjde <Emi/G>to, 
 
-\Ch{C}{být} aspoň tři týdny s \Ch{A7}{Katkou}, \Ch{D9}{hm}.
+<C>být aspoň tři týdny s <A7>Katkou, <D9>hm.
 \kr
 
 \zs
@@ -57,7 +57,7 @@ aby i ta má nemusela vstávat,
 a když volno má, tak proč ho naddělávat? 
 \ks
 
-\zr     \kr
+\zr \kr
 
 \zs
 Nejsem pilotem ani panem králem, 

--- a/tp-songs/01_folk/Samson_a_jeho_parta____Pohoda.tex
+++ b/tp-songs/01_folk/Samson_a_jeho_parta____Pohoda.tex
@@ -3,32 +3,32 @@
 \zp{Pohoda}{Samson a jeho parta}
 
 \zs
-U nás v \Ch{C}{ulici} bydlel pan \Ch{Emi7}{Svoboda}, 
+U nás v <C>ulici bydlel pan <Emi7>Svoboda, 
 
-že se \Ch{Ami}{pořád} smál, měl přezdívku \Ch{C}{Pohoda}, 
+že se <Ami>pořád smál, měl přezdívku <C>Pohoda, 
 
-když jsem \Ch{Dmi7}{se ho ptal,} jakpak \Ch{G7}{dneska} je, 
+když jsem <Dmi7>se ho ptal, jakpak <G7>dneska je, 
 
-říkával: \uv{\Ch{C}{Pohoda.}} 
+říkával: \uv{<C>Pohoda.} 
 
-Měl \Ch{C}{malej} byt, ženu a \Ch{Emi7}{dvě děti,}
+Měl <C>malej byt, ženu a <Emi7>dvě děti,
 
-v pět vstával \Ch{Ami}{do práce,} domů šel v \Ch{C}{půl} třetí, 
+v pět vstával <Ami>do práce, domů šel v <C>půl třetí, 
 
-noviny \Ch{Dmi7}{pod paží,} cukroví \Ch{G7}{pro} děti, 
+noviny <Dmi7>pod paží, cukroví <G7>pro děti, 
 
-zkrátka \Ch{C}{pohoda}. 
+zkrátka <C>pohoda. 
 \ks
 \zr
-\Ch{Dmi7}{Po domě} se \Ch{G7}{povídalo:} 
+<Dmi7>Po domě se <G7>povídalo: 
 
-\Ch{C}{ten} má \Ch{C/H}{asi} \Ch{Ami}{příjem,}\Ch{Ami/G}{} 
+<C>ten má <C/H>asi <Ami>příjem,<Ami/G> 
 
-\Ch{Dmi7}{zatímco} my \Ch{G7}{nadáváme}, \Ch{C}{vese}\Ch{C/H}{le} si \Ch{Ami}{žije,}\Ch{Ami/G}{}
+<Dmi7>zatímco my <G7>nadáváme, <C>vese<C/H>le si <Ami>žije,<Ami/G>
 
-a \Ch{Dmi7}{hlavně} paní \Ch{G7}{Šulcová} ze \Ch{C}{soused}\Ch{C/H}{ního} \Ch{Ami}{bytu}\Ch{Ami/G}{}
+a <Dmi7>hlavně paní <G7>Šulcová ze <C>soused<C/H>ního <Ami>bytu<Ami/G>
 
-\Ch{D7}{} \Ch{Ami/G}{poslouchala} za dveřmi a \Ch{F}{záviděla} v \Ch{G7}{skrytu}. 
+<D7> <Ami/G>poslouchala za dveřmi a <F>záviděla v <G7>skrytu. 
 \kr
 \zs
 Paní Šulcová psala dopisy, 
@@ -80,7 +80,7 @@ zjišťuji to ponenáhlu a málo se mi líbí,
 
 že Šulcová je na koni, a proto není náhoda, 
 
-že \Ch{Dmi7}{lidi zdravím} úsměvem a \Ch{G7}{odpovídám}: 
+že <Dmi7>lidi zdravím úsměvem a <G7>odpovídám: 
 
 Pohoda...
 \kr

--- a/tp-songs/01_folk/Samson_a_jeho_parta____Už_to_nenapravím.tex
+++ b/tp-songs/01_folk/Samson_a_jeho_parta____Už_to_nenapravím.tex
@@ -3,32 +3,32 @@
 \zp{Už to nenapravím}{Samson a jeho parta}
 
 \zr
-\Ch{Ami}{Vap} ta da ta ta da tada ta tadada... \Ch{D}{}  \Ch{F}{} \Ch{E}{} \Ch{Ami}{} \Ch{E}{} \Ch{E7}{}
+<Ami>Vap ta da ta ta da tada ta tadada... <D> <F> <E> <Ami> <E> <E7>
 \kr
 \zs
-V \Ch{Ami}{devět} hodin dvacet pět \Ch{D}{mě} opustilo štěstí,
+V <Ami>devět hodin dvacet pět <D>mě opustilo štěstí,
 
-ten \Ch{F}{vlak,} co jsem jím měl jet, na koleji \Ch{E}{dávno} \Ch{E7}{nestál.}
+ten <F>vlak, co jsem jím měl jet, na koleji <E>dávno <E7>nestál.
 
-V \Ch{Ami}{devět} hodin dvacet pět \Ch{D}{jako} bych dostal pěstí,
+V <Ami>devět hodin dvacet pět <D>jako bych dostal pěstí,
 
-já \Ch{F}{za} hodinu na náměstí měl jsem \Ch{E}{stát,}
-ale v \Ch{E7}{jiným} městě.
-
-
-Tvá \Ch{A7}{zpráva} zněla prostě a byla tak krátká,
-
-že \Ch{Dmi}{stavíš} se jen na skok, že nechalas' mi vrátka
-
-\Ch{G}{zadní} otevřená, \Ch{E}{zadní} otevře\Ch{E7}{ná.}
+já <F>za hodinu na náměstí měl jsem <E>stát,
+ale v <E7>jiným městě.
 
 
+Tvá <A7>zpráva zněla prostě a byla tak krátká,
 
-Já \Ch{A7}{naposled} tě viděl, když ti bylo dvacet,
+že <Dmi>stavíš se jen na skok, že nechalas' mi vrátka
 
-\Ch{Dmi}{to jsi} tenkrát řekla, že se nechceš vracet,
+<G>zadní otevřená, <E>zadní otevře<E7>ná.
 
-\Ch{G}{že} jsi unavená, \Ch{E}{ze} mě unave\Ch{E7}{ná.}
+
+
+Já <A7>naposled tě viděl, když ti bylo dvacet,
+
+<Dmi>to jsi tenkrát řekla, že se nechceš vracet,
+
+<G>že jsi unavená, <E>ze mě unave<E7>ná.
 \ks
 
 \zr \kr

--- a/tp-songs/01_folk/Semtex____Mašinka.tex
+++ b/tp-songs/01_folk/Semtex____Mašinka.tex
@@ -3,9 +3,9 @@
 \zp{Mašinka}{Semtex}
 
 \zr
-\Ch{D}{Jede} jede mašinka, kouří \Ch{G}{se jí} z komín\Ch{D}{ka,}
+<D>Jede jede mašinka, kouří <G>se jí z komín<D>ka,
 
-/: jede, \Ch{G}{jede} do dá\Ch{A}{li, veze} \Ch{G}{samý} vožra\Ch{D}{lý.} :/
+/: jede, <G>jede do dá<A>li, veze <G>samý vožra<D>lý. :/
 \kr
 
 \zs
@@ -20,7 +20,7 @@ Lásko má jsi jediná do třinácti nevinná,
 /: vyhrnu si rukávy, praštím s tebou do trávy. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Přijde ke mně průvodčí, kleštičkama zatočí:
@@ -29,7 +29,7 @@ Přijde ke mně průvodčí, kleštičkama zatočí:
 \uv{To máte tak.} :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Jel jsem jednou tramvají pod sedačkou, potají,
@@ -37,7 +37,7 @@ Jel jsem jednou tramvají pod sedačkou, potají,
 /: přistoupila starší dáma, přisedla mi Dařbujána. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Spirituál_kvintet____Batalion.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Batalion.tex
@@ -2,19 +2,19 @@
 
 \zp{Batalion}{Spirituál kvintet}
 
-\Ch{Ami}{Víno }\Ch{C}{máš} a \Ch{G}{markyt}\Ch{Ami}{ánku,}
+<Ami>Víno <C>máš a <G>markyt<Ami>ánku,
 
-dlouhá \Ch{C}{noc} \Ch{G}{se }\Ch{Ami}{pro}\Ch{Emi}{hý-}\Ch{Ami}{ří.}
+dlouhá <C>noc <G>se <Ami>pro<Emi>hý-<Ami>ří.
 
-\Ch{Ami}{Víno} \Ch{C}{máš} a \Ch{G}{chvilku} \Ch{Ami}{spánku,}
+<Ami>Víno <C>máš a <G>chvilku <Ami>spánku,
 
-\Ch{C}{díky,} dí\Ch{G}{ky,} \Ch{Ami}{ver-}\Ch{Emi}{bí-}\Ch{Ami}{ři.}
+<C>díky, dí<G>ky, <Ami>ver-<Emi>bí-<Ami>ři.
 
 \zs
-\Ch{Ami}{Dříve} než se rozední,
-kapitán k \Ch{C}{osedlání} \Ch{G}{rozkaz} \Ch{Ami}{dá-}\Ch{Emi}{vá,}
+<Ami>Dříve než se rozední,
+kapitán k <C>osedlání <G>rozkaz <Ami>dá-<Emi>vá,
 
-\Ch{Ami}{ostruhami} do slabin \Ch{G}{koně} \Ch{Ami}{po-}\Ch{Emi}{há-}\Ch{Ami}{ní.}
+<Ami>ostruhami do slabin <G>koně <Ami>po-<Emi>há-<Ami>ní.
 
 Tam na straně polední
 čekají ženy, zlaťáky a sláva,
@@ -23,15 +23,15 @@ do výstřelů z karabin zvon už vyzvání.
 \ks
 
 \zr
-\Ch{Ami}{Víno} na \Ch{C}{kuráž} a \Ch{G}{pomilovat} marky\Ch{Ami}{tánku},
+<Ami>Víno na <C>kuráž a <G>pomilovat marky<Ami>tánku,
 
-\Ch{Ami}{zítra} do \Ch{C}{Burgund} bata\Ch{G}{lion} 
-\Ch{Ami}{za-}\Ch{Emi}{mí-}\Ch{Ami}{ří.}
+<Ami>zítra do <C>Burgund bata<G>lion 
+<Ami>za-<Emi>mí-<Ami>ří.
 
-\Ch{Ami}{Víno} na \Ch{C}{kuráž} a k \Ch{G}{ránu} dvě hodiny \Ch{Ami}{spánku}.
+<Ami>Víno na <C>kuráž a k <G>ránu dvě hodiny <Ami>spánku.
 
-\Ch{Ami}{Díky}, díky \Ch{C}{vám,} králo\Ch{G}{vští} 
-\Ch{Ami}{ver-}\Ch{Emi}{bí-}\Ch{Ami}{ři.}
+<Ami>Díky, díky <C>vám, králo<G>vští 
+<Ami>ver-<Emi>bí-<Ami>ři.
 \kr
 
 \zs
@@ -46,7 +46,7 @@ verbíři nové chlapce přivedou ti,
 za královský hermelín padne každý rád.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Spirituál_kvintet____Batalion.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Batalion.tex
@@ -4,17 +4,17 @@
 
 <Ami>Víno <C>máš a <G>markyt<Ami>ánku,
 
-dlouhá <C>noc <G>se <Ami>pro<Emi>hý-<Ami>ří.
+dlouhá <C>noc <G>se <Ami>pro<Emi>hý<Ami>ří.
 
 <Ami>Víno <C>máš a <G>chvilku <Ami>spánku,
 
-<C>díky, dí<G>ky, <Ami>ver-<Emi>bí-<Ami>ři.
+<C>díky, dí<G>ky, <Ami>ver<Emi>bí<Ami>ři.
 
 \zs
 <Ami>Dříve než se rozední,
-kapitán k <C>osedlání <G>rozkaz <Ami>dá-<Emi>vá,
+kapitán k <C>osedlání <G>rozkaz <Ami>dá<Emi>vá,
 
-<Ami>ostruhami do slabin <G>koně <Ami>po-<Emi>há-<Ami>ní.
+<Ami>ostruhami do slabin <G>koně <Ami>po<Emi>há<Ami>ní.
 
 Tam na straně polední
 čekají ženy, zlaťáky a sláva,
@@ -26,12 +26,12 @@ do výstřelů z karabin zvon už vyzvání.
 <Ami>Víno na <C>kuráž a <G>pomilovat marky<Ami>tánku,
 
 <Ami>zítra do <C>Burgund bata<G>lion 
-<Ami>za-<Emi>mí-<Ami>ří.
+<Ami>za<Emi>mí<Ami>ří.
 
 <Ami>Víno na <C>kuráž a k <G>ránu dvě hodiny <Ami>spánku.
 
 <Ami>Díky, díky <C>vám, králo<G>vští 
-<Ami>ver-<Emi>bí-<Ami>ři.
+<Ami>ver<Emi>bí<Ami>ři.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Spirituál_kvintet____Stará_archa.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Stará_archa.tex
@@ -3,27 +3,27 @@
 \zp{Stará archa}{Spirituál kvintet}
 
 \zr
-/: \Ch{D7}{Já} mám \Ch{G}{kocábku} náram-, \Ch{D7}{náram-,} \Ch{G}{náram-,}
+/: <D7>Já mám <G>kocábku náram-, <D7>náram-, <G>náram-,
 
-kocábku náram-, \Ch{D7}{náram}\Ch{G}{nou}. :/
+kocábku náram-, <D7>náram<G>nou. :/
 \kr
 
 \zs
-\Ch{G}{Pršelo} a blejskalo se sedm neděl,
-kocábku náram-, \Ch{D7}{náram}\Ch{G}{nou,}
+<G>Pršelo a blejskalo se sedm neděl,
+kocábku náram-, <D7>náram<G>nou,
 
 Noe nebyl překvapenej, on to věděl,
-kocábku náram-, \Ch{D7}{náram}\Ch{G}{nou.}
+kocábku náram-, <D7>náram<G>nou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
-\Ch{G}{Archa} má cíl, jé, archa má směr, jé,
-plaví se k Araratu \Ch{D7}{na se}\Ch{G}{ver.}
+<G>Archa má cíl, jé, archa má směr, jé,
+plaví se k Araratu <D7>na se<G>ver.
 \kr
 
-\zr  \kr
+\zr \kr
 
 \zs
 Šem, Ham a Jáfet byli bratři rodní,
@@ -41,14 +41,14 @@ kocábku náram-, náramnou,
 kocábku náram-, náramnou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Archa má cíl, jé, archa má směr, jé,
 plaví se k Araratu na sever.
 \kr
 
-\zr  \kr
+\zr \kr
 
 \zs
 Přišla bouře, zlámala jim pádla, vesla,
@@ -66,14 +66,14 @@ ještě že tu starou dobrou archu měli,
 kocábku náram-, náramnou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Archa má cíl, jé, archa má směr, jé,
 plaví se k Araratu na sever.
 \kr
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Spirituál_kvintet____Starý_příběh.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Starý_příběh.tex
@@ -3,13 +3,13 @@
 \zp{Starý příběh}{Spirituál kvintet}
 
 \zs
-Řek \Ch{D}{Mojžíš} jednou lidu svému: \uv{Přišel čas,
+Řek <D>Mojžíš jednou lidu svému: \uv{Přišel čas,
 
-dnes v noci tiše vytratí se \Ch{A7}{každý} z vás.
+dnes v noci tiše vytratí se <A7>každý z vás.
 
-\Ch{D}{Má}\Ch{D7}{vá,} \Ch{G}{má}\Ch{G#dim}{vá}
+<D>Má<D7>vá, <G>má<G#dim>vá
 
-nám \Ch{D}{všem} svo\Ch{A7}{bodná} \Ch{D}{zem.}}
+nám <D>všem svo<A7>bodná <D>zem.}
 \ks
 
 \zs
@@ -21,13 +21,13 @@ Mává, mává nám všem svobodná zem.}
 \ks
 
 \zr
-\uv{A \Ch{D}{kdo} se bojí vodou jít,
+\uv{A <D>kdo se bojí vodou jít,
 
-ten podle tónů faraónů \Ch{A7}{musí žít.}
+ten podle tónů faraónů <A7>musí žít.
 
-\Ch{D}{Má}\Ch{D7}{vá,} \Ch{G}{má}\Ch{G#dim}{vá}
+<D>Má<D7>vá, <G>má<G#dim>vá
 
-nám \Ch{D}{všem} svo\Ch{A7}{bodná} \Ch{D}{zem.}}
+nám <D>všem svo<A7>bodná <D>zem.}
 \kr
 
 \zs

--- a/tp-songs/01_folk/Spirituál_kvintet____Válka_ruží.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Válka_ruží.tex
@@ -2,13 +2,13 @@
 
 \zp{Válka růží}{Spirituál kvintet}
 \zs
-Už \Ch{Dmi}{rozplynul} se \Ch{Gmi}{hustý} dým, \Ch{Dmi}{derry} down, hej, \Ch{A7}{down}-a-down, 
+Už <Dmi>rozplynul se <Gmi>hustý dým, <Dmi>derry down, hej, <A7>down-a-down, 
 
-nad \Ch{Dmi}{ztichlým} polem \Ch{C}{válečným}, derry \Ch{Dmi}{down} \Ch{A7}{} 
+nad <Dmi>ztichlým polem <C>válečným, derry <Dmi>down <A7> 
 
-jen \Ch{F}{ticho} stojí \Ch{C}{kolko}\Ch{A}{lem} a \Ch{Dmi}{vítěz} plení \Ch{B}{vlastní} \Ch{A}{zem,} 
+jen <F>ticho stojí <C>kolko<A>lem a <Dmi>vítěz plení <B>vlastní <A>zem, 
 
-je válka \Ch{Dmi}{růží}, \Ch{Gmi}{derry}, derry, \Ch{A}{derry} down-a-\Ch{Dmi}{down}.  \ks
+je válka <Dmi>růží, <Gmi>derry, derry, <A>derry down-a-<Dmi>down. \ks
 
 \zs
 Nečekej soucit od rváče, derry down, hej, down-a-down, 

--- a/tp-songs/01_folk/Spirituál_kvintet____Za_svou_pravdou_stát.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Za_svou_pravdou_stát.tex
@@ -3,19 +3,19 @@
 \zp{Za svou pravdou stát}{Spirituál kvintet}
 
 \zs
-	Máš \Ch{Ami}{všechny} trumfy mládí a \Ch{G}{ruce} čistý \Ch{Ami}{máš,}
+	Máš <Ami>všechny trumfy mládí a <G>ruce čistý <Ami>máš,
 
-  jen \Ch{Dmi}{na tobě} teď \Ch{Ami}{záleží,} na \Ch{E7}{jakou hru} se se \Ch{Ami}{dáš.}
+ jen <Dmi>na tobě teď <Ami>záleží, na <E7>jakou hru se se <Ami>dáš.
 
-  /: Musíš za svou pravdou \Ch{E7}{stát,} musíš za svou pravdou \Ch{Ami}{stát.} :/
+ /: Musíš za svou pravdou <E7>stát, musíš za svou pravdou <Ami>stát. :/
 \ks
 
 \zs
 	Už víš, kolik co stojí, už víš, co bys rád měl,
 
-  už ocenil jsi kompromis a párkrát zapomněls',
+ už ocenil jsi kompromis a párkrát zapomněls',
 
-  /: že máš za svou pravdou stát... :/
+ /: že máš za svou pravdou stát... :/
 \ks
 
 \zs
@@ -23,7 +23,7 @@
 	
 	už víš, jak s králem ustoupit a jak s ním dávat mat.
 
-  /: Tak hleď za svou pravdou stát... :/
+ /: Tak hleď za svou pravdou stát... :/
 \ks
 
 \zs
@@ -31,13 +31,13 @@
 	
 	tvůj sok poslušně neuhnul -- a ty mu zlámeš vaz!
 
-  /: Neměl za svou pravdou stát... :/
+ /: Neměl za svou pravdou stát... :/
 \ks
 
 \zs
 	Tvůj potomek ctí tátu, ty vštěpuješ mu rád
 
-   to heslo, které dobře znáš z dob, kdy jsi býval mlád.
+ to heslo, které dobře znáš z dob, kdy jsi býval mlád.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Spirituál_kvintet____Žízeň.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Žízeň.tex
@@ -3,27 +3,27 @@
 \zp{Žízeň}{Spirituál kvintet}
 
 \zs
-Když ka\Ch{C}{pky} deště buší na \Ch{Fmaj7}{rozpále}\Ch{Ami}{nou} \Ch{G}{ze}\Ch{C}{m,}
+Když ka<C>pky deště buší na <Fmaj7>rozpále<Ami>nou <G>ze<C>m,
 
-já toužím celou duší dát \Ch{Fmaj7}{živou vodu} \Ch{C}{všem},
+já toužím celou duší dát <Fmaj7>živou vodu <C>všem,
 
-už v Knize knih je psáno: bez \Ch{Fmaj7}{vody} \Ch{Ami}{nel-}\Ch{G}{ze} \Ch{C}{žít},
+už v Knize knih je psáno: bez <Fmaj7>vody <Ami>nel-<G>ze <C>žít,
 
-však ne každému je dáno \Ch{Fmaj7}{z řeky} pravdy \Ch{C}{pít}.
+však ne každému je dáno <Fmaj7>z řeky pravdy <C>pít.
 \ks
 
 \zr
-Já mám ží\Ch{G}{zeň}, věčnou \Ch{C}{žízeň}, \Ch{C7}{}
+Já mám ží<G>zeň, věčnou <C>žízeň, <C7>
 
-stačí \Ch{F}{říct}, kde najdu vlá\Ch{C}{hu}
+stačí <F>říct, kde najdu vlá<C>hu
 
-a zchladím \Ch{F}{žá}\Ch{C}{hu} páli\Ch{G}{vou},
+a zchladím <F>žá<C>hu páli<G>vou,
 
-ó, já mám žízeň, věčnou \Ch{C}{ží}\Ch{C7}{zeň,}
+ó, já mám žízeň, věčnou <C>ží<C7>zeň,
 
-stačí \Ch{F}{říct}, kde najdu \Ch{C}{vláhu},
+stačí <F>říct, kde najdu <C>vláhu,
 
-a zmizí \Ch{F}{ží}\Ch{C}{zeň}, \Ch{F}{ží}\Ch{C}{zeň}, \Ch{F}{ží}\Ch{C}{zeň}.
+a zmizí <F>ží<C>zeň, <F>ží<C>zeň, <F>ží<C>zeň.
 \kr
 
 \zs
@@ -36,7 +36,7 @@ mně čistá voda schází, mně chybí její třpyt,
 vždyť z moře lží a frází se voda nedá pít.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Jak vytékají říčky zpod úbočí hor,
@@ -48,6 +48,6 @@ ten pramen vody živé má v sobě každý z nás
 a vytryskne jak gejzír, až přijde jeho čas.
 \ks
 
-\zr  \kr  \zr  \kr
+\zr \kr \zr \kr
 
 \kp

--- a/tp-songs/01_folk/Spirituál_kvintet____Žízeň.tex
+++ b/tp-songs/01_folk/Spirituál_kvintet____Žízeň.tex
@@ -7,7 +7,7 @@ Když ka<C>pky deště buší na <Fmaj7>rozpále<Ami>nou <G>ze<C>m,
 
 já toužím celou duší dát <Fmaj7>živou vodu <C>všem,
 
-už v Knize knih je psáno: bez <Fmaj7>vody <Ami>nel-<G>ze <C>žít,
+už v Knize knih je psáno: bez <Fmaj7>vody <Ami>nel<G>ze <C>žít,
 
 však ne každému je dáno <Fmaj7>z řeky pravdy <C>pít.
 \ks

--- a/tp-songs/01_folk/Tichá_dohoda____Marioneta.tex
+++ b/tp-songs/01_folk/Tichá_dohoda____Marioneta.tex
@@ -2,19 +2,19 @@
 
 \zp{Marioneta}{Tichá dohoda}
 \zs
-\Ch{D}{Každej} večer hlídám
-\Ch{Hmi}{svoje} \Ch{G}{tělo} \Ch{A}{dřevě}\Ch{D}{ný,}
+<D>Každej večer hlídám
+<Hmi>svoje <G>tělo <A>dřevě<D>ný,
 
-\Ch{D}{svý} starý role střídám,
-\Ch{Hmi}{nechám}  \Ch{G}{oči} \Ch{A}{zavře}\Ch{D}{ný.}
+<D>svý starý role střídám,
+<Hmi>nechám <G>oči <A>zavře<D>ný.
 \ks
 
 \zr
-\Ch{Hmi}{Marioneta,} \Ch{G}{} \Ch{A}{to} jsem \Ch{D}{já,}
+<Hmi>Marioneta, <G> <A>to jsem <D>já,
 
-\Ch{Hmi}{Marioneta} \Ch{G}{} \Ch{A}{zasně}\Ch{D}{ná,} \Ch{A}{ }
+<Hmi>Marioneta <G> <A>zasně<D>ná, <A> 
 
-\Ch{D}{loutka} \Ch{G}{s tváří} \Ch{A}{dřevě}\Ch{Hmi}{nou.}
+<D>loutka <G>s tváří <A>dřevě<Hmi>nou.
 \kr
 
 
@@ -30,12 +30,12 @@ provázky rukou zlámaných.
 \kr
 
 \zs
-\Ch{A}{Vrah} se plíží \Ch{G}{podél} zdí,
+<A>Vrah se plíží <G>podél zdí,
 
-\Ch{F#mi}{velký} těžký \Ch{A}{závaží,}
+<F#mi>velký těžký <A>závaží,
 
-\Ch{A}{kdo} chce viset \Ch{G}{hlavou} dolů,
-\Ch{F#mi}{už mi} někdy \Ch{A}{překáží.}
+<A>kdo chce viset <G>hlavou dolů,
+<F#mi>už mi někdy <A>překáží.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Tomáš_Klus____Až.tex
+++ b/tp-songs/01_folk/Tomáš_Klus____Až.tex
@@ -3,11 +3,11 @@
 \zp{Až...}{Tomáš Klus}
 
 \zs
-Až \Ch{Ami}{rozp}ustím \Ch{D}{dým} a k tomu
-\Ch{G}{skon}čí další den, \Ch{C}{tak} půjdem
+Až <Ami>rozpustím <D>dým a k tomu
+<G>skončí další den, <C>tak půjdem
 
-\Ch{Ami}{oba} domů \Ch{D}{za} tím svým \Ch{G}{}
-štěstím. \Ch{C}{Jsem} kolemjdoucí z davu,
+<Ami>oba domů <D>za tím svým <G>
+štěstím. <C>Jsem kolemjdoucí z davu,
 
 součást osudu, a budu
 tebou znovu oslněn.
@@ -27,13 +27,13 @@ Tady, vždyť víš.
 \zr \kr
 
 \zs
-Zatím \Ch{Emi}{mi n}ikdo nevěří \Ch{Ami}{mý vz}dušný zámky
-\Ch{F}{u dv}eří. Jen ty jsi na oko smu\Ch{C}{tná.}
+Zatím <Emi>mi nikdo nevěří <Ami>mý vzdušný zámky
+<F>u dveří. Jen ty jsi na oko smu<C>tná.
 
-\Ch{Emi}{A co} mám dělat, když jsme tři? \Ch{Ami}{Ty jsi} ta, co s láskou 
-nešetří. \Ch{F}{}
+<Emi>A co mám dělat, když jsme tři? <Ami>Ty jsi ta, co s láskou 
+nešetří. <F>
 
-Ty jsi ta na oko smutná.\Ch{C}{}
+Ty jsi ta na oko smutná.<C>
 \ks
 
 \zs

--- a/tp-songs/01_folk/Tomáš_Klus____Panenka.tex
+++ b/tp-songs/01_folk/Tomáš_Klus____Panenka.tex
@@ -3,14 +3,14 @@
 \zp{Panenka}{Tomáš Klus}
 
 \zs
-\Ch{Ami}{Stanu} se \Ch{F}{myš}lenkou \Ch{C}{a bu}du v tobě, \Ch{G}{}
+<Ami>Stanu se <F>myšlenkou <C>a budu v tobě, <G>
 
-\Ch{Ami}{budeš} mou \Ch{F}{mil}enkou \Ch{C}{výhl}edově, \Ch{G}{}
+<Ami>budeš mou <F>milenkou <C>výhledově, <G>
 
-\Ch{Ami}{budeš} můj \Ch{F}{druh}ej hlas \Ch{C}{pro} tuhle \Ch{G}{píseň,} 
-\Ch{Ami}{jsi kr}ásná, \Ch{F}{} \Ch{C}{} \Ch{G}{}
+<Ami>budeš můj <F>druhej hlas <C>pro tuhle <G>píseň, 
+<Ami>jsi krásná, <F> <C> <G>
 
-\Ch{Ami}{bože,} jsi krásná. \Ch{F}{} \Ch{C}{} \Ch{G}{}
+<Ami>bože, jsi krásná. <F> <C> <G>
 \ks
 
 \zs
@@ -24,13 +24,13 @@ a tvojí nahou tvář pochopím nazpaměť.
 \ks
 
 \zr
-\Ch{C}{Jako} by nebylo \Ch{G}{nic,} \Ch{Ami}{mám} pocit že jsi se bála, \Ch{F}{}
+<C>Jako by nebylo <G>nic, <Ami>mám pocit že jsi se bála, <F>
 
-\Ch{C}{svůj} život bez hranic\Ch{G}{} \Ch{Ami}{jsi hr}ála, \Ch{F}{}
+<C>svůj život bez hranic<G> <Ami>jsi hrála, <F>
 
-\Ch{C}{panen}ku klidně si nech,\Ch{G}{} \Ch{Ami}{stejně} vím, v noci tě hřála, \Ch{F}{}
+<C>panenku klidně si nech,<G> <Ami>stejně vím, v noci tě hřála, <F>
 
-\Ch{C}{dvě} světla na voknech \Ch{G}{} \Ch{Ami}{vzplá}la. \Ch{F}{}
+<C>dvě světla na voknech <G> <Ami>vzplála. <F>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Tomáš_Klus____Pocity.tex
+++ b/tp-songs/01_folk/Tomáš_Klus____Pocity.tex
@@ -1,20 +1,20 @@
 % -*-coding: utf-8 -*-
 
 \zp{Pocity}{Tomáš Klus}
-\Ch{G}{} \Ch{D}{} \Ch{Emi}{} \Ch{C}{}
+<G> <D> <Emi> <C>
 
 \zs
-Z \Ch{G}{posledních} poc\Ch{D}{itů}
-\Ch{Emi}{pos}kládám ještě jednou \Ch{C}{úžas}nou chvíli,
+Z <G>posledních poc<D>itů
+<Emi>poskládám ještě jednou <C>úžasnou chvíli,
 
-\Ch{G}{je} to tím, že jsi \Ch{D}{tu,}
-\Ch{Emi}{mož}ná tím, že \Ch{C}{kdys}i jsme byli
+<G>je to tím, že jsi <D>tu,
+<Emi>možná tím, že <C>kdysi jsme byli
 
-ty a \Ch{G}{já,} my dva, dvě \Ch{D}{nahý} těla,
-\Ch{Emi}{tak n}eříkej, že \Ch{C}{jina}k jsi to chtěla,
+ty a <G>já, my dva, dvě <D>nahý těla,
+<Emi>tak neříkej, že <C>jinak jsi to chtěla,
 
-\Ch{G}{tak} neříkej,
-\Ch{D}{neřík}ej, \Ch{Emi}{neří}kej mi \Ch{C}{nic.}
+<G>tak neříkej,
+<D>neříkej, <Emi>neříkej mi <C>nic.
 \ks
 \zs
 Stala ses do noci
@@ -28,17 +28,17 @@ pohled na okouzlení
 a prázdný náměstí na znamení.
 \ks
 \zr
-\Ch{G}{Jenž}e ty nesly\Ch{D}{šíš,}
-jenže ty \Ch{Emi}{nepos}louch\Ch{C}{áš,}
+<G>Jenže ty nesly<D>šíš,
+jenže ty <Emi>neposlouch<C>áš,
 
-snad ani \Ch{G}{nev}idíš,
-\Ch{D}{neb}o spíš \Ch{Emi}{nech}ceš vi\Ch{C}{dět}
+snad ani <G>nevidíš,
+<D>nebo spíš <Emi>nechceš vi<C>dět
 
-a druhejm \Ch{G}{závi}díš
-\Ch{D}{a v} očích \Ch{Emi}{kap}ky slaný vody, \Ch{C}{}
+a druhejm <G>závidíš
+<D>a v očích <Emi>kapky slaný vody, <C>
 
-zkus změnu, \Ch{G}{uvid}íš, \Ch{D}{}
-a \Ch{Emi}{vítej} do \Ch{C}{svob}ody.
+zkus změnu, <G>uvidíš, <D>
+a <Emi>vítej do <C>svobody.
 \kr
 \zs
 Jsi anděl, netušíš,

--- a/tp-songs/01_folk/Vlasta_Redl____Sbohem_galánečko.tex
+++ b/tp-songs/01_folk/Vlasta_Redl____Sbohem_galánečko.tex
@@ -3,15 +3,15 @@
 \zp{Sbohem, galánečko}{Vlasta Redl}
 
 \zs
-\Ch{G}{Sbohem,} galá\Ch{Emi}{nečko,}
-\Ch{Ami}{já už musím} \Ch{D}{jí}\Ch{G}{ti.} \Ch{A7}{} 
+<G>Sbohem, galá<Emi>nečko,
+<Ami>já už musím <D>jí<G>ti. <A7> 
 
-\Ch{D}{sbohem,} galá\Ch{Hmi}{nečko,}
-\Ch{Emi}{já už musím} \Ch{A}{jí}\Ch{D4sus}{ti.} \Ch{D}{} 
+<D>sbohem, galá<Hmi>nečko,
+<Emi>já už musím <A>jí<D4sus>ti. <D> 
 
-\Ch{Ami}{Kyselé} ví\Ch{D}{nečko}, \Ch{G}{kyselé} ví\Ch{Ami}{neč}\Ch{D}{ko} 
+<Ami>Kyselé ví<D>nečko, <G>kyselé ví<Ami>neč<D>ko 
 
-\Ch{G}{podalas} \Ch{Ami}{mně} k \Ch{D}{pi}\Ch{G}{tí.}
+<G>podalas <Ami>mně k <D>pi<G>tí.
 \ks
 
 \zs

--- a/tp-songs/01_folk/Wabi_Daněk____Mávej.tex
+++ b/tp-songs/01_folk/Wabi_Daněk____Mávej.tex
@@ -3,21 +3,21 @@
 \zp{Mávej}{Wabi Daněk}
 
 \zr
-\Ch{E}{Mávej,} (mávej,) mávej, (mávej,) mávej \Ch{E7}{jen,}
+<E>Mávej, (mávej,) mávej, (mávej,) mávej <E7>jen,
 
-nic \Ch{A}{nepomůže,} že tu stojíš sama skoro celej \Ch{E}{den,}
+nic <A>nepomůže, že tu stojíš sama skoro celej <E>den,
 
-tak jen si \Ch{H7}{mávej,} (mávej,) \Ch{A}{mávej,} (mávej) a \Ch{E}{dávej} \Ch{A}{} sbo\Ch{E}{hem.}
+tak jen si <H7>mávej, (mávej,) <A>mávej, (mávej) a <E>dávej <A> sbo<E>hem.
 \kr
 
 \zs
-Jó, \Ch{A}{nemáš,} holka, páru, jakej pocit mám,
+Jó, <A>nemáš, holka, páru, jakej pocit mám,
 
-když \Ch{E}{prásknu} do kočáru a rukou zamávám
+když <E>prásknu do kočáru a rukou zamávám
 
-a \Ch{H7}{cesta} už mě zdraví a říká mi: \uv{Těpic,}
+a <H7>cesta už mě zdraví a říká mi: \uv{Těpic,}
 
-tak \Ch{E}{tohle} je to pravý, jó, \Ch{H7}{já už nechci} \Ch{E}{víc.}
+tak <E>tohle je to pravý, jó, <H7>já už nechci <E>víc.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Wabi_Daněk____Outsider_waltz.tex
+++ b/tp-songs/01_folk/Wabi_Daněk____Outsider_waltz.tex
@@ -3,23 +3,23 @@
 \zp{Outsider Waltz}{Wabi Daněk}
 
 \zs
-Dnes \Ch{C}{ráno,} když bylo půl, při \Ch{Emi}{pravidelný} hygieně
+Dnes <C>ráno, když bylo půl, při <Emi>pravidelný hygieně
 
-\Ch{Dmi}{poklesl's} hodně v ceně, když jsi \Ch{F}{zahlíd'} svůj \Ch{G}{zjev.}
+<Dmi>poklesl's hodně v ceně, když jsi <F>zahlíd' svůj <G>zjev.
 
-\Ch{Dmi}{Už nejsi,} co jsi \Ch{G7}{býval,} tu \Ch{C}{tvář} nespraví ti \Ch{Ami}{masáž,}
+<Dmi>Už nejsi, co jsi <G7>býval, tu <C>tvář nespraví ti <Ami>masáž,
 
-\Ch{Dmi}{marně se,} hochu, \Ch{G7}{kasáš,} už nejsi \Ch{C}{lev} a velký \Ch{G7}{šéf.}
+<Dmi>marně se, hochu, <G7>kasáš, už nejsi <C>lev a velký <G7>šéf.
 \ks
 
 \zr
-\Ch{C}{Máš svůj} svět a \Ch{Ami}{ten se ti hroutí,}
+<C>Máš svůj svět a <Ami>ten se ti hroutí,
 
-to \Ch{C}{dávno} znám, já \Ch{A7}{prožil to} sám,
+to <C>dávno znám, já <A7>prožil to sám,
 
-\Ch{Dmi}{kráčíš} \Ch{G7}{dál a} \Ch{Dmi}{cesta se} \Ch{G7}{kroutí,}
+<Dmi>kráčíš <G7>dál a <Dmi>cesta se <G7>kroutí,
 
-až \Ch{Dmi7}{potkáš nás} \Ch{Emi}{na ní, tak} \Ch{G7}{přidej se} k \Ch{C}{nám.}
+až <Dmi7>potkáš nás <Emi>na ní, tak <G7>přidej se k <C>nám.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Wabi_Daněk____Píseň_co_mě_učil_listopad.tex
+++ b/tp-songs/01_folk/Wabi_Daněk____Píseň_co_mě_učil_listopad.tex
@@ -3,23 +3,23 @@
 \zp{Píseň, co mě učil listopad}{Wabi Daněk}
 
 \zs
-\Ch{C}{Málo} jím a \Ch{F}{málo} spím a \Ch{C}{málokdy} tě \Ch{F}{vídám}, 
+<C>Málo jím a <F>málo spím a <C>málokdy tě <F>vídám, 
 
-\Ch{C}{málokdy} si \Ch{Emi}{nechám} něco \Ch{Dmi}{zdát.}\Ch {G}{} 
+<C>málokdy si <Emi>nechám něco <Dmi>zdát.<G> 
 
-\Ch{F}{Doma} nemám \Ch{C}{stání}, už od \Ch{Ami}{jarního} \Ch{F}{tání} 
+<F>Doma nemám <C>stání, už od <Ami>jarního <F>tání 
 
-\Ch{B}{cítím}, že se blíží listo\Ch{C}{pad,} hm, hm, hm.
+<B>cítím, že se blíží listo<C>pad, hm, hm, hm.
 \ks
 
 \zr
-Listopado\Ch{B}{vý písně} \Ch{F}{od} léta už \Ch{C}{slýchám} 
+Listopado<B>vý písně <F>od léta už <C>slýchám 
 
-vítr \Ch{Dmi}{ledový} \Ch{F}{} přinesl je k \Ch{C}{nám} 
+vítr <Dmi>ledový <F> přinesl je k <C>nám 
 
-Tak mě neče\Ch{B}{kej,} dneska \Ch{F}{nikam} nepos\Ch{C}{píchám,}
+Tak mě neče<B>kej, dneska <F>nikam nepos<C>píchám,
 
-listopado\Ch{Dmi}{vý} \Ch{F}{} písni naslou\Ch{C}{chám.}
+listopado<Dmi>vý <F> písni naslou<C>chám.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Wabi_Daněk____Rosa_na_kolejích.tex
+++ b/tp-songs/01_folk/Wabi_Daněk____Rosa_na_kolejích.tex
@@ -5,33 +5,33 @@
 
 
 \zs
-\Ch{C}{Tak,} jako jazyk \Ch{F6}{stále} n\Ch{F#6}{ará}\Ch{G6}{ží}
+<C>Tak, jako jazyk <F6>stále n<F#6>ará<G6>ží
 
-na vylomený \Ch{C}{zub,}
+na vylomený <C>zub,
 
-tak se vracím \Ch{F6}{k svý}mu ná\Ch{F#6}{dra}\Ch{G6}{ží,}
+tak se vracím <F6>k svýmu ná<F#6>dra<G6>ží,
 
-abych šel zas \Ch{C}{dál.}
+abych šel zas <C>dál.
 
-{Přede} mnou \Ch{F6}{stí}ny se \Ch{G6}{plouží}
+{Přede} mnou <F6>stíny se <G6>plouží
 
-a \Ch{Ami}{nad} krajinou \Ch{F#dim}{krouží}
+a <Ami>nad krajinou <F#dim>krouží
 
-podivnej \Ch{F6}{pták,}\Ch{F#6}{} \Ch{G6}{pták} nebo \Ch{C}{mrak}.
+podivnej <F6>pták,<F#6> <G6>pták nebo <C>mrak.
 \ks
 
 \zr
-Tak do toho \Ch{F6}{šlápni}, ať \Ch{G6}{vidíš} kousek \Ch{C}{světa,}
+Tak do toho <F6>šlápni, ať <G6>vidíš kousek <C>světa,
 
-vzít do dlaní \Ch{F6}{dálku} \Ch{G6}{zase} jednou \Ch{C}{zkus,}
+vzít do dlaní <F6>dálku <G6>zase jednou <C>zkus,
 
-telegrafní \Ch{F6}{dráty} \Ch{G6}{hrajou} ti už \Ch{C}{léta}
+telegrafní <F6>dráty <G6>hrajou ti už <C>léta
 
-to nekonečně \Ch{F6}{dlou}\Ch{F#6}{hý} \Ch{G6}{mono}\Ch{F#6}{tón}\Ch{F6}{ní} \Ch{C}{blues.}
+to nekonečně <F6>dlou<F#6>hý <G6>mono<F#6>tón<F6>ní <C>blues.
 
 Je ráno, je ráno.
 
-/: Nohama \Ch{F6}{stí}\Ch{F#6}{ráš} \Ch{G6}{rosu} na \Ch{F#6}{ko-}\Ch{F6}{le-}\Ch{C}{jích.} :/
+/: Nohama <F6>stí<F#6>ráš <G6>rosu na <F#6>ko-<F6>le-<C>jích. :/
 \kr
 
 \zs
@@ -44,6 +44,6 @@ po kolejích táhnou bosí a na špagátu nosí
 celej svůj dům -- deku a rum.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Wabi_Daněk____Rosa_na_kolejích.tex
+++ b/tp-songs/01_folk/Wabi_Daněk____Rosa_na_kolejích.tex
@@ -31,7 +31,7 @@ to nekonečně <F6>dlou<F#6>hý <G6>mono<F#6>tón<F6>ní <C>blues.
 
 Je ráno, je ráno.
 
-/: Nohama <F6>stí<F#6>ráš <G6>rosu na <F#6>ko-<F6>le-<C>jích. :/
+/: Nohama <F6>stí<F#6>ráš <G6>rosu na <F#6>ko<F6>le<C>jích. :/
 \kr
 
 \zs

--- a/tp-songs/01_folk/Waldemar_Matuška____Jó_třešně_zrály.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Jó_třešně_zrály.tex
@@ -9,7 +9,7 @@ sladký <E7>třešně <Ami>zrály a <F>vlahej <G7>vítr <C>vál, <G>
 
 <C>a já k <G7>horám v <Ami>dáli, k těm <Dmi7>modrejm <G7>horám v <C>dáli,
 
-sluncem, <E7>který <Ami>pá-<F>lí, tou <Dmi7>dobou <G7>stádo <C>hnal.
+sluncem, <E7>který <Ami>pá<F>lí, tou <Dmi7>dobou <G7>stádo <C>hnal.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Waldemar_Matuška____Jó_třešně_zrály.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Jó_třešně_zrály.tex
@@ -3,13 +3,13 @@
 \zp{Jó, třešně zrály}{Waldemar Matuška}
 
 \zs
-\Ch{C}{Jó,} třešně zrály, \Ch{G7}{zrovna} třešně \Ch{C}{zrály,}
+<C>Jó, třešně zrály, <G7>zrovna třešně <C>zrály,
 
-sladký \Ch{E7}{třešně} \Ch{Ami}{zrály a} \Ch{F}{vlahej} \Ch{G7}{vítr} \Ch{C}{vál,} \Ch{G}{}
+sladký <E7>třešně <Ami>zrály a <F>vlahej <G7>vítr <C>vál, <G>
 
-\Ch{C}{a já k} \Ch{G7}{horám v} \Ch{Ami}{dáli, k těm} \Ch{Dmi7}{modrejm} \Ch{G7}{horám v} \Ch{C}{dáli,}
+<C>a já k <G7>horám v <Ami>dáli, k těm <Dmi7>modrejm <G7>horám v <C>dáli,
 
-sluncem, \Ch{E7}{který} \Ch{Ami}{pá-}\Ch{F}{lí, tou} \Ch{Dmi7}{dobou} \Ch{G7}{stádo} \Ch{C}{hnal.}
+sluncem, <E7>který <Ami>pá-<F>lí, tou <Dmi7>dobou <G7>stádo <C>hnal.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Waldemar_Matuška____Růže_z_Texasu.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Růže_z_Texasu.tex
@@ -3,23 +3,23 @@
 \zp{Růže z Texasu}{Waldemar Matuška}
 
 \zs
-Je\Ch{E}{du} vám takhle \Ch{E7}{stezkou} dát \Ch{A}{koňům} v řece \Ch{E}{pít,}
+Je<E>du vám takhle <E7>stezkou dát <A>koňům v řece <E>pít,
 
-v tom potkám holku \Ch{C#mi}{hezkou,} až \Ch{F#}{jsem} vám z koně \Ch{H7}{slít,}
+v tom potkám holku <C#mi>hezkou, až <F#>jsem vám z koně <H7>slít,
 
-měla \Ch{E}{kytku} žlutejch \Ch{E7}{květů}, snad \Ch{A}{růží}, co já \Ch{E}{vím,}
+měla <E>kytku žlutejch <E7>květů, snad <A>růží, co já <E>vím,
 
-znám plno hezkejch \Ch{C#mi}{ženskejch} k světu, ale \Ch{H7}{tahle} hraje \Ch{E}{prim.}
+znám plno hezkejch <C#mi>ženskejch k světu, ale <H7>tahle hraje <E>prim.
 \ks
 
 \zr
-\Ch{E7}{Kdo} si \Ch{A}{kazíš} smysl pro krásu, ať s \Ch{E}{tou} a nebo s tou,
+<E7>Kdo si <A>kazíš smysl pro krásu, ať s <E>tou a nebo s tou,
 
-Dej si říct, že kromě \Ch{C#mi}{Texasu} tyhle \Ch{F#}{růže} neros\Ch{H7}{tou.}
+Dej si říct, že kromě <C#mi>Texasu tyhle <F#>růže neros<H7>tou.
 
-Ať máš \Ch{E}{kolťák} nízko \Ch{E7}{u pa}su, ať jsi \Ch{A}{třeba} zloděj \Ch{E}{stád,}
+Ať máš <E>kolťák nízko <E7>u pasu, ať jsi <A>třeba zloděj <E>stád,
 
-tyhle žlutý růže z \Ch{C#mi}{Texasu} budeš \Ch{H7}{pořád} mít už \Ch{E}{rád.}
+tyhle žlutý růže z <C#mi>Texasu budeš <H7>pořád mít už <E>rád.
 \kr
 
 \zs
@@ -42,7 +42,7 @@ Když si to tak v hlavě srovnám, co víc jsem si moh' přát?
 Ona byla krásná, štíhlá, rovná, zkrátka akorát.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Od těch dob svý stádo koní sem vodím k řece pít
@@ -54,6 +54,6 @@ Když večer banjo ladím a zpívám si tu svou,
 tak v duchu pořád hladím tu růži voňavou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/01_folk/Waldemar_Matuška____Sbohem_lásko.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Sbohem_lásko.tex
@@ -3,23 +3,23 @@
 \zp{Sbohem, lásko}{Waldemar Matuška}
 
 \zs
-Ať bylo \Ch{C}{mně} i \Ch{F}{jí tak} \Ch{G}{šestnáct} \Ch{C}{let,} \Ch{F}{} \Ch{G}{}
+Ať bylo <C>mně i <F>jí tak <G>šestnáct <C>let, <F> <G>
 
-zeleným \Ch{C}{údolím} \Ch{Ami}{jsem si ji} \Ch{Dmi}{ved',} \Ch{G7}{}
+zeleným <C>údolím <Ami>jsem si ji <Dmi>ved', <G7>
 
-\Ch{C}{byla krásná,} to \Ch{C7}{vím,} a já měl \Ch{F}{strach,} jak \Ch{Fmi}{říct,}
+<C>byla krásná, to <C7>vím, a já měl <F>strach, jak <Fmi>říct,
 
-když na řa\Ch{C}{sách} slzu \Ch{G7}{má velkou} jako \Ch{C}{hrách:} \Ch{F}{} \Ch{C}{}
+když na řa<C>sách slzu <G7>má velkou jako <C>hrách: <F> <C>
 \ks
 
 \zr
-\uv{\Ch{C7}{Sbohem,} \Ch{F}{lásko,} nech mě \Ch{Fmi}{jít, nech mě} \Ch{Emi}{jít, bude} \Ch{Ami}{klid,}
+\uv{<C7>Sbohem, <F>lásko, nech mě <Fmi>jít, nech mě <Emi>jít, bude <Ami>klid,
 
-žádnej \Ch{Dmi}{pláč už nespra}\Ch{G7}{ví ty mý} \Ch{C}{nohy} toula\Ch{C7}{vý,}
+žádnej <Dmi>pláč už nespra<G7>ví ty mý <C>nohy toula<C7>vý,
 
-já tě \Ch{F}{vážně} měl moc \Ch{Fmi}{rád, co ti} \Ch{Emi}{víc můžu} \Ch{Ami}{dát?}
+já tě <F>vážně měl moc <Fmi>rád, co ti <Emi>víc můžu <Ami>dát?
 
-Nejsem \Ch{Dmi}{žádnej ide}\Ch{G7}{ál, tak nech mě} \Ch{C}{jít zas} \Ch{F}{o dům} \Ch{C}{dál.}}
+Nejsem <Dmi>žádnej ide<G7>ál, tak nech mě <C>jít zas <F>o dům <C>dál.}
 \kr
 
 \zs

--- a/tp-songs/01_folk/Waldemar_Matuška____Slavíci_z_Madridu.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Slavíci_z_Madridu.tex
@@ -2,28 +2,28 @@
 
 \zp{Slavíci z Madridu}{Waldemar Matuška}
 
-/: \Ch{Ami}{La la la la la la} \Ch{Emi}{la...} \Ch{H7}{} \Ch{Emi}{} :/
+/: <Ami>La la la la la la <Emi>la... <H7> <Emi> :/
 
 \zs
-\Ch{Emi}{Nebe} je modrý a \Ch{H7}{zlatý}, bílá sluneční \Ch{Emi}{záře,}
+<Emi>Nebe je modrý a <H7>zlatý, bílá sluneční <Emi>záře,
 
-horko a sváteční \Ch{H7}{šaty}, vřava a zpocený \Ch{Emi}{tváře.}
+horko a sváteční <H7>šaty, vřava a zpocený <Emi>tváře.
 
-Vím, co bude se \Ch{H7}{dít}, býk už se v ohradě \Ch{Emi}{vzpíná,}
+Vím, co bude se <H7>dít, býk už se v ohradě <Emi>vzpíná,
 
-kdo chce, ten může \Ch{H7}{jít,} já si dám sklenici \Ch{Emi}{vína.}  \Ch{E7}{}
+kdo chce, ten může <H7>jít, já si dám sklenici <Emi>vína. <E7>
 \ks
 
 \zr
-\Ch{Ami}{Žízeň} je veliká, \Ch{Emi}{život} mi utíká,
+<Ami>Žízeň je veliká, <Emi>život mi utíká,
 
-\Ch{H7}{nechte} mě příjemně \Ch{Emi}{snít}, \Ch{E7}{}
+<H7>nechte mě příjemně <Emi>snít, <E7>
 
-\Ch{Ami}{ve stínu} pod fíky \Ch{Emi}{poslouchat} slavíky,
+<Ami>ve stínu pod fíky <Emi>poslouchat slavíky,
 
-\Ch{H7}{zpívat} si s nima a \Ch{Emi}{pít.} \Ch{E7}{Jó,}
+<H7>zpívat si s nima a <Emi>pít. <E7>Jó,
 
-/: \Ch{Ami}{La la la...} \Ch{Emi}{} \Ch{H7}{} \Ch{Emi}{} :/
+/: <Ami>La la la... <Emi> <H7> <Emi> :/
 
 \kr
 
@@ -37,7 +37,7 @@ dobře vím, co znamená pád do nástrah dívčího klína,
 někdo má pletky rád, já si dám sklenici vína.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Nebe je modrý a zlatý, ženy krásný a cudný,
@@ -49,7 +49,7 @@ zmoudřel jsem stranou od lidí, jsem jak ta zahrada stinná,
 kdo chce, ať mi závidí, já si dám sklenici vína.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Waldemar_Matuška____Už_koníček_pádí.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Už_koníček_pádí.tex
@@ -3,13 +3,13 @@
 \zp{Už koníček pádí}{Waldemar Matuška}
 
 \zs
-Znám \Ch{G7}{zem plnou} \Ch{C}{mlíka} a buclatejch \Ch{G}{krav,}
+Znám <G7>zem plnou <C>mlíka a buclatejch <G>krav,
 
-kde proud řeky \Ch{D7}{stříká} na dřevěnej \Ch{G}{splav.}
+kde proud řeky <D7>stříká na dřevěnej <G>splav.
 
-Mám \Ch{G7}{jediný} \Ch{C}{přání,} snům ostruhy \Ch{G}{dát}
+Mám <G7>jediný <C>přání, snům ostruhy <G>dát
 
-a pod známou \Ch{D7}{strání} zas kuličky \Ch{G}{hrát.}
+a pod známou <D7>strání zas kuličky <G>hrát.
 \ks
 
 \zr

--- a/tp-songs/01_folk/Waldemar_Matuška____Vítr_to_ví.tex
+++ b/tp-songs/01_folk/Waldemar_Matuška____Vítr_to_ví.tex
@@ -3,23 +3,23 @@
 \zp{Vítr to ví}{Waldemar Matuška}
 
 \zs
-\Ch{C}{Míle} a \Ch{F}{míle} jsou \Ch{C}{cest,} které \Ch{Ami}{znám,}
+<C>Míle a <F>míle jsou <C>cest, které <Ami>znám,
 
-jdou \Ch{C}{trávou} a \Ch{F}{úbočím} \Ch{G}{skal,}
+jdou <C>trávou a <F>úbočím <G>skal,
 
-\Ch{C}{jsou} cesty \Ch{F}{zpátky} a \Ch{C}{jsou} cesty \Ch{Ami}{tam}
+<C>jsou cesty <F>zpátky a <C>jsou cesty <Ami>tam
 
-a \Ch{C}{já na} všech s \Ch{F}{vámi} \Ch{G}{stál.}
+a <C>já na všech s <F>vámi <G>stál.
 
-\Ch{C}{Proč} ale \Ch{F}{blátem} nám \Ch{C}{kázaly} \Ch{Ami}{vést}
+<C>Proč ale <F>blátem nám <C>kázaly <Ami>vést
 
-a \Ch{C}{špínou} si \Ch{F}{třísniti} \Ch{G}{šat?}
+a <C>špínou si <F>třísniti <G>šat?
 \ks
 
 \zr
-To \Ch{F}{ví snad jen} \Ch{G}{déšť} a \Ch{C}{vítr kolem} \Ch{Ami}{nás,}
+To <F>ví snad jen <G>déšť a <C>vítr kolem <Ami>nás,
 
-ten \Ch{F}{vítr,} co \Ch{G}{začal} právě \Ch{C}{vát.}
+ten <F>vítr, co <G>začal právě <C>vát.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Zuzana_Navarová____Andělská.tex
+++ b/tp-songs/01_folk/Zuzana_Navarová____Andělská.tex
@@ -3,11 +3,11 @@
 \zp{Andělská}{Zuzana Navarová}
 
 \zs
-\Ch{A}{Bože,} \Ch{Hmi7}{podej} mi ještě ten \Ch{Amaj7}{kalich,} \Ch{Hmi7}{ }
-to \Ch{A}{víno,} co s \Ch{Hmi7/F#}{nocí se měnívá} \Ch{C#mi7}{na líh.} \Ch{C#7}{ }
-Snad \Ch{F#mi}{nad ránem na} dně se \Ch{F#mi}{dočtu,}
-že \Ch{F#mi7}{v kastlíku andělskou} \Ch{D#mi7}{počtu} mám. \Ch{Dmaj7}{ }
-\Ch{Hmi/F#}{Tu ru tu} \Ch{E}{tuu}
+<A>Bože, <Hmi7>podej mi ještě ten <Amaj7>kalich, <Hmi7> 
+to <A>víno, co s <Hmi7/F#>nocí se měnívá <C#mi7>na líh. <C#7> 
+Snad <F#mi>nad ránem na dně se <F#mi>dočtu,
+že <F#mi7>v kastlíku andělskou <D#mi7>počtu mám. <Dmaj7> 
+<Hmi/F#>Tu ru tu <E>tuu
 \ks
 
 \zs
@@ -21,12 +21,12 @@ Tu ru tu tu, zatím.
 \ks
 
 \zr
-\Ch{A}{Počítám} \Ch{Hmi7}{nebe} \Ch{C#mi7}{světla}, kam \Ch{Hmi7}{nedostanu.}
+<A>Počítám <Hmi7>nebe <C#mi7>světla, kam <Hmi7>nedostanu.
 
-\Ch{A}{Miluju} \Ch{C#mi7}{tebe a pak} \Ch{Hmi7/F#}{usnu a} \Ch{E}{vstanu.}
+<A>Miluju <C#mi7>tebe a pak <Hmi7/F#>usnu a <E>vstanu.
 
-A tak \Ch{A}{tu} \Ch{Hmi7}{ru tu} \Ch{C#mi7}{tuu} \Ch{Hmi7}{ }
-\Ch{A}{ } \Ch{C#mi7}{ } \Ch{Hmi7/F#}{ } \Ch{E}{ }
+A tak <A>tu <Hmi7>ru tu <C#mi7>tuu <Hmi7> 
+<A> <C#mi7> <Hmi7/F#> <E> 
 \kr
 
 \zs

--- a/tp-songs/01_folk/Zuzana_Navarová____Sedávám_na_domovních_schodech.tex
+++ b/tp-songs/01_folk/Zuzana_Navarová____Sedávám_na_domovních_schodech.tex
@@ -3,13 +3,13 @@
 \zp{Sedávám na domovních schodech}{Zuzana Navarová}
 
 \zs
-\Ch{C}{Sedá}\Ch{C#dim}{vám} \Ch{Dmi7}{na domovních} \Ch{G7}{schodech,}
+<C>Sedá<C#dim>vám <Dmi7>na domovních <G7>schodech,
 
-\Ch{C}{zpívá}\Ch{C#dim}{vám v} \Ch{Dmi7}{krásných cizích} \Ch{G7}{slovech,} 
+<C>zpívá<C#dim>vám v <Dmi7>krásných cizích <G7>slovech, 
 
-\Ch{C7}{kterým} jenom \Ch{H6}{sama} \Ch{B7}{rozu}\Ch{A7}{mím,}
+<C7>kterým jenom <H6>sama <B7>rozu<A7>mím,
 
-z \Ch{D9}{komínu} \Ch{G7}{stoupá} \Ch{C6}{dým.} \Ch{G7}{}
+z <D9>komínu <G7>stoupá <C6>dým. <G7>
 \ks
 
 \zs
@@ -23,13 +23,13 @@ z komínu stoupá dým.
 \ks
 
 \zr
-\Ch{E7}{Všechna} hnízda šla už spát, je nutno myslet na návrat,
+<E7>Všechna hnízda šla už spát, je nutno myslet na návrat,
 
-\Ch{Ami}{večer}\Ch{E7}{ní zvony} \Ch{Ami}{znějí.}
+<Ami>večer<E7>ní zvony <Ami>znějí.
 
-\Ch{D7}{Zvolna nota za notou} \Ch{D9}{kráčí svojí} \Ch{D7}{samotou}
+<D7>Zvolna nota za notou <D9>kráčí svojí <D7>samotou
 
-\Ch{F9}{jako černou} \Ch{D9}{závě}\Ch{G7}{jí.}
+<F9>jako černou <D9>závě<G7>jí.
 \kr
 
 \zs
@@ -56,11 +56,11 @@ zpívávám pomalu a líně
 
 neznámá blues hlasem zastřeným,
 
-z \Ch{D9}{komínu} \Ch{G7}{stoupá} \Ch{C}{dým,} \Ch{A7}{}
+z <D9>komínu <G7>stoupá <C>dým, <A7>
  
-z \Ch{D9}{komínu} \Ch{G7}{stoupá} \Ch{C}{dým,} \Ch{A7}{}
+z <D9>komínu <G7>stoupá <C>dým, <A7>
  
-z \Ch{D9}{komínu} \Ch{G7}{stoupá} \Ch{C}{dým.}
+z <D9>komínu <G7>stoupá <C>dým.
 \ks
 
 \kp

--- a/tp-songs/01_folk/Zuzana_Navarová____Somrkrálka_Blues.tex
+++ b/tp-songs/01_folk/Zuzana_Navarová____Somrkrálka_Blues.tex
@@ -2,35 +2,35 @@
 
 \zp{Somrkrálka blues}{Zuzana Navarová}
 
-2× /: \Ch{Cmaj7}{} \Ch{Dmi7}{} \Ch{Emi7}{} \Ch{Dmi7}{} :/
+2× /: <Cmaj7> <Dmi7> <Emi7> <Dmi7> :/
 
 \zs
-\Ch{Cmaj7}{Vlasy} až na paty, \Ch{H7}{třepivý} záplaty,
+<Cmaj7>Vlasy až na paty, <H7>třepivý záplaty,
 
-\Ch{Cmaj7}{má řeči} nahatý \Ch{A7}{somrkrálka-blues.}
+<Cmaj7>má řeči nahatý <A7>somrkrálka-blues.
 
-V \Ch{Dmi7}{kapse jako} \Ch{G}{proprietu} 
+V <Dmi7>kapse jako <G>proprietu 
 
-\Ch{Dmi7}{jako jednu} \Ch{G}{cigaretu,} 
+<Dmi7>jako jednu <G>cigaretu, 
 
-\Ch{Cmaj7}{vločky sbírá} \Ch{A7}{do baretu,} 
+<Cmaj7>vločky sbírá <A7>do baretu, 
 
-\Ch{Dmi7}{když má} léto \Ch{G7}{půst.} 
+<Dmi7>když má léto <G7>půst. 
 
 \ks
 
 \zr
-\Ch{Cmaj7}{Kantýny}, čekárny, \Ch{A7}{básničky} na koleně 
+<Cmaj7>Kantýny, čekárny, <A7>básničky na koleně 
 
-\Ch{Dmi7}{o paní} z \Ch{G7}{pekárny,} 
+<Dmi7>o paní z <G7>pekárny, 
 
-\Ch{Dmi7}{co má se} \Ch{G7}{čím dál} stejně.
+<Dmi7>co má se <G7>čím dál stejně.
 
-\Ch{Cmaj7}{Uprostřed} pohádky, \Ch{A7}{nevíme,} jak to bylo,
+<Cmaj7>Uprostřed pohádky, <A7>nevíme, jak to bylo,
 
-\Ch{Dmi7}{cukrovkář} \Ch{Emi7}{nedopil} 
+<Dmi7>cukrovkář <Emi7>nedopil 
 
-\Ch{Fmaj7}{třetinkový} \Ch{G}{pivo.} \Ch{G5+}{}
+<Fmaj7>třetinkový <G>pivo. <G5+>
 \kr
 
 \zs
@@ -53,6 +53,6 @@ má řeči nahatý ta somrkrálka-blues.
 
 \zr \kr
 
-2× /: \Ch{Cmaj7}{} ~ \Ch{Dmi7}{} ~ \Ch{Emi7}{} \Ch{Dmi7}{} :/
+2× /: <Cmaj7> ~ <Dmi7> ~ <Emi7> <Dmi7> :/
 
 \kp

--- a/tp-songs/01_folk/lidová____A_te_Rehradice.tex
+++ b/tp-songs/01_folk/lidová____A_te_Rehradice.tex
@@ -3,11 +3,11 @@
 \zp{A te Rehradice}{(lidová)}
 
 \zs
-\Ch{Dmi}{A te} Rehradice, \Ch{C}{na} pěkný \Ch{F}{rovině},
+<Dmi>A te Rehradice, <C>na pěkný <F>rovině,
 
-\Ch{G}{teče} tam \Ch{Ami}{voděnka} \Ch{Dmi}{dolů} \Ch{G}{po} dě\Ch{C}{dině.}
+<G>teče tam <Ami>voděnka <Dmi>dolů <G>po dě<C>dině.
 
-\Ch{Gmi}{Je pě}\Ch{Ami}{kná}, je \Ch{Dmi}{čistá.}
+<Gmi>Je pě<Ami>kná, je <Dmi>čistá.
 \ks
 
 \zs

--- a/tp-songs/01_folk/lidová____Kdyby_tady_byla_taková_panenka.tex
+++ b/tp-songs/01_folk/lidová____Kdyby_tady_byla_taková_panenka.tex
@@ -3,11 +3,11 @@
 \zp{Kdyby tady byla taková panenka}{(lidová)}
 
 \zs
-/: \Ch{D}{Kdyby} tady byla taková panenka,
-\Ch{A7}{která} by mě chtě\Ch{D}{la,} :/
+/: <D>Kdyby tady byla taková panenka,
+<A7>která by mě chtě<D>la, :/
 
-/: kte\Ch{G}{rá} by mi chtěla sy\Ch{D}{na} vychovati,
-\Ch{A7}{přitom} pannou bý\Ch{D}{ti.} :/
+/: kte<G>rá by mi chtěla sy<D>na vychovati,
+<A7>přitom pannou bý<D>ti. :/
 \ks
 
 \zs

--- a/tp-songs/01_folk/neznámý____Balada_o_princezně_a_o_hradu.tex
+++ b/tp-songs/01_folk/neznámý____Balada_o_princezně_a_o_hradu.tex
@@ -2,9 +2,9 @@
 
 \zp{Balada o princezně a o hradu}{(neznámý)}
 \zs
-\Ch{C}{Pov}ím vám jednu \Ch{F}{bal}adu o \Ch{G7}{pri}ncezně a \Ch{C}{o hra}du,
+<C>Povím vám jednu <F>baladu o <G7>princezně a <C>o hradu,
 
-bala\Ch{Ami}{daj}dajdaj bala\Ch{Dmi}{daj}dajdaj, o \Ch{G7}{pri}ncezně a \Ch{C}{o hr}adu.
+bala<Ami>dajdajdaj bala<Dmi>dajdajdaj, o <G7>princezně a <C>o hradu.
 \ks
 \zs
 Žila jedna princezna, moc krásná a moc líbezná...

--- a/tp-songs/01_folk/neznámý____Kolo_rovno_hovno.tex
+++ b/tp-songs/01_folk/neznámý____Kolo_rovno_hovno.tex
@@ -3,11 +3,11 @@
 \zp{Kolo, rovno, hovno}{(neznámý)}
 
 \zs
-\Ch{D}{Kolo}, rovno, hovno, jak \Ch{A7}{se to} rýmu\Ch{D}{je,}
-kolo, rovno, hovno, jak \Ch{G}{se} to rýmu\Ch{D}{je!}
+<D>Kolo, rovno, hovno, jak <A7>se to rýmu<D>je,
+kolo, rovno, hovno, jak <G>se to rýmu<D>je!
 
-kolo jede \Ch{A7}{rovno,} rovno přes to \Ch{D}{hovno,}
-rovno přes to hovno, tak \Ch{A7}{se to} rýmu\Ch{D}{je.}
+kolo jede <A7>rovno, rovno přes to <D>hovno,
+rovno přes to hovno, tak <A7>se to rýmu<D>je.
 \ks
 \zs
 /: Kostel, prdel, papír, jak se to rýmuje? :/

--- a/tp-songs/01_folk/neznámý____Okoř.tex
+++ b/tp-songs/01_folk/neznámý____Okoř.tex
@@ -3,23 +3,23 @@
 \zp{Okoř}{(neznámý)}
 
 \zs
-\Ch{D}{Na} Okoř je cesta jako žádná ze sta, \Ch{A7}{vroubená} je stroma\Ch{D}{ma.}
+<D>Na Okoř je cesta jako žádná ze sta, <A7>vroubená je stroma<D>ma.
 
-\Ch{D}{Když} du po ní v létě samoten ve světě, \Ch{A7}{sotva} pletu noha\Ch{D}{ma.}
+<D>Když du po ní v létě samoten ve světě, <A7>sotva pletu noha<D>ma.
 
-\Ch{G}{Na} konci té cesty \Ch{D}{trnité} \Ch{E}{stojí} krčma jako \Ch{A7}{hrad,}
+<G>Na konci té cesty <D>trnité <E>stojí krčma jako <A7>hrad,
 
-\Ch{D}{tam} zapadli trampi, (tam se trampi sešli,) hladoví a sešlí, \Ch{A7}{začli} sobě noto\Ch{D}{vat.}
+<D>tam zapadli trampi, (tam se trampi sešli,) hladoví a sešlí, <A7>začli sobě noto<D>vat.
 \ks
 
 \zr
-\Ch{D}{Na} hradě Okoři \Ch{A7}{světla} už nehoří, \Ch{D}{Bílá} paní \Ch{A7}{šla} už dávno \Ch{D}{spát.}
+<D>Na hradě Okoři <A7>světla už nehoří, <D>Bílá paní <A7>šla už dávno <D>spát.
 
-\Ch{D}{Ona} měla ve zvyku \Ch{A7}{podle} svého budíku \Ch{D}{o půlnoci} \Ch{A7}{chodit} straší\Ch{D}{vat.}
+<D>Ona měla ve zvyku <A7>podle svého budíku <D>o půlnoci <A7>chodit straší<D>vat.
 
-\Ch{G}{Od} těch dob, co jsou tam \Ch{D}{trampové,} \Ch{E}{nesmí} z hradu \Ch{A7}{pryč,}
+<G>Od těch dob, co jsou tam <D>trampové, <E>nesmí z hradu <A7>pryč,
 
-\Ch{D}{a tak} dole v podhradí \Ch{A7}{se šerifem} dovádí, \Ch{D}{on ji} sebral \Ch{A7}{od komnaty} \Ch{D}{klíč.}
+<D>a tak dole v podhradí <A7>se šerifem dovádí, <D>on ji sebral <A7>od komnaty <D>klíč.
 \kr
 
 \zs

--- a/tp-songs/01_folk/neznámý____Tři_citrónky.tex
+++ b/tp-songs/01_folk/neznámý____Tři_citrónky.tex
@@ -3,19 +3,19 @@
 \zp{Tři citrónky}{(neznámý)}
 
 \zs
-V \Ch{C}{jedné} \Ch{Ami}{mořské} \Ch{Dmi}{pusti}\Ch{G7}{ně}
-\Ch{C}{ztroskotal} \Ch{Ami}{parník} v \Ch{Dmi}{hlubi}\Ch{G7}{ně,}
+V <C>jedné <Ami>mořské <Dmi>pusti<G7>ně
+<C>ztroskotal <Ami>parník v <Dmi>hlubi<G7>ně,
 
-\Ch{C}{jenom} tři \Ch{Ami}{malé} \Ch{Dmi}{citrón}\Ch{G7}{ky}
-zůstaly na hladi\Ch{C}{ně.}
+<C>jenom tři <Ami>malé <Dmi>citrón<G7>ky
+zůstaly na hladi<C>ně.
 \ks
 
 \zr
-\Ch{C}{Ry}baroba \Ch{Ami}{rybaroba} \Ch{Dmi}{rybaroba} \Ch{G7}{čuču,}
+<C>Rybaroba <Ami>rybaroba <Dmi>rybaroba <G7>čuču,
 
-\Ch{C}{rybaroba} \Ch{Ami}{rybaroba} \Ch{Dmi}{rybaroba} \Ch{G7}{čuču,}
+<C>rybaroba <Ami>rybaroba <Dmi>rybaroba <G7>čuču,
 
-zůstaly na hladi\Ch{C}{ně}
+zůstaly na hladi<C>ně
 \kr
 
 \zs
@@ -24,7 +24,7 @@ Jeden z nich povídá: \uv{Přátelé, netvařte se tak kysele!
 Vždyť je to přece veselé, že nám patří moře celé!}
 \ks
 
-\zr  ... že nám patří moře celé. \kr
+\zr ... že nám patří moře celé. \kr
 
 \zs
 A tak se citronky plavily dál, jeden jim k tomu na kytaru hrál.
@@ -32,7 +32,7 @@ A tak se citronky plavily dál, jeden jim k tomu na kytaru hrál.
 A tak se plavily do dáli až na ostrov korálový.
 \ks
 
-\zr  ... až na ostrov korálový. \kr
+\zr ... až na ostrov korálový. \kr
 
 \zs
 Tam je však stihla nehoda zlá, byla to mořská příšera.
@@ -40,7 +40,7 @@ Tam je však stihla nehoda zlá, byla to mořská příšera.
 Sežrala citrónky i s kůrou a skončila tak baladu mou.
 \ks
 
-\zr  ... a skončila tak baladu mou. \kr
+\zr ... a skončila tak baladu mou. \kr
 
 \kp
 

--- a/tp-songs/01_folk/Čechomor____Mezi_horami.tex
+++ b/tp-songs/01_folk/Čechomor____Mezi_horami.tex
@@ -3,12 +3,12 @@
 \zp{Mezi horami}{Čechomor}
 
 \zs
-/: \Ch{Dmi}{Mezi} horami
-lipka \Ch{C}{zele}\Ch{Dmi}{ná, :/}
+/: <Dmi>Mezi horami
+lipka <C>zele<Dmi>ná, :/
 
-/: \Ch{F}{zabili} Janka,
-\Ch{C}{Janíčka,} \Ch{Dmi}{Janka,}
-miesto \Ch{C}{jele}\Ch{Dmi}{ňa. :/}
+/: <F>zabili Janka,
+<C>Janíčka, <Dmi>Janka,
+miesto <C>jele<Dmi>ňa. :/
 \ks
 
 \zs

--- a/tp-songs/01_folk/Čechomor____Proměny.tex
+++ b/tp-songs/01_folk/Čechomor____Proměny.tex
@@ -3,13 +3,13 @@
 \zp{Proměny}{Čechomor}
 
 \zs
-\Ch{Ami}{Darmo} sa ty trápíš, \Ch{G}{můj} milý sy\Ch{C}{nečku}, nenosím já tebe, \Ch{Dmi}{nenosím} v sr\Ch{Ami}{déčku.}
+<Ami>Darmo sa ty trápíš, <G>můj milý sy<C>nečku, nenosím já tebe, <Dmi>nenosím v sr<Ami>déčku.
 
-A já tvo\Ch{G}{ja} \Ch{C}{ne}\Ch{G}{bu}\Ch{C}{du} \Ch{Dmi}{ani je}dnu \Ch{E}{hodi}\Ch{Ami}{nu.}
+A já tvo<G>ja <C>ne<G>bu<C>du <Dmi>ani jednu <E>hodi<Ami>nu.
 \ks
 
 \zs
-Copak sobě myslíš, má milá panenko?  Vždyť ty si to moje rozmilé srdénko.
+Copak sobě myslíš, má milá panenko? Vždyť ty si to moje rozmilé srdénko.
 
 A ty musíš býti má, lebo mi tě Pán Bůh dá.
 \ks
@@ -39,7 +39,7 @@ A ty přece budeš má, lebo mi tě Pán Bůh dá.
 \ks
 
 \zr
-\Ch{Ami}{ } \Ch{F}{ } \Ch{C}{ } \Ch{F}{ } \Ch{C}{ } \Ch{G}{}
+<Ami> <F> <C> <F> <C> <G>
 \kr
 
 \zs
@@ -67,8 +67,8 @@ A ty musíš býti má, lebo mi tě Pán Bůh dá
 \ks
 
 \zr
-\Ch{Ami}{} \Ch{Dmi7}{} \Ch{C}{} \Ch{Dmi7}{} \Ch{C}{} \Ch{G}{} ~~
-\Ch{Ami}{} \Ch{Dmi7}{} \Ch{C}{} \Ch{Dmi7}{} \Ch{C}{} \Ch{G}{}
+<Ami> <Dmi7> <C> <Dmi7> <C> <G> ~~
+<Ami> <Dmi7> <C> <Dmi7> <C> <G>
 \kr
 
 \kp

--- a/tp-songs/01_folk/Čechomor____Včelín.tex
+++ b/tp-songs/01_folk/Čechomor____Včelín.tex
@@ -3,19 +3,19 @@
 \zp{Včelín}{Čechomor}
 
 \zs
-/: \Ch{Ami}{Sousedovic} Věra \Ch{G}{má}
+/: <Ami>Sousedovic Věra <G>má
 
-\Ch{Ami}{jako} žádná \Ch{G}{jiná,}
+<Ami>jako žádná <G>jiná,
 
-\Ch{Ami}{viděl} jsem ji včera \Ch{G}{máchat}
+<Ami>viděl jsem ji včera <G>máchat
 
-\Ch{Ami}{dole} u \Ch{Emi}{vče}\Ch{Ami}{lína.} :/
+<Ami>dole u <Emi>vče<Ami>lína. :/
 \ks
 
 \zr
-/: \Ch{Ami}{Dole} dole dole dole, \Ch{C}{dole} dole dole,
+/: <Ami>Dole dole dole dole, <C>dole dole dole,
 
-\Ch{G}{hej} dole dole dole, dole u vče\Ch{Ami}{lína.} :/
+<G>hej dole dole dole, dole u vče<Ami>lína. :/
 \kr
 
 \zs
@@ -28,7 +28,7 @@ nic ti nepomůže spát,
 skočím třeba do sna. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 /: Ať v poledne radost má,
@@ -40,7 +40,7 @@ když se na mě podívá,
 dám jí co si přeje. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 /: Líčka jako růže máš,
@@ -52,7 +52,7 @@ ať přikázat vašim dá,
 aby mi tě dali. :/
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/01_folk/Žalman____Jdem_zpátky_do_lesů.tex
+++ b/tp-songs/01_folk/Žalman____Jdem_zpátky_do_lesů.tex
@@ -3,29 +3,29 @@
 \zp{Jdem zpátky do lesů}{Žalman}
 
 \zs
-\Ch{Ami7}{Sedím} na kolejích,
+<Ami7>Sedím na kolejích,
 
-\Ch{D7}{které} nikam neve\Ch{G}{dou,} \Ch{C}{} \Ch{G}{}
+<D7>které nikam neve<G>dou, <C> <G>
 
-\Ch{Ami7}{koukám} na kopretinu, jak \Ch{D7}{miluje se} s lebe\Ch{G}{dou.}
+<Ami7>koukám na kopretinu, jak <D7>miluje se s lebe<G>dou.
 
-\Ch{Ami7}{Mraky} vzaly slunce \Ch{D7}{zase} pod svou ochra\Ch{G}{nu,} \Ch{Emi}{}
+<Ami7>Mraky vzaly slunce <D7>zase pod svou ochra<G>nu, <Emi>
 
-\Ch{Ami7}{jen ty} nejdeš, holka zlatá,
+<Ami7>jen ty nejdeš, holka zlatá,
 
-\Ch{D7}{kdypak} já tě dosta\Ch{G}{nu?} \Ch{D7}{}
+<D7>kdypak já tě dosta<G>nu? <D7>
 \ks
 
 \zr
-Z \Ch{G}{ráje,} my vyhnaní z \Ch{Emi}{ráje,}
+Z <G>ráje, my vyhnaní z <Emi>ráje,
 
-kde není už \Ch{Ami7}{místa,} \Ch{C7}{prej} něco se \Ch{G}{chystá.} \Ch{D7}{}
+kde není už <Ami7>místa, <C7>prej něco se <G>chystá. <D7>
 
-Z \Ch{G}{ráje,} nablýskaných \Ch{Emi}{plesů}
+Z <G>ráje, nablýskaných <Emi>plesů
 
-jdem zpátky do \Ch{Ami7}{lesů}
+jdem zpátky do <Ami7>lesů
 
-\Ch{C}{za} nějaký \Ch{G}{čas.} \Ch{D7}{}
+<C>za nějaký <G>čas. <D7>
 \kr
 
 \zs

--- a/tp-songs/01_folk/Žalman____Já_písnička.tex
+++ b/tp-songs/01_folk/Žalman____Já_písnička.tex
@@ -3,25 +3,25 @@
 \zp{Já, písnička}{Žalman}
 
 \zs
-To \Ch{Ami}{já, zrozená} z nemoc\Ch{G}{ných} básníků,
+To <Ami>já, zrozená z nemoc<G>ných básníků,
 
-z tichých \Ch{Emi}{vět po} nocích utka\Ch{Ami}{ná,}
+z tichých <Emi>vět po nocích utka<Ami>ná,
 
-to \Ch{Ami}{já, zrozená,} není \Ch{G}{mi} do smíchu,
+to <Ami>já, zrozená, není <G>mi do smíchu,
 
-když mám \Ch{Emi}{být} pod cenou proda\Ch{Ami}{ná.}
+když mám <Emi>být pod cenou proda<Ami>ná.
 \ks
 
 \zr
-Kdo \Ch{C}{vás} obléká do ša\Ch{G}{tů} svatebních,
+Kdo <C>vás obléká do ša<G>tů svatebních,
 
-holky \Ch{Ami}{mý ztrace}\Ch{Ami/G}{ný, ztrace}\Ch{Ami/F}{ný?} \Ch{E7}{} 
+holky <Ami>mý ztrace<Ami/G>ný, ztrace<Ami/F>ný? <E7> 
 
-Ženich \Ch{Ami}{spí na růži,}
+Ženich <Ami>spí na růži,
 
-až ně\Ch{G}{kam} pod kůži 
+až ně<G>kam pod kůži 
 
-se můj \Ch{Emi}{strach} do klína schová\Ch{Ami}{vá.}
+se můj <Emi>strach do klína schová<Ami>vá.
 \kr
 
 \zs

--- a/tp-songs/01_folk/Žalman____Rána_v_trávě.tex
+++ b/tp-songs/01_folk/Žalman____Rána_v_trávě.tex
@@ -3,30 +3,30 @@
 \zp{Rána v trávě}{Žalman}
 
 \zr
-\Ch{Ami}{Každý} ráno boty \Ch{G}{zouval,}
-\Ch{Ami}{orosil} si nohy v \Ch{G}{trávě,}
+<Ami>Každý ráno boty <G>zouval,
+<Ami>orosil si nohy v <G>trávě,
 
-\Ch{Ami}{že se} lidi mají radi, \Ch{G}{doufal,}
-\Ch{Ami}{a pro}\Ch{Emi}{citli} \Ch{Ami}{právě.}
+<Ami>že se lidi mají radi, <G>doufal,
+<Ami>a pro<Emi>citli <Ami>právě.
 
-Každý ráno dlouze \Ch{G}{zíval,}
-\Ch{Ami}{utřel} čelo do ru\Ch{G}{kávu}
+Každý ráno dlouze <G>zíval,
+<Ami>utřel čelo do ru<G>kávu
 
-\Ch{Ami}{a při} chůzi tělem semtam \Ch{G}{kýval,}
-\Ch{Ami}{před} se\Ch{Emi}{bou} sta \Ch{Ami}{sáhů.}
+<Ami>a při chůzi tělem semtam <G>kýval,
+<Ami>před se<Emi>bou sta <Ami>sáhů.
 \kr
 
 \zs
-\Ch{C}{Poznal} \Ch{G}{Mora}\Ch{F}{věnku} \Ch{C}{krásnou}
+<C>Poznal <G>Mora<F>věnku <C>krásnou
 
-\Ch{Ami}{a ví}\Ch{G}{nečko} \Ch{C}{ze} zlata,
+<Ami>a ví<G>nečko <C>ze zlata,
 
-v Čechách \Ch{G}{slávu} \Ch{F}{muzi}\Ch{C}{kantů}
+v Čechách <G>slávu <F>muzi<C>kantů
 
-\Ch{Ami}{uma}\Ch{Emi}{zanou} \Ch{Ami}{od bláta.}
+<Ami>uma<Emi>zanou <Ami>od bláta.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Toužil najít studánečku
@@ -48,6 +48,6 @@ Abych já ti pravdu řekla,
 měl ses jindy narodit.}
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Aleš_Brichta____Dívka_s_perlami_ve_vlasech.tex
+++ b/tp-songs/02_pop_rock/Aleš_Brichta____Dívka_s_perlami_ve_vlasech.tex
@@ -3,23 +3,23 @@
 \zp{Dívka s perlami ve vlasech}{Aleš Brichta}
 
 \zs
-\Ch{Emi}{Zas} mě tu \Ch{D}{máš}, \Ch{Ami}{nějak} se \Ch{Emi}{mračíš},
-vybledlej \Ch{D}{smích} \Ch{Ami}{už ve} dve\Ch{Emi}{řích.}
+<Emi>Zas mě tu <D>máš, <Ami>nějak se <Emi>mračíš,
+vybledlej <D>smích <Ami>už ve dve<Emi>řích.
 
-S čelenkou z \Ch{D}{perel} \Ch{Ami}{svatozář} \Ch{Emi}{ztrácíš},
-kolik se \Ch{D}{platí} \Ch{Ami}{za vlá}čnej \Ch{Emi}{hřích?}
+S čelenkou z <D>perel <Ami>svatozář <Emi>ztrácíš,
+kolik se <D>platí <Ami>za vláčnej <Emi>hřích?
 \ks
 
 \zr
-No tak, \Ch{G}{lásko}, \Ch{D}{co} chceš mi říct?
-\Ch{Ami}{Máš} už perly, \Ch{Emi}{možná} i víc.
+No tak, <G>lásko, <D>co chceš mi říct?
+<Ami>Máš už perly, <Emi>možná i víc.
 
-\Ch{G}{Lásko}, \Ch{D}{na} co se ptáš? \Ch{Ami}{Svíčku} zhasí\Ch{Emi}{náš.}
+<G>Lásko, <D>na co se ptáš? <Ami>Svíčku zhasí<Emi>náš.
 
-Nemám, \Ch{G}{lásko}, \Ch{D}{co} bych ti dal,
-\Ch{Ami}{chtělas'} všechno, \Ch{Emi}{nebyl} jsem král.
+Nemám, <G>lásko, <D>co bych ti dal,
+<Ami>chtělas' všechno, <Emi>nebyl jsem král.
 
-\Ch{G}{Lásko}, \Ch{D}{na} co se ptáš? \Ch{Ami}{Perly} ve vlasech \Ch{Emi}{máš.}
+<G>Lásko, <D>na co se ptáš? <Ami>Perly ve vlasech <Emi>máš.
 \kr
 
 \zs
@@ -46,7 +46,7 @@ Lásko, na co je pláč?
 Perly ve vlasech máš.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Chtěla jsi víc pro svoje touhy,
@@ -72,7 +72,7 @@ Lásko, na co je pláč?
 Perly ve vlasech máš.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 No tak, lásko, kdo mi tě vzal,

--- a/tp-songs/02_pop_rock/Aleš_Brichta____Slečna_závist.tex
+++ b/tp-songs/02_pop_rock/Aleš_Brichta____Slečna_závist.tex
@@ -3,17 +3,17 @@
 \zp{Slečna Závist}{Aleš Brichta}
 
 \zs
-\Ch{Ami}{Ta dí}vka u oltáře, co pohled tvůj teď váže,
+<Ami>Ta dívka u oltáře, co pohled tvůj teď váže,
 
-skrýt \Ch{G}{závi}st zkouší za \Ch{Ami}{vlas}tním bohatstvím.
+skrýt <G>závist zkouší za <Ami>vlastním bohatstvím.
 
-Má \Ch{Ami}{krásu,} moc i slávu, přesto vidíš, že se trápí,
+Má <Ami>krásu, moc i slávu, přesto vidíš, že se trápí,
 
-když tvář \Ch{G}{zakrývá} jí závoj tkanej z \Ch{Ami}{černejch} pavučin.
+když tvář <G>zakrývá jí závoj tkanej z <Ami>černejch pavučin.
 \ks
 
 \zr
-\Ch{Ami}{Ááá...} \Ch{G}{} \Ch{Ami}{} \Ch{G}{} \Ch{Ami}{}
+<Ami>Ááá... <G> <Ami> <G> <Ami>
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/BSP____Země_vzdálená.tex
+++ b/tp-songs/02_pop_rock/BSP____Země_vzdálená.tex
@@ -3,11 +3,11 @@
 \zp{Země vzdálená}{BSP}
 
 \zs
-\Ch{G}{Smutnej} déšť a \Ch{D}{město} v kouři,
+<G>Smutnej déšť a <D>město v kouři,
 
-\Ch{Ami}{ticho} prázdnejch rán, \Ch{C}{}
+<Ami>ticho prázdnejch rán, <C>
 
-\Ch{Emi}{noční} můry \Ch{D}{pijou} silnej čaj. \Ch{A}{}
+<Emi>noční můry <D>pijou silnej čaj. <A>
 \ks
 
 \zs
@@ -19,9 +19,9 @@ ještě málo žijou, když se ptaj.
 \ks
 
 \zr
-\Ch{G}{Znám} tě mnohem \Ch{D}{víc}, země vzdálená, \Ch{Ami}{} \Ch{C}{}
+<G>Znám tě mnohem <D>víc, země vzdálená, <Ami> <C>
 
-\Ch{Emi}{spát} s tajem\Ch{D}{nou} závratí. \Ch{A}{}
+<Emi>spát s tajem<D>nou závratí. <A>
 \kr
 
 \zs
@@ -41,23 +41,23 @@ v malým ráji chtěl jsem říct:
 \ks
 
 \zs
-\Ch{F}{Den} chová stín v \Ch{C}{záclonách,}
+<F>Den chová stín v <C>záclonách,
 
-\Ch{G}{toulavejch} pár \Ch{D}{koček} strach,
+<G>toulavejch pár <D>koček strach,
 
-\Ch{F}{sen} ti skrývá \Ch{C}{na} víčkách,
+<F>sen ti skrývá <C>na víčkách,
 
-že jsi \Ch{G}{mou.}
+že jsi <G>mou.
 \ks
 
 \zs
-\Ch{F}{Bláznům} se jen může \Ch{C}{smát,}
+<F>Bláznům se jen může <C>smát,
 
-\Ch{G}{když} nám ráno dává \Ch{D}{mat,}
+<G>když nám ráno dává <D>mat,
 
-\Ch{F}{chtěl} jsem dál jen \Ch{C}{poslouchat,}
+<F>chtěl jsem dál jen <C>poslouchat,
 
-že jsi \Ch{D}{má}, že jsi má. \Ch{E}{}
+že jsi <D>má, že jsi má. <E>
 \ks
 
 \zr

--- a/tp-songs/02_pop_rock/Blue_Effect____Sluneční_hrob.tex
+++ b/tp-songs/02_pop_rock/Blue_Effect____Sluneční_hrob.tex
@@ -29,9 +29,9 @@ kterej si <G#mi>rád hraje a kterej je <F#mi>s tebou. <E>
 \ks
 
 \zr
-<C#mi>Su-<D#mi>chá <A>hlína <G#mi>ta-<F#mi>dy
+<C#mi>Su<D#mi>chá <A>hlína <G#mi>ta<F#mi>dy
 
-<C#mi>nevz<D#mi>klí-<Ami>čí bez <G#mi>vo-<F#mi>dy,
+<C#mi>nevz<D#mi>klí<Ami>čí bez <G#mi>vo<F#mi>dy,
 
 <G#mi>já na ni <F#mi>poklekám, <G#mi>vzpomínkou poc<H>ta se vzdává.
 \kr

--- a/tp-songs/02_pop_rock/Blue_Effect____Sluneční_hrob.tex
+++ b/tp-songs/02_pop_rock/Blue_Effect____Sluneční_hrob.tex
@@ -3,37 +3,37 @@
 \zp{Sluneční hrob}{Blue Effect}
 
 \zs
-\Ch{E}{Usínám} a \Ch{F#mi}{chtěl} bych se vrátit
+<E>Usínám a <F#mi>chtěl bych se vrátit
 
-o ně\Ch{G#mi}{jakej} ten rok zpát\Ch{F#mi}{ky,}
+o ně<G#mi>jakej ten rok zpát<F#mi>ky,
 
-\Ch{E}{bejt} zase malým \Ch{F#mi}{klukem,}
+<E>bejt zase malým <F#mi>klukem,
 
-kterej si \Ch{G#mi}{rád hr}aje a kterej je \Ch{F#mi}{s tebou.} \Ch{E}{}
+kterej si <G#mi>rád hraje a kterej je <F#mi>s tebou. <E>
 \ks
 
 \zs
-\Ch{E}{Zdá} se \Ch{F#mi}{mi,} \Ch{G#mi}{je to} \Ch{F#mi}{moc} let,
+<E>Zdá se <F#mi>mi, <G#mi>je to <F#mi>moc let,
 
-\Ch{E}{já} byl \Ch{F#mi}{kluk,} \Ch{G#mi}{kterej} \Ch{F#mi}{chtěl}
+<E>já byl <F#mi>kluk, <G#mi>kterej <F#mi>chtěl
 
-\Ch{E}{zná}\Ch{F#mi}{ti sv}ět, \Ch{G#mi}{s tebou} \Ch{F#mi}{jsem} si hr\Ch{E}{ál.}
+<E>zná<F#mi>ti svět, <G#mi>s tebou <F#mi>jsem si hr<E>ál.
 \ks
 
 \zs
-\Ch{E}{Vrátím} \Ch{F#mi}{se a ch}těl \Ch{G#mi}{bych} \Ch{F#mi}{rád}
+<E>Vrátím <F#mi>se a chtěl <G#mi>bych <F#mi>rád
 
-\Ch{E}{být} s \Ch{F#mi}{tebou,} \Ch{G#mi}{zavzpo}\Ch{F#mi}{mínat.}
+<E>být s <F#mi>tebou, <G#mi>zavzpo<F#mi>mínat.
 
-\Ch{E}{Mám} \Ch{F#mi}{teď} \Ch{G#mi}{ale} \Ch{F#mi}{zprávu} \Ch{E}{zlou.} \Ch{E7}{}
+<E>Mám <F#mi>teď <G#mi>ale <F#mi>zprávu <E>zlou. <E7>
 \ks
 
 \zr
-\Ch{C#mi}{Su-}\Ch{D#mi}{chá} \Ch{A}{hlína} \Ch{G#mi}{ta-}\Ch{F#mi}{dy}
+<C#mi>Su-<D#mi>chá <A>hlína <G#mi>ta-<F#mi>dy
 
-\Ch{C#mi}{nevz}\Ch{D#mi}{klí-}\Ch{Ami}{čí} bez \Ch{G#mi}{vo-}\Ch{F#mi}{dy,}
+<C#mi>nevz<D#mi>klí-<Ami>čí bez <G#mi>vo-<F#mi>dy,
 
-\Ch{G#mi}{já na ni} \Ch{F#mi}{poklekám,} \Ch{G#mi}{vzpomínkou} poc\Ch{H}{ta} se vzdává.
+<G#mi>já na ni <F#mi>poklekám, <G#mi>vzpomínkou poc<H>ta se vzdává.
 \kr
 
 \zs
@@ -44,7 +44,7 @@ z těch našich dnů,
 já teď vím, věrný zůstanu.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Nemůžu spát a probouzím se a zase se nemohu ubránit myšlence

--- a/tp-songs/02_pop_rock/Buty____Chtěl_bych_se_jmenovat_Jan.tex
+++ b/tp-songs/02_pop_rock/Buty____Chtěl_bych_se_jmenovat_Jan.tex
@@ -13,9 +13,9 @@ Přicházet k nim nepoz<Dmi>ván
 \ks
 
 \zr
-Celé <Ami>mlá-<Emi>dí, <F> <E> <F> <F#> <G>
+Celé <Ami>mlá<Emi>dí, <F> <E> <F> <F#> <G>
 
-Celé <Ami>stá-<Emi>ří, <F> <E> <F> <F#> <G>
+Celé <Ami>stá<Emi>ří, <F> <E> <F> <F#> <G>
 
 chtěl bych se jmenovat <C>Jan.
 \kr

--- a/tp-songs/02_pop_rock/Buty____Chtěl_bych_se_jmenovat_Jan.tex
+++ b/tp-songs/02_pop_rock/Buty____Chtěl_bych_se_jmenovat_Jan.tex
@@ -3,21 +3,21 @@
 \zp{Chtěl bych se jmenovat Jan}{Buty}
 
 \zs
-Chtěl bych se jmenovat \Ch{Dmi}{Jan,}
+Chtěl bych se jmenovat <Dmi>Jan,
 
-\Ch{F}{být přítel} dívek a \Ch{C}{dam.}
+<F>být přítel dívek a <C>dam.
 
-Přicházet k nim nepoz\Ch{Dmi}{ván}
+Přicházet k nim nepoz<Dmi>ván
 
-\Ch{F}{a odcházet} nepoz\Ch{C}{nán.}
+<F>a odcházet nepoz<C>nán.
 \ks
 
 \zr
-Celé \Ch{Ami}{mlá-}\Ch{Emi}{dí,} \Ch{F}{} \Ch{E}{} \Ch{F}{} \Ch{F#}{} \Ch{G}{}
+Celé <Ami>mlá-<Emi>dí, <F> <E> <F> <F#> <G>
 
-Celé \Ch{Ami}{stá-}\Ch{Emi}{ří,} \Ch{F}{} \Ch{E}{} \Ch{F}{} \Ch{F#}{} \Ch{G}{}
+Celé <Ami>stá-<Emi>ří, <F> <E> <F> <F#> <G>
 
-chtěl bych se jmenovat \Ch{C}{Jan.}
+chtěl bych se jmenovat <C>Jan.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Buty____František.tex
+++ b/tp-songs/02_pop_rock/Buty____František.tex
@@ -3,13 +3,13 @@
 \zp{František}{Buty}
 
 \zs
-\Ch{G}{Na} hladinu rybníká svítí sluníč\Ch{C}{ko}
+<G>Na hladinu rybníká svítí sluníč<C>ko
 
-\Ch{Emi}{a ko}lem stojí v hustém kruhu \Ch{G}{topoly,}
+<Emi>a kolem stojí v hustém kruhu <G>topoly,
 
-\Ch{Ami}{které} tam zasadil jeden hodný \Ch{Hmi}{člověk,}
+<Ami>které tam zasadil jeden hodný <Hmi>člověk,
 
-\Ch{Ami}{jmenoval} se František \Ch{D}{Dobrota.}
+<Ami>jmenoval se František <D>Dobrota.
 
 \ks \zs
 František Dobrota, rodák z blízké vesnice,
@@ -22,9 +22,9 @@ teď dobře poslouchej, co máš všechno udělat!}
 \ks
 
 \zr
-3× /: \Ch{C}{Balabambam}, balabambam \Ch{C}{} \Ch{D}{} \Ch{C}{} :/
+3× /: <C>Balabambam, balabambam <C> <D> <C> :/
 
-... \Ch{Ami}{a kolem} rybníka nahusto nasázet \Ch{D}{topoly.}
+... <Ami>a kolem rybníka nahusto nasázet <D>topoly.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Buty____Jednou_ráno.tex
+++ b/tp-songs/02_pop_rock/Buty____Jednou_ráno.tex
@@ -3,16 +3,16 @@
 \zp{Jednou ráno}{Buty}
 
 \zs
-Jednou \Ch{Dmi}{ráno} \Ch{A7+}{přišel} \Ch{Dmi}{vítr,} \Ch{Dmi7}{} \Ch{G7}{}
+Jednou <Dmi>ráno <A7+>přišel <Dmi>vítr, <Dmi7> <G7>
 
-vzal si \Ch{Bmaj7}{střechu} \Ch{A7+}{i s po}krý\Ch{Dmi}{vačem} \Ch{Dmi7}{} \Ch{G7}{}
+vzal si <Bmaj7>střechu <A7+>i s pokrý<Dmi>vačem <Dmi7> <G7>
 
-i s klempí\Ch{Bmaj7}{řem} \Ch{A7+}{i s ko}mi\Ch{Dmi}{níkem,} \Ch{Dmi7}{} \Ch{G7}{}
+i s klempí<Bmaj7>řem <A7+>i s komi<Dmi>níkem, <Dmi7> <G7>
 
-jenom \Ch{Bmaj7}{dláždič} \Ch{A7+}{zůstal} \Ch{Dmi}{dole.} \Ch{A7+}{} \Ch{Dmi}{}
+jenom <Bmaj7>dláždič <A7+>zůstal <Dmi>dole. <A7+> <Dmi>
 \ks
 
-\Ch{Dmi}{Mezihra} \Ch{A7+}{} \Ch{Dmi}{} \Ch{Dmi7}{} \Ch{G7}{} \Ch{Bmaj7...}{}
+<Dmi>Mezihra <A7+> <Dmi> <Dmi7> <G7> <Bmaj7...>
 
 \zs
 Zůstal dole, chodník dláždil,
@@ -21,8 +21,8 @@ plival na zem a byl sprostý.
 
 Kamarádi někam letí
 
-$\infty\times$ /: a on \Ch{Bmaj7}{tady} \Ch{A7+}{musí} \Ch{Dmi}{klečet...} 
-\Ch{Dmi7}{} \Ch{G7}{} :/
+$\infty\times$ /: a on <Bmaj7>tady <A7+>musí <Dmi>klečet... 
+<Dmi7> <G7> :/
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Buty____Krtek.tex
+++ b/tp-songs/02_pop_rock/Buty____Krtek.tex
@@ -3,23 +3,23 @@
 \zp{Krtek}{Buty}
 
 \zs
-V zemi se narodil \Ch{Ami}{krtek,}
-\Ch{D}{tam} svoje mléko \Ch{Fmaj7}{sál,}
+V zemi se narodil <Ami>krtek,
+<D>tam svoje mléko <Fmaj7>sál,
 
-\Ch{Dmi}{do pu}sy vlezla mu \Ch{B}{hlína,}
-\Ch{G}{a on} ji vykuc\Ch{F}{kal,} \Ch{E}{jé,}
+<Dmi>do pusy vlezla mu <B>hlína,
+<G>a on ji vykuc<F>kal, <E>jé,
 
-chtěl se na {ni} po\Ch{Ami}{dívat,}
-\Ch{D}{ale} byla tam \Ch{Ami}{tma.}
+chtěl se na {ni} po<Ami>dívat,
+<D>ale byla tam <Ami>tma.
 
-\uv{\Ch{Dmi}{Ty ni}kdy nebudeš \Ch{B}{vidět,}}
-\Ch{G}{řekla} mu mamin\Ch{E}{ka.}
+\uv{<Dmi>Ty nikdy nebudeš <B>vidět,}
+<G>řekla mu mamin<E>ka.
 
 \ks
 \zs
 
-\Ch{G}{Zaměstnávám} \Ch{C}{pána} se žlutým \Ch{Ami}{sakem,}
-do práce mi \Ch{Dmi}{nosí} fajfku s tabá\Ch{C}{kem,}
+<G>Zaměstnávám <C>pána se žlutým <Ami>sakem,
+do práce mi <Dmi>nosí fajfku s tabá<C>kem,
 
 s tabákem co voní -- přesně nevím čím,
 v duši se mi honí jeho saka stín.
@@ -33,10 +33,10 @@ a v tom kouře dýmu náhle uvidím.
 \ks
 \zs
 
-Ufo si\Ch{C}{fon,} Milan si\Ch{Ami}{lon,}
-to pěkně \Ch{Dmi}{zapadá}, kytka -- \Ch{C}{lopata.}
+Ufo si<C>fon, Milan si<Ami>lon,
+to pěkně <Dmi>zapadá, kytka -- <C>lopata.
 
-Lopata do země \Ch{Ami}{jede,}
+Lopata do země <Ami>jede,
 otvírá se škvírka,
 
 vidíme normální nebe,

--- a/tp-songs/02_pop_rock/Buty____Mám_jednu_ruku_dlouhou.tex
+++ b/tp-songs/02_pop_rock/Buty____Mám_jednu_ruku_dlouhou.tex
@@ -2,16 +2,16 @@
 
 \zp{Mám jednu ruku dlouhou}{Buty}
 
-\Ch{E}{Na}, \Ch{Cmi}{na na na na} \Ch{A}{ná} \Ch{E}{ná}
+<E>Na, <Cmi>na na na na <A>ná <E>ná
 
 \zs
-\Ch{E}{Najdem} si \Ch{C#mi}{místo,} \Ch{G#mi}{kde se} dobře \Ch{F#mi}{kouří,}
+<E>Najdem si <C#mi>místo, <G#mi>kde se dobře <F#mi>kouří,
 
-\Ch{E}{kde} horké \Ch{C#mi}{slunce} \Ch{G#mi}{do ná}pojů \Ch{F#mi}{nepíchá,}
+<E>kde horké <C#mi>slunce <G#mi>do nápojů <F#mi>nepíchá,
 
-\Ch{H}{kde} vítr \Ch{H7}{snáší} \Ch{E}{žmolky} ptačích \Ch{A}{hovínek}
+<H>kde vítr <H7>snáší <E>žmolky ptačích <A>hovínek
 
-\Ch{H}{okolo} \Ch{A}{nás} a \Ch{H}{říká...}
+<H>okolo <A>nás a <H>říká...
 \ks
 
 \zs
@@ -25,30 +25,30 @@ a řekne: \uv{Nazdar, kluci!}
 \ks
 
 \zr
-/: \uv{\Ch{E}{Mám} \Ch{C#mi}{jednu} ruku \Ch{A}{dlou}\Ch{E}{hou.}} :/
+/: \uv{<E>Mám <C#mi>jednu ruku <A>dlou<E>hou.} :/
 \kr
 
 \zs
-\Ch{A}{Posaď} se k \Ch{F#mi}{nám,} \Ch{C#mi}{necháme} tě \Ch{Hmi}{vymluvit}
+<A>Posaď se k <F#mi>nám, <C#mi>necháme tě <Hmi>vymluvit
 
-\Ch{A}{a} vzpome\Ch{F#mi}{nout si} \Ch{C#mi}{na ty} naše \Ch{Hmi}{úkoly,}
+<A>a vzpome<F#mi>nout si <C#mi>na ty naše <Hmi>úkoly,
 
-\Ch{E}{tu} ruku nám \Ch{Hmi}{dej a} \Ch{A}{odpočívej} v \Ch{D}{pokoji} 
-\Ch{E}{}
+<E>tu ruku nám <Hmi>dej a <A>odpočívej v <D>pokoji 
+<E>
 
 \bigskip
 
-\Ch{A}{tam} na tom \Ch{F#mi}{místě,} \Ch{C#mi}{kde se} dobře \Ch{Hmi}{není.}
+<A>tam na tom <F#mi>místě, <C#mi>kde se dobře <Hmi>není.
 \ks
 
 \zr
-4× /: \Ch{A}{Na}, \Ch{F#mi}{na na na na} \Ch{D}{ná} \Ch{A}{ná} :/
+4× /: <A>Na, <F#mi>na na na na <D>ná <A>ná :/
 
-3× /: \Ch{Ami}{na,} na na na na, :/
+3× /: <Ami>na, na na na na, :/
 
-\Ch{D}{ná} \Ch{A}{ná.}
+<D>ná <A>ná.
 
-8× /: \Ch{A}{Mám} \Ch{F#mi}{jednu} ruku \Ch{D}{dlou}\Ch{A}{hou.} :/
+8× /: <A>Mám <F#mi>jednu ruku <D>dlou<A>hou. :/
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Buty____Nad_stádem_koní.tex
+++ b/tp-songs/02_pop_rock/Buty____Nad_stádem_koní.tex
@@ -3,25 +3,25 @@
 \zp{Nad stádem koní}{Buty}
 
 \zs
-\Ch{D}{Nad stádem} \Ch{A}{koní} \Ch{Emi}{podkovy} \Ch{G}{zvoní,} zvoní,
+<D>Nad stádem <A>koní <Emi>podkovy <G>zvoní, zvoní,
 
-\Ch{D}{černý vůz} \Ch{A}{vlečou} \Ch{Emi}{a slzy} \Ch{G}{tečou}
+<D>černý vůz <A>vlečou <Emi>a slzy <G>tečou
 
 a já volám:
 \ks
 
 \zs
-\uv{\Ch{D}Tak neplač, \Ch{A}{můj} kamará\Ch{Emi}{de,}
+\uv{<D>Tak neplač, <A>můj kamará<Emi>de,
 
-náhoda je \Ch{G}{blbec,} když krade,
+náhoda je <G>blbec, když krade,
 
-\Ch{D}{je tuhý} jak \Ch{A}{veka} a řeka ho \Ch{Emi}{splaví,}
+<D>je tuhý jak <A>veka a řeka ho <Emi>splaví,
 
-máme ho \Ch{G}{rádi,}
+máme ho <G>rádi,
 
-no tak \Ch{C}{co},
-tak \Ch{G}{co},
-tak \Ch{A}{co?}}
+no tak <C>co,
+tak <G>co,
+tak <A>co?}
 \ks
 
 \zs
@@ -53,17 +53,17 @@ a já šeptám:
 \zs
 \uv{Vysyp ten popel, kamaráde, do bílé vody, vody,
 
-vyhasnul kotel a náhoda je štěstí od \Ch{G}{podkovy.}}
+vyhasnul kotel a náhoda je štěstí od <G>podkovy.}
 \ks
 
 \zs
-Vysyp ten \Ch{D}{popel}, \Ch{A}{kamará}\Ch{G}{de,} / Heja hej ...
+Vysyp ten <D>popel, <A>kamará<G>de, / Heja hej ...
 
-do bílé \Ch{D}{vody,} \Ch{A}{vo}\Ch{G}{dy,} / Heja hej ....
+do bílé <D>vody, <A>vo<G>dy, / Heja hej ....
 
-vyhasnul \Ch{D}{kotel} a \Ch{A}{náhoda} \Ch{Emi}{je} / Heja hej ...
+vyhasnul <D>kotel a <A>náhoda <Emi>je / Heja hej ...
 
-štěstí od podko\Ch{G}{vy.} / Heja hej ...
+štěstí od podko<G>vy. / Heja hej ...
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Buty____Tata.tex
+++ b/tp-songs/02_pop_rock/Buty____Tata.tex
@@ -2,21 +2,21 @@
 
 \zp{Tata}{Buty}
 \zs
-\Ch{Gmi}{Musíme} zajet na chatu,
+<Gmi>Musíme zajet na chatu,
 
-\Ch{Dmi7}{musím} se podívat na tatu,
+<Dmi7>musím se podívat na tatu,
 
-\Ch{Cmi7}{chtěl} bych se za ním podívat,
+<Cmi7>chtěl bych se za ním podívat,
 
-\Ch{Gmi}{tralalalalalalala.}
+<Gmi>tralalalalalalala.
 
-\Ch{Gmi}{ } \Ch{Dmi7}{ } \Ch{Cmi7}{ } \Ch{Gmi}{ } \Ch{Dmi7}{ } \Ch{Cmi7}{ 
-} \Ch{Gmi}{ }
+<Gmi> <Dmi7> <Cmi7> <Gmi> <Dmi7> <Cmi7> 
+ <Gmi> 
 
 \ks
 \zr
 
-/: \Ch{B}{Tata}, tata, \Ch{Dmi7}{tata tata} tata, \Ch{Cmi7}{tata.} :/
+/: <B>Tata, tata, <Dmi7>tata tata tata, <Cmi7>tata. :/
 
 \kr
 \zs

--- a/tp-songs/02_pop_rock/Buty____Vrána.tex
+++ b/tp-songs/02_pop_rock/Buty____Vrána.tex
@@ -3,19 +3,19 @@
 \zp{Vrána}{Buty}
 
 \zs
-\Ch{Eb}{Letí} vrána, \Ch{Cmi}{letí vzduchem,}
+<Eb>Letí vrána, <Cmi>letí vzduchem,
 
-\Ch{Fmi}{nepospíchá,} \Ch{B}{šetří} síly,
+<Fmi>nepospíchá, <B>šetří síly,
 
-\Ch{Eb}{jedním} okem, \Ch{Cmi}{jedním} uchem
+<Eb>jedním okem, <Cmi>jedním uchem
 
-\Ch{Fmi}{sleduje}, co \Ch{B}{ostatní} vrány.
+<Fmi>sleduje, co <B>ostatní vrány.
 \ks
 
 \zs
-\Ch{F}{Taky} letí, \Ch{Dmi}{taky} letí,
+<F>Taky letí, <Dmi>taky letí,
 
-\Ch{Gmi}{druhá} vrána, \Ch{C}{třetí} vrána,
+<Gmi>druhá vrána, <C>třetí vrána,
 
 nespěchají, šetří síly,
 
@@ -23,9 +23,9 @@ ještě dlouho poletí vzduchem.
 \ks
 
 \zs
-\Ch{G}{Letí} vrány, \Ch{Emi}{letí}, letí,
+<G>Letí vrány, <Emi>letí, letí,
 
-\Ch{Ami}{nepotí} se, \Ch{D}{vzduch} je chladí,
+<Ami>nepotí se, <D>vzduch je chladí,
 
 letí dlouho, všechny spolu,
 
@@ -33,9 +33,9 @@ jedna vrána jako druhá.
 \ks
 
 \zs
-\Ch{A}{Na} chvíli se \Ch{F#mi}{vystřídají},
+<A>Na chvíli se <F#mi>vystřídají,
 
-\Ch{Hmi}{první} vrána \Ch{E}{už se cítí}
+<Hmi>první vrána <E>už se cítí
 
 unavená, unavená,
 
@@ -43,13 +43,13 @@ tak se schová na konec hejna.
 \ks
 
 \zr
-/: \Ch{H}{Letí}, letí, \Ch{G#mi}{letí, le}tí. \Ch{C#mi}{} \Ch{F#}{} :/
+/: <H>Letí, letí, <G#mi>letí, letí. <C#mi> <F#> :/
 \kr
 
 \zs
-\Ch{Eb}{Letí} vrány, \Ch{Cmi}{letí,} letí,
+<Eb>Letí vrány, <Cmi>letí, letí,
 
-\Ch{Fmi}{ještě} pořád \Ch{B}{letí} vzduchem,
+<Fmi>ještě pořád <B>letí vzduchem,
 
 nic si spolu neříkají,
 
@@ -57,10 +57,10 @@ unavené černé vrány.
 \ks
 
 \zr
-\Ch{Gmi}{Až} si najdou \Ch{Cmi}{dobré} místo,
+<Gmi>Až si najdou <Cmi>dobré místo,
 
-\Ch{Fmi}{sednou} si a \Ch{B}{budou} klidně \Ch{Eb}{spát.} \Ch{Cmi}{} 
-\Ch{Fmi}{} \Ch{B}{} \Ch{Eb}{}
+<Fmi>sednou si a <B>budou klidně <Eb>spát. <Cmi> 
+<Fmi> <B> <Eb>
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Chinaski____1._signální.tex
+++ b/tp-songs/02_pop_rock/Chinaski____1._signální.tex
@@ -3,10 +3,10 @@
 \zp{1. signální}{Chinaski}
 
 \zs
-Až si \Ch{G}{zejtra} ráno \Ch{C}{řeknu} zase
-\Ch{Emi}{jednou} provždy: \uv{dost,}
+Až si <G>zejtra ráno <C>řeknu zase
+<Emi>jednou provždy: \uv{dost,}
 
-\Ch{G}{právem} se mi \Ch{C}{budeš} tiše \Ch{Emi}{smát.}
+<G>právem se mi <C>budeš tiše <Emi>smát.
 
 Jak omluvit si svoji slabost, nenávist a zlost,
 
@@ -14,15 +14,15 @@ když za všechno si můžu vlastně sám?
 \ks
 
 \zr
-Za \Ch{Ami}{spoustu} dní, možná za \Ch{C}{spoustu} let,
+Za <Ami>spoustu dní, možná za <C>spoustu let,
 
-až se mi \Ch{G}{rozední,} budu ti \Ch{D}{vyprávět,}
+až se mi <G>rozední, budu ti <D>vyprávět,
 
 na 1. signální jak jsem vobletěl svět,
 
 jak tě to vomámí a nepustí zpět.
 
-/: Jaký si to \Ch{F}{uděláš}, \Ch{B}{takový} to \Ch{Dmi}{máš.} :/
+/: Jaký si to <F>uděláš, <B>takový to <Dmi>máš. :/
 \kr
 
 \zs
@@ -35,7 +35,7 @@ všechna sláva polní tráva, ale peníz přijde vhod,
 jak jsem si to uďál, tak to mám.
 \ks
 
-\zr  \kr
+\zr \kr
 
 Nana...
 

--- a/tp-songs/02_pop_rock/Chinaski____1970.tex
+++ b/tp-songs/02_pop_rock/Chinaski____1970.tex
@@ -2,32 +2,32 @@
 
 \zp{1970}{Chinaski}
 
-/: \Ch{C}{} \Ch{Dmi}{} \Ch{F}{} \Ch{C}{} :/
+/: <C> <Dmi> <F> <C> :/
 
 \zs
 
-\Ch{C}{Nevim,} jestli je to \Ch{Dmi}{znát,}
-možná by bylo lepší \Ch{Emi}{lhát,}
+<C>Nevim, jestli je to <Dmi>znát,
+možná by bylo lepší <Emi>lhát,
 
-jsem silnej ročník \Ch{F}{sedmdesát,} tak začni počí\Ch{C}{tat.}
+jsem silnej ročník <F>sedmdesát, tak začni počí<C>tat.
 
-Nechci tu hloupě vzpomí\Ch{Dmi}{nat, koho} taky dneska zají\Ch{Emi}{má}
+Nechci tu hloupě vzpomí<Dmi>nat, koho taky dneska zají<Emi>má
 
-silnej ročník \Ch{F}{sedmdesát,} tak začni počí\Ch{C}{tat.}
+silnej ročník <F>sedmdesát, tak začni počí<C>tat.
 
-Tenkrát tu bejval jinej \Ch{Dmi}{stát} a já byl blbej na kvad\Ch{Emi}{rát,}
+Tenkrát tu bejval jinej <Dmi>stát a já byl blbej na kvad<Emi>rát,
 
-jsem silnej ročník \Ch{F}{sedmdesát,} třeba napřík\Ch{G}{lad...}
+jsem silnej ročník <F>sedmdesát, třeba napřík<G>lad...
 \ks
 
 \zr
-\Ch{G}{Naši} mi vždycky říka\Ch{Ami}{li, jen nehas} co tě nepá\Ch{F}{lí,}
+<G>Naši mi vždycky říka<Ami>li, jen nehas co tě nepá<F>lí,
 
-jakej pán, takovej \Ch{C}{krám.}
+jakej pán, takovej <C>krám.
 
-\Ch{G}{Naši} mi vždycky říka\Ch{Ami}{li, co} můžeš, sleduj z povzdá\Ch{F}{lí}
+<G>Naši mi vždycky říka<Ami>li, co můžeš, sleduj z povzdá<F>lí
 
-a nikdy nebojuj \Ch{C}{sám.}
+a nikdy nebojuj <C>sám.
 \kr
 
 \zs
@@ -46,9 +46,9 @@ jsem silnej ročník sedmdesát a možná, že jsem rád.
 
 
 \zs
-/: Čas \Ch{F}{pádí,} čas letí, těžko ta \Ch{G}{léta} vrátíš zpět
+/: Čas <F>pádí, čas letí, těžko ta <G>léta vrátíš zpět
 
-a tak i \Ch{C}{Husákovy} děti dospěly \Ch{Dmi}{do Kristových} let. :/
+a tak i <C>Husákovy děti dospěly <Dmi>do Kristových let. :/
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Chinaski____Kláro.tex
+++ b/tp-songs/02_pop_rock/Chinaski____Kláro.tex
@@ -2,20 +2,20 @@
 
 \zp{Kláro}{Chinaski}
 
-/: \Ch{H}{Ná,} na na na \Ch{G#mi}{na na na na na na na} \Ch{E}{ná,} \Ch{Emi}{ááá.} :/
+/: <H>Ná, na na na <G#mi>na na na na na na na <E>ná, <Emi>ááá. :/
 
 \zs
-\Ch{H}{Kláro,} jak to s \Ch{D#mi}{tebou} vypadá od půl \Ch{C#mi}{devátý} do osmi \Ch{Emi}{ráno,}
+<H>Kláro, jak to s <D#mi>tebou vypadá od půl <C#mi>devátý do osmi <Emi>ráno,
 
-co nám \Ch{H}{brání} bejt spolu, \Ch{D#mi}{jenom} ty a já?
+co nám <H>brání bejt spolu, <D#mi>jenom ty a já?
 
-\Ch{C#mi}{Nebuď} včerejší, no tak, \Ch{Emi}{Kláro.}
+<C#mi>Nebuď včerejší, no tak, <Emi>Kláro.
 
-Pro tebe \Ch{H}{slibuju}, žaluju, denně \Ch{D#mi}{piju jak} Dán,
+Pro tebe <H>slibuju, žaluju, denně <D#mi>piju jak Dán,
 
-\Ch{C#mi}{ve skr}ytu duše marně \Ch{Emi}{tajně} doufám,
+<C#mi>ve skrytu duše marně <Emi>tajně doufám,
 
-že \Ch{H}{já,} jenom \Ch{G#mi}{já jsem} ten tvůj vysněný \Ch{E}{pán.} \Ch{Emi}{}
+že <H>já, jenom <G#mi>já jsem ten tvůj vysněný <E>pán. <Emi>
 \ks
 
 \zs
@@ -32,37 +32,37 @@ inženýr, šarlatán.
 \ks
 
 \zr
-\Ch{C}{Koukám} na tebe, Kláro, už několik \Ch{Dmi7}{dní,} \Ch{Fmi}{}
+<C>Koukám na tebe, Kláro, už několik <Dmi7>dní, <Fmi>
 
-\Ch{C}{nejsem} ňákej ten chlápek, jsem solid\Ch{Dmi7}{ní.} \Ch{Fmi}{}
+<C>nejsem ňákej ten chlápek, jsem solid<Dmi7>ní. <Fmi>
 
-\Ch{C}{Kláro}, stačí jen málo a budeme \Ch{Dmi7}{pár.} \Ch{Dmi}{}
+<C>Kláro, stačí jen málo a budeme <Dmi7>pár. <Dmi>
 
-\Ch{C}{Královno} má, ty to víš, co bych si \Ch{Dmi7}{přál.} \Ch{Dmi}{}
+<C>Královno má, ty to víš, co bych si <Dmi7>přál. <Dmi>
 \kr
 
 
-/: \Ch{C}{Ná} na na na \Ch{Ami}{na na na na na na na} \Ch{F}{ná,} \Ch{Fmi}{ááá.} :/
+/: <C>Ná na na na <Ami>na na na na na na na <F>ná, <Fmi>ááá. :/
 
 
 \zs
-\Ch{C}{Hele,} kotě, na co tě \Ch{Emi}{nalákám:}
+<C>Hele, kotě, na co tě <Emi>nalákám:
 
-\Ch{Dmi}{mám} doma sbírku cinknu\Ch{Fmi}{tejch} srdcovejch králů,
+<Dmi>mám doma sbírku cinknu<Fmi>tejch srdcovejch králů,
 
-\Ch{C}{naslouchám,} následně \Ch{Emi}{vím,} kudy kam,
+<C>naslouchám, následně <Emi>vím, kudy kam,
 
-\Ch{Dmi}{dáme} si partičku a \Ch{Fmi}{skončíme} k \Ch{C}{ránu.}
+<Dmi>dáme si partičku a <Fmi>skončíme k <C>ránu.
 
-Počkám až \Ch{Emi}{usneš} \Ch{Dmi}{a} \Ch{Fmi}{bude} se ti \Ch{C}{zdát}
+Počkám až <Emi>usneš <Dmi>a <Fmi>bude se ti <C>zdát
 
-Jenom \Ch{Ami}{já jsem} ten tvůj vysněný \Ch{F}{pán,}
-inženýr, \Ch{Fmi}{šarlatán.}
+Jenom <Ami>já jsem ten tvůj vysněný <F>pán,
+inženýr, <Fmi>šarlatán.
 \ks
 
-\zr  \kr
+\zr \kr
 
-3× /: \Ch{C#}{Ná} na na na \Ch{Bmi}{na na na na na na na} \Ch{F#}{ná,} 
-\Ch{F#mi}{ááá.} :/
+3× /: <C#>Ná na na na <Bmi>na na na na na na na <F#>ná, 
+<F#mi>ááá. :/
 
 \kp

--- a/tp-songs/02_pop_rock/Chinaski____Tabáček.tex
+++ b/tp-songs/02_pop_rock/Chinaski____Tabáček.tex
@@ -2,21 +2,21 @@
 
 \zp{Tabáček}{Chinaski}
 \zs
-\Ch{D}{Haló}, kdo je tam? Po zaznění tónu
-\Ch{G}{zanechte} zprávy \Ch{A}{a bu}ďte zdrávi.
+<D>Haló, kdo je tam? Po zaznění tónu
+<G>zanechte zprávy <A>a buďte zdrávi.
 
-\Ch{D}{Haló}, nejsem doma, no je to fakt bída,
-\Ch{G}{volané} číslo vám \Ch{A}{neodpovídá.}
+<D>Haló, nejsem doma, no je to fakt bída,
+<G>volané číslo vám <A>neodpovídá.
 \ks
 
 \zr
-\Ch{Emi}{Polevím} z vysokejch \Ch{A}{otáček,}
-\Ch{Dmaj7}{pohoda,} klídek a \Ch{Hmi}{tabáček,}
+<Emi>Polevím z vysokejch <A>otáček,
+<Dmaj7>pohoda, klídek a <Hmi>tabáček,
 
-\Ch{Emi}{půl dne} {noviny} číst a pak \Ch{A}{cigáro},
-\Ch{Dmaj7}{pohoda,} klídek, \Ch{Hmi}{leháro,}
+<Emi>půl dne {noviny} číst a pak <A>cigáro,
+<Dmaj7>pohoda, klídek, <Hmi>leháro,
 
-\Ch{Emi}{nejspíš} jsem jenom \Ch{A}{línej} čím dál \Ch{D}{víc.}
+<Emi>nejspíš jsem jenom <A>línej čím dál <D>víc.
 \kr
 
 \zs
@@ -54,46 +54,46 @@ všude se dočítám, že umřu předčasně,
 a taky vím, že obtěžuju okolí,
 čekám konec, zatím nic nebolí.
 
-\Ch{Emi}{Více}méně se to dobře \Ch{A}{vyví}jí,
-život je \Ch{Dmaj7}{návykovej} a někdy \Ch{A}{zabíjí.}
+<Emi>Víceméně se to dobře <A>vyvíjí,
+život je <Dmaj7>návykovej a někdy <A>zabíjí.
 \kr
 
 
-\Ch{E}{ } \Ch{A}{ } \Ch{H}{ }
-\Ch{E}{ } \Ch{A}{ } \Ch{H}{ }
+<E> <A> <H> 
+<E> <A> <H> 
 
 \zr
-\Ch{F#mi}{Polevím} z vysokejch \Ch{H}{otáček,}
-\Ch{Emaj7}{pohoda}, klídek a \Ch{C#mi}{tabáček,}
+<F#mi>Polevím z vysokejch <H>otáček,
+<Emaj7>pohoda, klídek a <C#mi>tabáček,
 
-\Ch{F#mi}{vzpomínat} na to, co se \Ch{H}{událo,}
-\Ch{Emaj7}{chci to tak} mít, nejmíň na \Ch{C#mi}{stálo,}
+<F#mi>vzpomínat na to, co se <H>událo,
+<Emaj7>chci to tak mít, nejmíň na <C#mi>stálo,
 
-\Ch{F#mi}{nejspíš} jsem jenom \Ch{H}{línej} čím dál \Ch{E}{víc.}
+<F#mi>nejspíš jsem jenom <H>línej čím dál <E>víc.
 \kr
 
 \zs
-\Ch{D}{Volané} číslo je odpojené,
-a bude \Ch{G}{odpojené,} žádný \Ch{A}{né}, že né,
+<D>Volané číslo je odpojené,
+a bude <G>odpojené, žádný <A>né, že né,
 
-\Ch{D}{volané} číslo včetně mojí tváře
-\Ch{G}{vymažte} ze svýho \Ch{A}{adresáře.}
+<D>volané číslo včetně mojí tváře
+<G>vymažte ze svýho <A>adresáře.
 
 \ks
 
 \zs
-\Ch{Emi}{A pokuste} se tvářit \Ch{A}{nešťastně,}
-všude se \Ch{Dmaj7}{dočítám,} že umřu \Ch{Hmi}{předčasně,}
+<Emi>A pokuste se tvářit <A>nešťastně,
+všude se <Dmaj7>dočítám, že umřu <Hmi>předčasně,
 
-a taky \Ch{Emi}{vím,} že obtěžuju \Ch{A}{okolí,}
-čekám \Ch{Dmaj7}{konec,} zatím nic \Ch{Hmi}{nebolí.}
+a taky <Emi>vím, že obtěžuju <A>okolí,
+čekám <Dmaj7>konec, zatím nic <Hmi>nebolí.
 \ks
 
 \zs
-\Ch{Emi}{Víceméně} se to dobře \Ch{A}{vyvíjí,}
-život je \Ch{Dmaj7}{návykovej} a někdy \Ch{Hmi}{zabíjí.}
+<Emi>Víceméně se to dobře <A>vyvíjí,
+život je <Dmaj7>návykovej a někdy <Hmi>zabíjí.
 
-\Ch{Emi}{Víceméně} se to dobře \Ch{A}{vyvíjí,},
-život je \Ch{Dmaj7}{návykovej} a někdy...
+<Emi>Víceméně se to dobře <A>vyvíjí,,
+život je <Dmaj7>návykovej a někdy...
 \ks
 \kp

--- a/tp-songs/02_pop_rock/Divokej_Bill____Plakala.tex
+++ b/tp-songs/02_pop_rock/Divokej_Bill____Plakala.tex
@@ -3,49 +3,49 @@
 \zp{Plakala}{Divokej Bill}
 
 \zs
-\Ch{Ami}{Toužila,} kroužila, kryla mi záda,
+<Ami>Toužila, kroužila, kryla mi záda,
 
 souložila, kouřila mě, měla mě ráda,
 
 poháněná chtíčem vrněla jak káča,
 
-moje milá \Ch{C}{plakala.} \Ch{G}{}
+moje milá <C>plakala. <G>
 \ks
 
 \zs
-\Ch{Ami}{Utíkala} pryč, nevěděla kam,
+<Ami>Utíkala pryč, nevěděla kam,
 
 pletla na mě bič, já byl na to sám,
 
 poháněná chtíčem vrněla jak káča,
 
-moje milá \Ch{C}{plakala.} \Ch{G}{}
+moje milá <C>plakala. <G>
 \ks
 
 \zs
-\Ch{Ami}{Modlila} se, hlásila se o svý práva,
+<Ami>Modlila se, hlásila se o svý práva,
 
 motala se na mý trase, byla to kráva,
 
 poháněná chtíčem vrněla jak káča,
 
-moje milá \Ch{C}{plakala.} \Ch{G}{}
+moje milá <C>plakala. <G>
 \ks
 
 \zr
-4× /: \Ch{Ami}{Moje} milá \Ch{C}{plakala.} \Ch{G}{} :/
+4× /: <Ami>Moje milá <C>plakala. <G> :/
 
-\Ch{Ami}{Pozdravuj} \Ch{C}{pocestný,}
+<Ami>Pozdravuj <C>pocestný,
 
-\Ch{G}{svět} je malej, \Ch{Ami}{dokona}\Ch{G}{lej,}
+<G>svět je malej, <Ami>dokona<G>lej,
 
-\Ch{Ami}{pozdravuj} \Ch{C}{pocestný,}
+<Ami>pozdravuj <C>pocestný,
 
-\Ch{G}{svět} je zlej, co když se \Ch{Ami}{nevrá}\Ch{G}{tí,}
+<G>svět je zlej, co když se <Ami>nevrá<G>tí,
 
-co když se \Ch{Ami}{nevrátí?} / Moje milá \Ch{C}{plakala,} \Ch{G}{}
+co když se <Ami>nevrátí? / Moje milá <C>plakala, <G>
 
-Co když se \Ch{Ami}{nevrátí?} / moje milá \Ch{C}{plakala...} \Ch{G}{}
+Co když se <Ami>nevrátí? / moje milá <C>plakala... <G>
 
 \kr
 

--- a/tp-songs/02_pop_rock/Divokej_Bill____Píseň_o_Ferdovi_a_Mravenci.tex
+++ b/tp-songs/02_pop_rock/Divokej_Bill____Píseň_o_Ferdovi_a_Mravenci.tex
@@ -3,43 +3,43 @@
 \zp{Píseň o Ferdovi a Mravenci}{Divokej Bill}
 
 \zs
-    \Ch{G}{Ferda} Mravenec se vám \Ch{C}{klan}í -- to jsi \Ch{Ami}{ty?}
+ <G>Ferda Mravenec se vám <C>klaní -- to jsi <Ami>ty?
 
-    To jsem \Ch{D}{já!}
+ To jsem <D>já!
 
-    Slečno Beruško, či snad paní -- paní!
+ Slečno Beruško, či snad paní -- paní!
 
-    Já povím vám:
+ Já povím vám:
 \ks
 
 \zs
-    Před vaší krásou ledy tají,
+ Před vaší krásou ledy tají,
 
-    no a i já.
+ no a i já.
 
-    Vy Eva a já Adam v ráji,
+ Vy Eva a já Adam v ráji,
 
-    to bych si přál.
+ to bych si přál.
 \ks
 
 \zr
-    \Ch{Emi}{Co si} to usmrkanec \Ch{C}{mysl}í \Ch{G}{ne,} na mě dojem neudělá!
+ <Emi>Co si to usmrkanec <C>myslí <G>ne, na mě dojem neudělá!
 
-    \Ch{C}{Víš,} kdo jsem já? \Ch{D}{Beruška} nádherná, \Ch{C}{a ty} jen \Ch{C/Emi}{mravenec!}
+ <C>Víš, kdo jsem já? <D>Beruška nádherná, <C>a ty jen <C/Emi>mravenec!
 \kr
 
 \zs
-    Prostý se vám klaní,
+ Prostý se vám klaní,
 
-    to jsem celej já.
+ to jsem celej já.
 
-    Slečno Beruško, či snad paní...
+ Slečno Beruško, či snad paní...
 \ks
 
 \zr
-    Co si to usmrkanec myslí...
+ Co si to usmrkanec myslí...
 
-    ...a ty jen mravenec pro smích!
+ ...a ty jen mravenec pro smích!
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Elán____Smrtka_na_pražskom_orloji.tex
+++ b/tp-songs/02_pop_rock/Elán____Smrtka_na_pražskom_orloji.tex
@@ -2,13 +2,13 @@
 
 \zp{Smrtka na pražskom Orloji}{Elán}
 \zs
-\Ch{Ami}{Turisti} \Ch{Dmi}{vrabce,} ško\Ch{Ami}{ly,}
+<Ami>Turisti <Dmi>vrabce, ško<Ami>ly,
 
-orloj a \Ch{Dmi}{apošto}\Ch{Ami}{li,}
+orloj a <Dmi>apošto<Ami>li,
 
-na konci \Ch{Dmi}{smrťka} sto\Ch{Ami}{jí}
+na konci <Dmi>smrťka sto<Ami>jí
 
-\Ch{Amimaj7}{a každy sa jej} bojí. \Ch{Ami}{}
+<Amimaj7>a každy sa jej bojí. <Ami>
 \ks
 
 \zs
@@ -22,15 +22,15 @@ jej bozky strašne bolia.
 \ks
 
 \zr
-4× /: \Ch{Ami}{Óóóóóóóo}...    \Ch{Dmi}{} \Ch{Ami}{} :/
+4× /: <Ami>Óóóóóóóo... <Dmi> <Ami> :/
 
-\Ch{Ami}{Tej kr}áske na \Ch{Emi}{pražskom} Orlo\Ch{Ami}{ji}
+<Ami>Tej kráske na <Emi>pražskom Orlo<Ami>ji
 
-\Ch{C}{odkážte,} že o ňu \Ch{Emi}{vôbec} nesto\Ch{C}{jím,}
+<C>odkážte, že o ňu <Emi>vôbec nesto<C>jím,
 
-nech si ďalej \Ch{Emi}{máta} na ve\Ch{C}{ži,}
+nech si ďalej <Emi>máta na ve<C>ži,
 
-\Ch{Ami}{ja verím,} že \Ch{Emi}{budem} stále \Ch{Ami}{žiť.}
+<Ami>ja verím, že <Emi>budem stále <Ami>žiť.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Hana_Hegerová,_Waldemar_Matuška____Tak_abyste_to_věděla.tex
+++ b/tp-songs/02_pop_rock/Hana_Hegerová,_Waldemar_Matuška____Tak_abyste_to_věděla.tex
@@ -1,39 +1,39 @@
 % -*-coding: utf-8 -*-
 
 \zp{Tak abyste to věděla}{Hana Hegerová, Waldemar Matuška}
-\Ch{Gmi}{~~} \Ch{Gmi}{~~}
-\Ch{D7}{~~} \Ch{D7}{~~}
-\Ch{Gmi}{~~} \Ch{Gmi}{~~}
-\Ch{D7}{~~} \Ch{D7}{~~}
+<Gmi>~~ <Gmi>~~
+<D7>~~ <D7>~~
+<Gmi>~~ <Gmi>~~
+<D7>~~ <D7>~~
 
 \zs
-\Ch{Gmi}{Marně} si hlavu \Ch{Cmi}{lámu,}
-\Ch{D7}{proč} muži větši\Ch{Gmi}{nou}
+<Gmi>Marně si hlavu <Cmi>lámu,
+<D7>proč muži větši<Gmi>nou
 
-neradi vidí \Ch{Cmi}{dámu}
-\Ch{A7}{chladnou} a nečin\Ch{D7}{nou.}
+neradi vidí <Cmi>dámu
+<A7>chladnou a nečin<D7>nou.
 
-\Ch{Cmi}{Nedávno} přišel \Ch{D7}{ke mně,}
-\Ch{Cmi}{sladkej} a \Ch{A7}{milej} \Ch{D7}{byl}
+<Cmi>Nedávno přišel <D7>ke mně,
+<Cmi>sladkej a <A7>milej <D7>byl
 
-\Ch{Gmi}{a doop}ravdy \Ch{A7}{jemně},
-\Ch{D7}{jemně} mě oslo\Ch{G}{vil.}
+<Gmi>a doopravdy <A7>jemně,
+<D7>jemně mě oslo<G>vil.
 \ks
 
 \zr
-\Ch{G}{Vy} byste porád seděla
-a nevydala \Ch{D7}{hlásku}
+<G>Vy byste porád seděla
+a nevydala <D7>hlásku
 
 a to se přece nedělá
-a já vás varu\Ch{G}{ju!}
+a já vás varu<G>ju!
 
-Tak \Ch{G7}{abys}te to \Ch{C}{věděla,}
-tak \Ch{Eb7}{já vám} vyznám \Ch{G}{lásku,}
+Tak <G7>abyste to <C>věděla,
+tak <Eb7>já vám vyznám <G>lásku,
 
-Tak a-\Ch{F#7}{by-}\Ch{F7}{ste} \Ch{E7}{to} \Ch{A7}{věděla,}
-tak \Ch{D7}{já v}ás \Ch{Gmi}{miluju!}
+Tak a-<F#7>by-<F7>ste <E7>to <A7>věděla,
+tak <D7>já vás <Gmi>miluju!
 
-\Ch{D7}{~~} \Ch{D7}{~~} \Ch{Gmi}{~~} \Ch{Gmi}{~~} \Ch{D7}{~~} \Ch{D7}{~~}
+<D7>~~ <D7>~~ <Gmi>~~ <Gmi>~~ <D7>~~ <D7>~~
 \kr
 
 \zs
@@ -68,9 +68,9 @@ tak tiše zašeptá:
 
 \zr
 
-...\Ch{D7}{jááá} vás \Ch{D7}{milu}ju\Ch{G}{}
+...<D7>jááá vás <D7>miluju<G>
 
-á dá \Ch{D7}{dá} já jaš ta \Ch{G}{dá}
+á dá <D7>dá já jaš ta <G>dá
 \kr
 \kp
 

--- a/tp-songs/02_pop_rock/Hana_Hegerová,_Waldemar_Matuška____Tak_abyste_to_věděla.tex
+++ b/tp-songs/02_pop_rock/Hana_Hegerová,_Waldemar_Matuška____Tak_abyste_to_věděla.tex
@@ -1,10 +1,7 @@
 % -*-coding: utf-8 -*-
 
 \zp{Tak abyste to věděla}{Hana Hegerová, Waldemar Matuška}
-<Gmi>~~ <Gmi>~~
-<D7>~~ <D7>~~
-<Gmi>~~ <Gmi>~~
-<D7>~~ <D7>~~
+<Gmi> <Gmi> <D7> <D7> <Gmi> <Gmi> <D7> <D7>
 
 \zs
 <Gmi>Marně si hlavu <Cmi>lámu,
@@ -30,10 +27,10 @@ a já vás varu<G>ju!
 Tak <G7>abyste to <C>věděla,
 tak <Eb7>já vám vyznám <G>lásku,
 
-Tak a-<F#7>by-<F7>ste <E7>to <A7>věděla,
+Tak a<F#7>by<F7>ste <E7>to <A7>věděla,
 tak <D7>já vás <Gmi>miluju!
 
-<D7>~~ <D7>~~ <Gmi>~~ <Gmi>~~ <D7>~~ <D7>~~
+<D7> <D7> <Gmi> <Gmi> <D7> <D7>
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Hana_Hegerová____Levandulová.tex
+++ b/tp-songs/02_pop_rock/Hana_Hegerová____Levandulová.tex
@@ -3,26 +3,26 @@
 \zp{Levandulová}{Hana Hegerová}
 \zs
 
-\Ch{C}{Za} mostem v úzké \Ch{Ami}{ulici}
-\Ch{C}{je} krámek z dálky \Ch{Ami}{vonící}
-\Ch{C}{meduňkou}, rdesnem, \Ch{Ami}{skořicí,}
-ale \Ch{Dmi}{hlavně} -- ach \Ch{G}{jo...}
+<C>Za mostem v úzké <Ami>ulici
+<C>je krámek z dálky <Ami>vonící
+<C>meduňkou, rdesnem, <Ami>skořicí,
+ale <Dmi>hlavně -- ach <G>jo...
 
 \ks
 \zs
 
-\Ch{Dmi}{Léta} snad z úcty k \Ch{G}{tradici}
-\Ch{Dmi}{kupuji} celou \Ch{G}{krabici}
-\Ch{Dmi}{a přes} ní i papír \Ch{G}{balící}
-cí\Ch{Dmi}{tím,} že řekneš: \Ch{G}{ }
+<Dmi>Léta snad z úcty k <G>tradici
+<Dmi>kupuji celou <G>krabici
+<Dmi>a přes ní i papír <G>balící
+cí<Dmi>tím, že řekneš: <G> 
 
 \ks
 \zr
 
-Ty jsi \Ch{C}{má,} \Ch{Ami}{levandulo}\Ch{C}{vá,} \Ch{Ami}{ }
-úplně \Ch{C}{celá}, celičká \Ch{Ami}{levandulo}\Ch{C}{vá,} \Ch{Ami}{ }
-nád\Ch{Dmi}{herně} \Ch{G}{levandulo}\Ch{Dmi}{vá,}\Ch{G}{ }
-\Ch{Dmi}{hmm} \Ch{G}{--} levandulo\Ch{C}{vá.}
+Ty jsi <C>má, <Ami>levandulo<C>vá, <Ami> 
+úplně <C>celá, celičká <Ami>levandulo<C>vá, <Ami> 
+nád<Dmi>herně <G>levandulo<Dmi>vá,<G> 
+<Dmi>hmm <G>-- levandulo<C>vá.
 
 \kr
 \zs

--- a/tp-songs/02_pop_rock/Hana_Zagorová____Maluj_zase_obrázky.tex
+++ b/tp-songs/02_pop_rock/Hana_Zagorová____Maluj_zase_obrázky.tex
@@ -3,30 +3,30 @@
 \zp{Maluj zase obrázky}{Hana Zagorová}
 
 \zs
-\Ch{Ami}{Měli} jsme dva hrníčky, \Ch{G}{čtyři} talí\Ch{Ami}{ře,}
+<Ami>Měli jsme dva hrníčky, <G>čtyři talí<Ami>ře,
 
-\Ch{Dmi}{vyzdobené} \Ch{G}{sluníčky} \Ch{C}{přímo od} malíře,
+<Dmi>vyzdobené <G>sluníčky <C>přímo od malíře,
 
-\Ch{Ami}{cukru} na pět \Ch{E}{hromádek}, \Ch{Ami}{čtyři} {knížky} \Ch{F}{pohádek,}
+<Ami>cukru na pět <E>hromádek, <Ami>čtyři {knížky} <F>pohádek,
 
-\Ch{C}{dva} prstýnky \Ch{Dmi}{na splátky,} \Ch{Cdim}{prázdné} přihrád\Ch{E}{ky.}
+<C>dva prstýnky <Dmi>na splátky, <Cdim>prázdné přihrád<E>ky.
 
 \bigskip
 
-\Ch{F}{Maloval} jsi \Ch{Fmaj7}{obrázky} \Ch{C}{dlaní} horkou \Ch{Cmaj7}{od lásky,}
+<F>Maloval jsi <Fmaj7>obrázky <C>dlaní horkou <Cmaj7>od lásky,
 
-\Ch{B}{Chroupali} jsme \Ch{B7}{oblázky} \Ch{E}{jako} oplat\Ch{Ami}{ky.} \Ch{E}{ }
+<B>Chroupali jsme <B7>oblázky <E>jako oplat<Ami>ky. <E> 
 \ks
 
 
 \zr
-\Ch{Ami}{Žádné} auto v garáži, \Ch{G}{jenom} \Ch{Emi}{pevná} \Ch{Ami}{zem,}
+<Ami>Žádné auto v garáži, <G>jenom <Emi>pevná <Ami>zem,
 
-\Ch{Dmi}{stávali} jsme v \Ch{G}{pasáži} \Ch{C}{frontu} na podnájem,
+<Dmi>stávali jsme v <G>pasáži <C>frontu na podnájem,
 
-\Ch{Dmi}{chodili} jsme \Ch{G}{do} Šárky, \Ch{C}{kupovali} Polárky,
+<Dmi>chodili jsme <G>do Šárky, <C>kupovali Polárky,
 
-\Ch{Dmi}{šetřili} jsme \Ch{E}{na} dárky \Ch{Ami}{malé} jako svět.
+<Dmi>šetřili jsme <E>na dárky <Ami>malé jako svět.
 
 \bigskip
 

--- a/tp-songs/02_pop_rock/Ivan_Hlas____Aranka_umí_hula_hop.tex
+++ b/tp-songs/02_pop_rock/Ivan_Hlas____Aranka_umí_hula_hop.tex
@@ -3,13 +3,13 @@
 \zp{Aranka umí hula hop}{Ivan Hlas}
 
 \zs
-\Ch{Hmi}{Barevnej} šátek {do} vla\Ch{G}{sů} a \Ch{F#}{jedem,}
+<Hmi>Barevnej šátek {do} vla<G>sů a <F#>jedem,
 
-\Ch{Hmi}{na křídlech} černejch pega\Ch{G}{sů} se \Ch{F#}{svedem,}
+<Hmi>na křídlech černejch pega<G>sů se <F#>svedem,
 
-\Ch{Hmi}{tohle} je vůbec dobrej \Ch{G}{kraj,}
+<Hmi>tohle je vůbec dobrej <G>kraj,
 
-kde ti všechno \Ch{Hmi}{daj a} nejjemější z \Ch{A}{vín} tu \Ch{Hmi}{znaj.}
+kde ti všechno <Hmi>daj a nejjemější z <A>vín tu <Hmi>znaj.
 \ks
 
 \zs
@@ -23,13 +23,13 @@ v tom stavu nejsi zlej a oči kryje stín.}
 \ks
 
 \zr
-\Ch{D}{Aranka} umí \uv{hula \Ch{G}{hop,}} ty dy ty ty,
+<D>Aranka umí \uv{hula <G>hop,} ty dy ty ty,
 
-\Ch{D}{až} Pánbůh tiše úpí \uv{\Ch{G}{stop,}} ty dy ty ty,
+<D>až Pánbůh tiše úpí \uv{<G>stop,} ty dy ty ty,
 
-\Ch{D}{občas} se ve tmě blejskne \Ch{C}{nůž,}
+<D>občas se ve tmě blejskne <C>nůž,
 
-i ty ho pilně \Ch{Hmi}{bruš} a srdce otví\Ch{A}{rej,} co s \Ch{Hmi}{tím.}
+i ty ho pilně <Hmi>bruš a srdce otví<A>rej, co s <Hmi>tím.
 \kr
 
 \zs
@@ -53,7 +53,7 @@ a nutí cizí koně v klus, ty dy ty ty,
 
 občas se ve tmě blejskne nůž,
 
-i ty ho pilně bruš a dobře vybírej, kam s ním, \Ch{A}{hej,} kam \Ch{D}{s ním.}
+i ty ho pilně bruš a dobře vybírej, kam s ním, <A>hej, kam <D>s ním.
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Ivan_Hlas____Jednou_mi_fotr_povídá.tex
+++ b/tp-songs/02_pop_rock/Ivan_Hlas____Jednou_mi_fotr_povídá.tex
@@ -3,11 +3,11 @@
 \zp{Jednou mi fotr povídá}{Ivan Hlas}
 
 \zs
-\Ch{A}{Jednou} mi fotr \Ch{A7}{povídá:}
+<A>Jednou mi fotr <A7>povídá:
 
-\uv{\Ch{D}{Zůstali} jsme už sami dva,}
+\uv{<D>Zůstali jsme už sami dva,}
 
-že \Ch{E}{si} chce začít taky trochu \Ch{A}{žít.}
+že <E>si chce začít taky trochu <A>žít.
 
 \uv{Nech si to projít palicí
 
@@ -17,13 +17,13 @@ snaž se mě, hochu, trochu pochopit.}
 \ks
 
 \zr
-Já \Ch{E}{šel}, šel dál, oh baby, \Ch{A}{kam} mě Pán Bůh zval,
+Já <E>šel, šel dál, oh baby, <A>kam mě Pán Bůh zval,
 
-já \Ch{E}{šel}, šel dál, oh baby, a \Ch{D7}{furt} jen tancoval.
+já <E>šel, šel dál, oh baby, a <D7>furt jen tancoval.
 
-Na \Ch{A}{každý} divný hranici, \Ch{D}{na} policejní stanici,
+Na <A>každý divný hranici, <D>na policejní stanici,
 
-\Ch{E}{hrál} jsem jenom rock'n'roll for \Ch{A}{you.}
+<E>hrál jsem jenom rock'n'roll for <A>you.
 \kr
 
 \zs
@@ -40,7 +40,7 @@ po boku krásnou slepici
 a lidi šeptaj: \uv{Přijel nějakej král.}
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Pořád tak nějak nemohu
@@ -56,7 +56,7 @@ a nový ráno šacovat
 a do mě vždycky pustí silnej proud.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Ivan_Hlas____Na_kolena.tex
+++ b/tp-songs/02_pop_rock/Ivan_Hlas____Na_kolena.tex
@@ -3,13 +3,13 @@
 \zp{Na kolena}{Ivan Hlas}
 
 \zs
-Táhněte \Ch{G}{do} háje, všichni \Ch{Emi}{pryč!}
+Táhněte <G>do háje, všichni <Emi>pryč!
 
-Chtěl jsem jít \Ch{G}{do} ráje a nemám \Ch{Emi}{klíč.}
+Chtěl jsem jít <G>do ráje a nemám <Emi>klíč.
 
-Jak si tu \Ch{G}{můžete} takhle \Ch{Emi}{žrát}?
+Jak si tu <G>můžete takhle <Emi>žrát?
 
-Ztratil jsem \Ch{C}{holku}, co jí mám \Ch{D}{rád!}
+Ztratil jsem <C>holku, co jí mám <D>rád!
 \ks
 
 \zs
@@ -23,13 +23,13 @@ váš pohled {káravej} už dávno {znám.}
 \ks
 
 \zr
-Pořád jen: \uv{\Ch{C}{Na} kolena, na kolena, na kolena, na kolena,} \Ch{G}{jé,} jé, jé,
+Pořád jen: \uv{<C>Na kolena, na kolena, na kolena, na kolena,} <G>jé, jé, jé,
 
-pořád jen: \uv{\Ch{C}{Na} kolena, na kolena, na kolena, na kolena,}  \Ch{G}{jé,} jé, jé,
+pořád jen: \uv{<C>Na kolena, na kolena, na kolena, na kolena,} <G>jé, jé, jé,
 
-pořád jen: \uv{\Ch{C}{Na} kolena, na kolena, na kolena, na kolena,} \Ch{G}{je} to \Ch{Emi}{tak}
+pořád jen: \uv{<C>Na kolena, na kolena, na kolena, na kolena,} <G>je to <Emi>tak
 
-a vaše \Ch{C}{saka} vám posere \Ch{D}{pták.}
+a vaše <C>saka vám posere <D>pták.
 \kr
 
 \zs
@@ -42,7 +42,7 @@ Kašlu vám na bonton, \uv{Bejby, si chytrej chlap,}
 sere mě Tichej Don a ten váš tupej dav.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Pořád jen: \uv{Na kolena...}

--- a/tp-songs/02_pop_rock/Ivan_Hlas____Pod_oknem.tex
+++ b/tp-songs/02_pop_rock/Ivan_Hlas____Pod_oknem.tex
@@ -3,7 +3,7 @@
 \zp{Pod oknem}{Ivan Hlas}
 
 \zs
-\Ch{G}{Práz}dnou \Ch{A}{nár}uč mám, \Ch{Ami}{když} nemů\Ch{D7}{žu být} s \Ch{G4sus}{tebou,}\Ch{G}{}
+<G>Prázdnou <A>náruč mám, <Ami>když nemů<D7>žu být s <G4sus>tebou,<G>
 
 chci jít a nevím kam a svět má barvu šedou,
 
@@ -13,13 +13,13 @@ trpím jak mladej mnich a chtěl bych tě vzít s sebou.
 \ks
 
 \zr
-\Ch{Emi}{V rok}li je tráva \Ch{A}{taj}emná
+<Emi>V rokli je tráva <A>tajemná
 
-\Ch{Emi}{a nej}hebčí co \Ch{A}{znám},
+<Emi>a nejhebčí co <A>znám,
 
-\Ch{C}{nad} hlavou hloubka \Ch{G}{bez}edná,
+<C>nad hlavou hloubka <G>bezedná,
 
-\Ch{C}{líb}aní, noc a \Ch{H}{já}...
+<C>líbaní, noc a <H>já...
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Jana_Kirschner____Žienka.tex
+++ b/tp-songs/02_pop_rock/Jana_Kirschner____Žienka.tex
@@ -3,13 +3,13 @@
 \zp{Žienka domáca}{Jana Kirschner}
 
 \zs
-\Ch{C}{Nechcem} byť žienka domáca
+<C>Nechcem byť žienka domáca
 
-a už \Ch{F}{vôbec} nechcem vydať sa,
+a už <F>vôbec nechcem vydať sa,
 
-\Ch{G}{nechcem} byť žena a mať stres,
+<G>nechcem byť žena a mať stres,
 
-\Ch{C}{nechcem} mať muža a deti \Ch{H+}{päť.}
+<C>nechcem mať muža a deti <H+>päť.
 \ks
 
 \zs
@@ -23,19 +23,19 @@ to nie je pre mňa, to je zlý sen.
 \ks
 
 \zr
-\Ch{F}{Žiť ako} kvietok umelý
+<F>Žiť ako kvietok umelý
 
-\Ch{C}{a čakať} kým ma niekto \Ch{Ami}{opelí,}
+<C>a čakať kým ma niekto <Ami>opelí,
 
-byť \Ch{D}{milá} a dobrá, to radšej nie,
+byť <D>milá a dobrá, to radšej nie,
 
-\Ch{G}{dúfam,} že sa mi to \Ch{H+}{nestane.}
+<G>dúfam, že sa mi to <H+>nestane.
 
-/: \Ch{C}{Ty chceš} a ja nie
+/: <C>Ty chceš a ja nie
 
-\Ch{F}{veď žiť} s tebou, to je umenie
+<F>veď žiť s tebou, to je umenie
 
-\Ch{G}{nechcem} žiť s tebou, ale bez teba \Ch{C}{nie.} ~\Ch{H+}{} :/
+<G>nechcem žiť s tebou, ale bez teba <C>nie. ~<H+> :/
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Janek_Ledecký____Na_ptáky_jsme_krátký.tex
+++ b/tp-songs/02_pop_rock/Janek_Ledecký____Na_ptáky_jsme_krátký.tex
@@ -3,19 +3,19 @@
 \zp{Na ptáky jsme krátký}{Janek Ledecký}
 
 \zr
-\Ch{E}{Na ptáky} jsme \Ch{H}{krátký,}
+<E>Na ptáky jsme <H>krátký,
 
-\Ch{C#mi}{na ptáky} jsme \Ch{A}{malý páky,}
+<C#mi>na ptáky jsme <A>malý páky,
 
-\Ch{E}{je to tak,} to \Ch{H}{my si dáme} na zo\Ch{E}{bák.}
+<E>je to tak, to <H>my si dáme na zo<E>bák.
 \kr
 
 \zs
-\Ch{E}{V patnácti} s prvním cigárem
+<E>V patnácti s prvním cigárem
 
-\Ch{F#mi}{říkal jsem} si: \uv{Aspoň trochu zestárnem,}
+<F#mi>říkal jsem si: \uv{Aspoň trochu zestárnem,}
 
-z plnejch \Ch{A}{plic} -- a pak už se mnou nebylo \Ch{E}{nic.}
+z plnejch <A>plic -- a pak už se mnou nebylo <E>nic.
 \ks
 
 \zs
@@ -27,11 +27,11 @@ s Yesterday a Žlutou ponorkou,
 \ks
 
 \zs
-\Ch{C#mi}{Kdekdo by} chtěl \Ch{A}{lítat} ke hvěz\Ch{E}{dám,}
+<C#mi>Kdekdo by chtěl <A>lítat ke hvěz<E>dám,
 
-\Ch{C#mi}{každej na} to \Ch{A}{musí} přijít \Ch{H}{sám,}
+<C#mi>každej na to <A>musí přijít <H>sám,
 
-jen \Ch{A}{sám,} jen \Ch{D}{sám,} jen \Ch{H}{sám.}
+jen <A>sám, jen <D>sám, jen <H>sám.
 \ks
 
 \zr

--- a/tp-songs/02_pop_rock/Jarda_Hypochondr____Šenkýřka.tex
+++ b/tp-songs/02_pop_rock/Jarda_Hypochondr____Šenkýřka.tex
@@ -3,38 +3,38 @@
 \zp{Šenkýřka}{Jarda Hypochondr}
 
 \zr
-Dneska to \Ch{C}{roz}jedem na plný \Ch{F}{pecky,}
+Dneska to <C>rozjedem na plný <F>pecky,
 
-zpívat a \Ch{G}{tan}covat, prošoupem \Ch{C}{kec}ky.
+zpívat a <G>tancovat, prošoupem <C>kecky.
 
-Skoč na stůl, \Ch{C}{šenk}ýřko, svlíkni se \Ch{F}{do na}ha,
+Skoč na stůl, <C>šenkýřko, svlíkni se <F>do naha,
 
-ať se nám \Ch{G}{voká}že tvá kyprá \Ch{C}{pos}tava.
+ať se nám <G>vokáže tvá kyprá <C>postava.
 \kr
 
 
 \zs
-\Ch{C}{Stou}pá mi to, stoupá,
+<C>Stoupá mi to, stoupá,
 
-konto na \Ch{F}{lís}tku, huso hloupá,
+konto na <F>lístku, huso hloupá,
 
-natoč \Ch{G}{piv}o, navrch pěnu,
+natoč <G>pivo, navrch pěnu,
 
-za tvý \Ch{F}{tělo} zvedám \Ch{G}{cenu.}
+za tvý <F>tělo zvedám <G>cenu.
 \ks
 
 \zr \kr
 
 \zr
-Aua\Ch{C}{ú} aua\Ch{F}{ú,}
+Aua<C>ú aua<F>ú,
 
-Aua\Ch{G}{ú} aua\Ch{C}{ú,}
+Aua<G>ú aua<C>ú,
 
 
 
-Aua\Ch{C}{ú} aua\Ch{F}{ú,}
+Aua<C>ú aua<F>ú,
 
-Aua\Ch{G}{ú} aua\Ch{C}{ú.}
+Aua<G>ú aua<C>ú.
 \kr
 
 

--- a/tp-songs/02_pop_rock/Jaroslav_Hutka____Morava.tex
+++ b/tp-songs/02_pop_rock/Jaroslav_Hutka____Morava.tex
@@ -3,23 +3,23 @@
 \zp{Morava}{Jaroslav Hutka}
 
 \zs
-\Ch{Ami}{Brněnská radnice} stavěná do vejš\Ch{E}{ky,}
+<Ami>Brněnská radnice stavěná do vejš<E>ky,
 
-v ulicích práší se a nejvíc na Čes\Ch{Ami}{ký} \Ch{E7}{}
+v ulicích práší se a nejvíc na Čes<Ami>ký <E7>
 
-\Ch{Ami}{Dětičky} s jásotem z radnice máva\Ch{Dmi}{jí,}
+<Ami>Dětičky s jásotem z radnice máva<Dmi>jí,
 
-\Ch{C}{holubi} nad měs\Ch{E}{tem poletu}\Ch{Ami}{jí.}
+<C>holubi nad měs<E>tem poletu<Ami>jí.
 \ks
 
 \zr
-\Ch{G7}{A Mora}\Ch{C}{va je krásná} zem, na její \Ch{G7}{slávu} připijem,
+<G7>A Mora<C>va je krásná zem, na její <G7>slávu připijem,
 
-só na ní hezká děvčata tvářičky \Ch{C}{majó ze} zlata.
+só na ní hezká děvčata tvářičky <C>majó ze zlata.
 
-Dobrý člo\Ch{Dmi}{věk ještě ži}\Ch{E}{je: na} Moravě víno pi\Ch{Ami}{je.}
+Dobrý člo<Dmi>věk ještě ži<E>je: na Moravě víno pi<Ami>je.
 
-Proto ať vzkvétá Mora\Ch{C}{va a je}\Ch{G7}{jí slá}\Ch{C}{va.} \Ch{E}{}
+Proto ať vzkvétá Mora<C>va a je<G7>jí slá<C>va. <E>
 \kr
 
 \zs
@@ -54,17 +54,17 @@ Visí na řetizku, v průvanu houpe se, píšu do notysku, ať nekrmí se.
 
 \zr\kr
 
-Rec: \Ch{Ami}{} \uv{Tož, dámo, co si dáte?}
+Rec: <Ami> \uv{Tož, dámo, co si dáte?}
 
-\Ch{E}{} \uv{Nic nechcu, pane vrchní, su smutná.}
+<E> \uv{Nic nechcu, pane vrchní, su smutná.}
 
-\Ch{E}{} \uv{Tož něco si dát musíte, jste v jedničce.}
+<E> \uv{Tož něco si dát musíte, jste v jedničce.}
 
-\Ch{E}{} \Ch{Ami}{} \uv{Říkám, nic nechcu, su smutná!}
+<E> <Ami> \uv{Říkám, nic nechcu, su smutná!}
 
-\Ch{Ami}{} \uv{Tož si dajte něco tvrdýho, \Ch{Dmi}{} třeba gruziňak.}
+<Ami> \uv{Tož si dajte něco tvrdýho, <Dmi> třeba gruziňak.}
 
-\uv{\Ch{Ami}{Nechcu, pane vrchní,} \Ch{E7}{po tem su} \Ch{Ami}{smutná.}}
+\uv{<Ami>Nechcu, pane vrchní, <E7>po tem su <Ami>smutná.}
 
 \zr\kr
 

--- a/tp-songs/02_pop_rock/Jiří_Schelinger____Holubí_dům.tex
+++ b/tp-songs/02_pop_rock/Jiří_Schelinger____Holubí_dům.tex
@@ -3,13 +3,13 @@
 \zp{Holubí dům}{Jiří Schelinger}
 
 \zs
-\Ch{Emi}{Zpí}\Ch{D}{vám} \Ch{Cmaj7}{ptákům} a \Ch{Hmi7}{zvlášť} holu\Ch{Emi}{bům,}
+<Emi>Zpí<D>vám <Cmaj7>ptákům a <Hmi7>zvlášť holu<Emi>bům,
 
-stá\Ch{D}{val} v \Ch{Cmaj7}{údolí} \Ch{Hmi7}{mém} starý \Ch{Emi}{dům.}
+stá<D>val v <Cmaj7>údolí <Hmi7>mém starý <Emi>dům.
 
-\Ch{G}{Ptá}\Ch{D}{ků} \Ch{G}{houf} zalé\Ch{D}{tal} ke kro\Ch{G}{vům,}
+<G>Ptá<D>ků <G>houf zalé<D>tal ke kro<G>vům,
 
-\Ch{Emi}{měl} \Ch{D}{jsem} \Ch{Cmaj7}{rád} holu\Ch{Hmi7}{bích} křídel \Ch{Emi}{šum.}
+<Emi>měl <D>jsem <Cmaj7>rád holu<Hmi7>bích křídel <Emi>šum.
 \ks
 
 \zs
@@ -23,15 +23,15 @@ měl jsem rád starý dům, jeho práh.
 \ks
 
 \zr
-\Ch{Emi}{Hledám} \Ch{Ami7}{dům holu}\Ch{D}{bí,}
+<Emi>Hledám <Ami7>dům holu<D>bí,
 
-kdopak \Ch{G}{z vás} cestu \Ch{Emi}{ví?}
+kdopak <G>z vás cestu <Emi>ví?
 
-Míval \Ch{C}{stáj} roube\Ch{D}{nou}, bílý \Ch{G}{štít.}
+Míval <C>stáj roube<D>nou, bílý <G>štít.
 
-Kde je \Ch{Ami7}{dům holu}\Ch{D}{bí} a ta \Ch{G}{dívka} kde \Ch{Emi}{spí?}
+Kde je <Ami7>dům holu<D>bí a ta <G>dívka kde <Emi>spí?
 
-Vždyť to \Ch{C}{ví,} že jsem \Ch{Hmi}{chtěl} pro ni \Ch{Emi}{žít.}
+Vždyť to <C>ví, že jsem <Hmi>chtěl pro ni <Emi>žít.
 \kr
 
 \zs
@@ -54,7 +54,7 @@ Můžeš mít třeba zrak sokolí,
 nespatříš ztracené údolí.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Jiří_Schelinger____Šípková_Růženka.tex
+++ b/tp-songs/02_pop_rock/Jiří_Schelinger____Šípková_Růženka.tex
@@ -3,23 +3,23 @@
 \zp{Šípková Růženka}{Jiří Schelinger}
 
 \zs
-Ještě \Ch{Gmi}{spí a spí} a spí zámek \Ch{F}{šípkový,}
+Ještě <Gmi>spí a spí a spí zámek <F>šípkový,
 
-\Ch{Gmi}{žádný} princ tam v lesích \Ch{Dmi}{ptáky} neloví.
+<Gmi>žádný princ tam v lesích <Dmi>ptáky neloví.
 
-Ještě \Ch{Gmi}{spí a sp}í a spí dívka \Ch{F}{zakletá,}
+Ještě <Gmi>spí a spí a spí dívka <F>zakletá,
 
-\Ch{Gmi}{u lůž}ka jí planá \Ch{Dmi}{růže} rozkvétá.  \Ch{D}{ } \Ch{C}{ } \Ch{B}{ }
+<Gmi>u lůžka jí planá <Dmi>růže rozkvétá. <D> <C> <B> 
 
-To se \Ch{C}{schválně} dětem \Ch{Gmi}{říká,}  \Ch{G}{ } \Ch{F}{ } \Ch{D#}{ }
+To se <C>schválně dětem <Gmi>říká, <G> <F> <D#> 
 
-aby s \Ch{F}{důvěrou} šly \Ch{B}{spát}, klidně \Ch{Dmi}{spát,}
+aby s <F>důvěrou šly <B>spát, klidně <Dmi>spát,
 
-že se \Ch{Gmi}{dům} probou\Ch{F}{zí}
+že se <Gmi>dům probou<F>zí
 
-a ta \Ch{B}{kráska} proci\Ch{D#}{tá,} \Ch{D#}{ } \Ch{D}{ }
+a ta <B>kráska proci<D#>tá, <D#> <D> 
 
-\Ch{Cmi}{zatím} spí tam \Ch{Dmi}{dál,} spí tam v \Ch{Gmi}{růžích.}
+<Cmi>zatím spí tam <Dmi>dál, spí tam v <Gmi>růžích.
 \ks
 
 \zs
@@ -41,11 +41,11 @@ zatím spí tam dál, spí v růžích.
 \ks
 
 \zs
-\Ch{Gmi}{Musíš} přijít \Ch{F}{sám},
+<Gmi>Musíš přijít <F>sám,
 
-nesmíš \Ch{B}{věřit} pohád\Ch{D#}{kám,} \Ch{D#}{ } \Ch{D}{ }
+nesmíš <B>věřit pohád<D#>kám, <D#> <D> 
 
-/: \Ch{Cmi}{čeká} dívka \Ch{F}{dál}, spí tam v \Ch{Dmi}{růžích.} :/
+/: <Cmi>čeká dívka <F>dál, spí tam v <Dmi>růžích. :/
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Jiří_Suchý____Marnivá_sestřenice.tex
+++ b/tp-songs/02_pop_rock/Jiří_Suchý____Marnivá_sestřenice.tex
@@ -3,43 +3,43 @@
 \zp{Marnivá sestřenice}{Jiří Suchý}
 
 \zs
-\Ch{C}{Měla} vlasy samou loknu, jé \Ch{G}{je je,}
+<C>Měla vlasy samou loknu, jé <G>je je,
 
-\Ch{G7}{ráno} přistoupila k oknu, jé \Ch{C}{je je,}
+<G7>ráno přistoupila k oknu, jé <C>je je,
 
-\Ch{C}{vlasy} samou \Ch{C7}{loknu} měla \Ch{F}{a} na nic víc \Ch{Fmi}{nemyslela,}
+<C>vlasy samou <C7>loknu měla <F>a na nic víc <Fmi>nemyslela,
 
-\Ch{C}{a} na nic víc \Ch{A7}{nemyslela}, \Ch{D7}{jé,} \Ch{G7}{jé,} \Ch{C}{jé}.
+<C>a na nic víc <A7>nemyslela, <D7>jé, <G7>jé, <C>jé.
 \ks
 
 \zs
-\Ch{C#}{Nutno ještě} podotknouti, jé \Ch{G#}{je je,}
+<C#>Nutno ještě podotknouti, jé <G#>je je,
 
-\Ch{G#7}{že si vlasy} kulmou kroutí, jé \Ch{C#}{je je,}
+<G#7>že si vlasy kulmou kroutí, jé <C#>je je,
 
-nesuší si \Ch{C#7}{vlasy fénem,} \Ch{F#}{nýbrž jen tak} \Ch{F#mi}{nad plamenem,}
+nesuší si <C#7>vlasy fénem, <F#>nýbrž jen tak <F#mi>nad plamenem,
 
-\Ch{C#}{nýbrž jen tak} \Ch{A#7}{nad plamenem,} \Ch{D#7}{jé,} \Ch{G#7}{jé,} \Ch{C#}{jé.}
+<C#>nýbrž jen tak <A#7>nad plamenem, <D#7>jé, <G#7>jé, <C#>jé.
 \ks
 
 \zs
-\Ch{D}{Jednou vlasy} sežehla si, jé \Ch{A}{je je,}
+<D>Jednou vlasy sežehla si, jé <A>je je,
 
-\Ch{A7}{tím pádem je} konec krásy, jé \Ch{D}{je je,}
+<A7>tím pádem je konec krásy, jé <D>je je,
 
-když přistoupí \Ch{D7}{ráno k oknu,} \Ch{G}{nemá vlasy} \Ch{Gmi}{samou loknu,}
+když přistoupí <D7>ráno k oknu, <G>nemá vlasy <Gmi>samou loknu,
 
-\Ch{D}{nemá vlasy} \Ch{H7}{samou loknu,} \Ch{E7}{jé,} \Ch{A7}{jé,} \Ch{D}{jé.}
+<D>nemá vlasy <H7>samou loknu, <E7>jé, <A7>jé, <D>jé.
 \ks
 
 \zs
-\Ch{D#}{O vlasy už} nestará se, jé \Ch{A#}{je je,}
+<D#>O vlasy už nestará se, jé <A#>je je,
 
-\Ch{A#7}{a diví se} světa kráse, jé \Ch{D#}{je je,}
+<A#7>a diví se světa kráse, jé <D#>je je,
 
-vidí plno \Ch{D#7}{jinejch věcí,} \Ch{G#7}{a to za} \Ch{G#mi}{to stojí přeci,}
+vidí plno <D#7>jinejch věcí, <G#7>a to za <G#mi>to stojí přeci,
 
-\Ch{D#}{a to za to} \Ch{C7}{stojí přeci,} \Ch{F7}{jé,} \Ch{A#7}{jé,} \Ch{D#}{jé.}
+<D#>a to za to <C7>stojí přeci, <F7>jé, <A#7>jé, <D#>jé.
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Jiří_Suchý____Pramínek_vlasů.tex
+++ b/tp-songs/02_pop_rock/Jiří_Suchý____Pramínek_vlasů.tex
@@ -2,16 +2,16 @@
 
 \zp{Pramínek vlasů}{Jiří Suchý}
 
-\Ch{C}{~~} \Ch{Ami}{~~} \Ch{F}{~~} \Ch{G}{}
+<C>~~ <Ami>~~ <F>~~ <G>
 
 \zs
-Když měsíc \Ch{C}{roz}lije \Ch{Ami}{světlo} své \Ch{F}{po} kraji\Ch{G}{}
+Když měsíc <C>rozlije <Ami>světlo své <F>po kraji<G>
 
-a hvězdy \Ch{C}{řek}nou, \Ch{Ami}{že čas} je jít \Ch{F}{spát,} \Ch{G7}{}
+a hvězdy <C>řeknou, <Ami>že čas je jít <F>spát, <G7>
 
-pramínek \Ch{C}{vlasů} \Ch{Ami}{jí ustřihnu} \Ch{F}{potají,} \Ch{G}{}
+pramínek <C>vlasů <Ami>jí ustřihnu <F>potají, <G>
 
-komu? No \Ch{C}{přece té,} \Ch{Fdim}{kterou} mám \Ch{C}{rád.} \Ch{G7}{}
+komu? No <C>přece té, <Fdim>kterou mám <C>rád. <G7>
 \ks
 
 \zs
@@ -25,15 +25,15 @@ věřím, že dnes v noci budou se zdát.
 \ks
 
 \zr
-O sny mě \Ch{B}{připraví} teprve \Ch{C}{svítání,}
+O sny mě <B>připraví teprve <C>svítání,
 
-zpěv ptáků v \Ch{B}{oblacích} a modré \Ch{C}{nebe,}
+zpěv ptáků v <B>oblacích a modré <C>nebe,
 
-od vlasů, \Ch{F}{jichž} jsem se
+od vlasů, <F>jichž jsem se
 
-dotýkal \Ch{C}{ve} spaní,
+dotýkal <C>ve spaní,
 
-nový den \Ch{Ab7}{nůžkama} odstřihne \Ch{G}{tebe.}
+nový den <Ab7>nůžkama odstřihne <G>tebe.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Jiří_Suchý____Zlatý_slunce_nad_hlavou.tex
+++ b/tp-songs/02_pop_rock/Jiří_Suchý____Zlatý_slunce_nad_hlavou.tex
@@ -4,58 +4,58 @@
 
 \zs
 
-\Ch{Cmi}{Někdy} se \Ch{Fmi}{zajíkáme} \Ch{Cmi}{štěstím,}
-\Ch{Cmi}{a jindy} \Ch{Fmi}{zase} život \Ch{G}{sám} \Ch{G7}{}
+<Cmi>Někdy se <Fmi>zajíkáme <Cmi>štěstím,
+<Cmi>a jindy <Fmi>zase život <G>sám <G7>
 
-\Ch{Cmi}{nás} pro\Ch{Fmi}{žene} trním a \Ch{Cmi}{klestím,}
-\Ch{G#}{takže} jsme \Ch{G#mi7}{zase samej} \Ch{Cmi}{šrám.}
+<Cmi>nás pro<Fmi>žene trním a <Cmi>klestím,
+<G#>takže jsme <G#mi7>zase samej <Cmi>šrám.
 
-\Ch{C}{Někdy} se \Ch{G}{ale} štěstí \Ch{C}{vrátí} \Ch{C7}{}
-\Ch{F}{a popřeje} nám dobrý \Ch{G}{den,}
+<C>Někdy se <G>ale štěstí <C>vrátí <C7>
+<F>a popřeje nám dobrý <G>den,
 
-\Ch{Cmi}{jindy} se \Ch{Fmi}{jednou provždy} \Ch{Cmi}{ztratí,}
-\Ch{G#}{jako se} \Ch{G#mi7}{ráno ztrácí} \Ch{Cmi}{sen.}
+<Cmi>jindy se <Fmi>jednou provždy <Cmi>ztratí,
+<G#>jako se <G#mi7>ráno ztrácí <Cmi>sen.
 
-\Ch{C}{Život} je \Ch{G}{něco} jako \Ch{C}{sázka,}
-\Ch{F}{jak} ta kulička v \Ch{G}{ruletě,}
+<C>Život je <G>něco jako <C>sázka,
+<F>jak ta kulička v <G>ruletě,
 
-\Ch{Cmi}{dneska} ti \Ch{Fmi}{řekne, co} je \Ch{Cmi}{láska (jé),}
-\Ch{G#}{a zejtra} \Ch{G#mi7}{mučit bu}de \Ch{C}{tě.}
+<Cmi>dneska ti <Fmi>řekne, co je <Cmi>láska (jé),
+<G#>a zejtra <G#mi7>mučit bude <C>tě.
 
-\Ch{Cmi}{Jásej, i} \Ch{Fmi}{když jen} polo\Ch{Cmi}{vina}
-\Ch{Cmi}{tvých} snů se \Ch{Fmi}{dočká} splně\Ch{G}{ní,} \Ch{G7}{}
+<Cmi>Jásej, i <Fmi>když jen polo<Cmi>vina
+<Cmi>tvých snů se <Fmi>dočká splně<G>ní, <G7>
 
-\Ch{Cmi}{víme,} že \Ch{Fmi}{je to vol}o\Ch{Cmi}{vina,}
-\Ch{G#}{však nikdo} \Ch{G#mi7}{z nás to nez}mě\Ch{C}{ní.} ~~ \Ch{H}{} \Ch{B}{} 
+<Cmi>víme, že <Fmi>je to volo<Cmi>vina,
+<G#>však nikdo <G#mi7>z nás to nezmě<C>ní. ~~ <H> <B> 
 \ks
 
 \zr
-\Ch{A7}{Zlatý} slunce nad hlavou
-\Ch{D}{a v duši} léto mít,
+<A7>Zlatý slunce nad hlavou
+<D>a v duši léto mít,
 
-\Ch{D7}{usnout} s tichou únavou
-\Ch{C}{na terase} \Ch{E}{a pak} zase
+<D7>usnout s tichou únavou
+<C>na terase <E>a pak zase
 
-\Ch{A7}{zlatý} slunce nad hlavou
-a \Ch{D}{pravdu} s vínem \Ch{D7}{pít,}
+<A7>zlatý slunce nad hlavou
+a <D>pravdu s vínem <D7>pít,
 
-zdravit \Ch{C}{máky} vlčí,
-co kve\Ch{Cmi}{tou a mlčí,}
+zdravit <C>máky vlčí,
+co kve<Cmi>tou a mlčí,
 
-a pak \Ch{C}{smát} se, \Ch{Cmaj7}{zpívat} a \Ch{C}{žííííí}íít ~~ \Ch{H}{} \Ch{B}{} 
+a pak <C>smát se, <Cmaj7>zpívat a <C>žííííííít ~~ <H> <B> 
 \kr
 
 \zr
 
-\Ch{A7}{Tada....} \Ch{D}{}  \Ch{D}{} \Ch{D7}{} \Ch{C}{} \Ch{E}{}
+<A7>Tada.... <D> <D> <D7> <C> <E>
 
-\Ch{A7}{Tada....} \Ch{D}{} \Ch{D7}{}
+<A7>Tada.... <D> <D7>
 
 
-zdravit \Ch{C}{máky} vlčí,
-co kve\Ch{Cmi}{tou} a mlčí,
+zdravit <C>máky vlčí,
+co kve<Cmi>tou a mlčí,
 
-a pak \Ch{C}{smát} se, \Ch{D}{zpívat} a \Ch{C}{žííííí}íít.
+a pak <C>smát se, <D>zpívat a <C>žííííííít.
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Josef_Zíma,_Karel_Štědrý____Milenci_v_texaskách.tex
+++ b/tp-songs/02_pop_rock/Josef_Zíma,_Karel_Štědrý____Milenci_v_texaskách.tex
@@ -3,13 +3,13 @@
 \zp{Milenci v texaskách}{Josef Zíma, Karel Štědrý}
 
 \zs
-\Ch{C}{Chodili} spolu z velké \Ch{Ami}{lásky} \Ch{F}{a sedmnáct} jim bylo \Ch{Ami}{let} \Ch{G7}{}
+<C>Chodili spolu z velké <Ami>lásky <F>a sedmnáct jim bylo <Ami>let <G7>
 
-\Ch{C}{a do té} lásky bez nad\Ch{Ami}{sázky} \Ch{F}{se vešel} celý širý \Ch{Ami}{svět.}
+<C>a do té lásky bez nad<Ami>sázky <F>se vešel celý širý <Ami>svět.
 
-\Ch{F}{Ten svět} v nich ale viděl \Ch{Emi}{pásky} \Ch{F}{a jak by} mohl nevi\Ch{G7}{dět.}
+<F>Ten svět v nich ale viděl <Emi>pásky <F>a jak by mohl nevi<G7>dět.
 
-\Ch{C}{Vždyť} horovali pro te\Ch{Ami}{xasky} \Ch{F}{a sedmnáct} jim bylo \Ch{Ami}{let.} \Ch{G7}{}
+<C>Vždyť horovali pro te<Ami>xasky <F>a sedmnáct jim bylo <Ami>let. <G7>
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/Kabát____Láďa.tex
+++ b/tp-songs/02_pop_rock/Kabát____Láďa.tex
@@ -3,32 +3,32 @@
 \zp{Láďa}{Kabát}
 
 \zs
-\Ch{Ami}{Láďa} jede na skejtu
+<Ami>Láďa jede na skejtu
 a umí chodit po laně
 
-a \Ch{G7}{když} je v dobrý náladě,
-tak \Ch{Ami}{napod}obí vorvaně,
+a <G7>když je v dobrý náladě,
+tak <Ami>napodobí vorvaně,
 
 má veliký BMW,
 nikdo se na něj nechytá,
 
-\Ch{G7}{jak} sou ňáký problémy,
-\Ch{Ami}{Láďa} je všechny vychytá.
+<G7>jak sou ňáký problémy,
+<Ami>Láďa je všechny vychytá.
 
-\Ch{F}{Gen}iální nápady má, mozek obřích rozměrů,
+<F>Geniální nápady má, mozek obřích rozměrů,
 
-\Ch{G}{vejde} se mu do hlavy, \Ch{E}{jestlipak víte proč?}
+<G>vejde se mu do hlavy, <E>jestlipak víte proč?
 
 Protože...
 \ks
 
 \zr
-\Ch{Ami}{Láďa} má velkou hlavu, \Ch{F}{jak} pytel od banánů,
-\Ch{Ami}{Láďa} se v davu neztra\Ch{F}{tí,}
+<Ami>Láďa má velkou hlavu, <F>jak pytel od banánů,
+<Ami>Láďa se v davu neztra<F>tí,
 
-\Ch{Ami}{když} se mu holky smějou,
-\Ch{F}{pra}chy ho v kapse hřejou,
-\Ch{Ami}{jedn}ou si všechny zapla\Ch{F}{tí.}
+<Ami>když se mu holky smějou,
+<F>prachy ho v kapse hřejou,
+<Ami>jednou si všechny zapla<F>tí.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Kabát____Moderní_děvče.tex
+++ b/tp-songs/02_pop_rock/Kabát____Moderní_děvče.tex
@@ -2,9 +2,9 @@
 
 \zp{Moderní děvče}{Kabát}
 \zs
-\Ch{C}{Moderní} devče, \Ch{F}{když chlapce} spatří,
+<C>Moderní devče, <F>když chlapce spatří,
 
-\Ch{G}{vypadá} jak klaun do \Ch{F}{cirkusu} patří,
+<G>vypadá jak klaun do <F>cirkusu patří,
 
 má růžovou vestu a modrý oči,
 
@@ -33,13 +33,13 @@ milovat děvče a být s ním šťastný,
 oléo, oléo, Leo Kangasero.
 \ks
 \zr
-Jenže já jsem \Ch{C}{denně} vožralej, \Ch{G}{denně} vožralej,
+Jenže já jsem <C>denně vožralej, <G>denně vožralej,
 
-\Ch{Dmi}{mám} velikej pupek, smrdím a \Ch{C}{jsem} špina\Ch{G}{vej.}
+<Dmi>mám velikej pupek, smrdím a <C>jsem špina<G>vej.
 
-\Ch{C}{Hodně} piju, jím, \Ch{G}{ženský nebalím}
+<C>Hodně piju, jím, <G>ženský nebalím
 
-\Ch{Dmi}{a když} někdy vo sobě vím, \Ch{C}{hned} to \Ch{G}{voslavím.}
+<Dmi>a když někdy vo sobě vím, <C>hned to <G>voslavím.
 \kr
 
 \zr\kr

--- a/tp-songs/02_pop_rock/Kabát____Pohoda.tex
+++ b/tp-songs/02_pop_rock/Kabát____Pohoda.tex
@@ -3,27 +3,27 @@
 \zp{Pohoda}{Kabát}
 
 \zs
-\Ch{Ami}{Vezmu tě, má milá,} \Ch{Emi}{rovnou k nám,}
+<Ami>Vezmu tě, má milá, <Emi>rovnou k nám,
 
-\Ch{Ami}{kolem louky, lesy,} \Ch{Emi}{hejna vran,}
+<Ami>kolem louky, lesy, <Emi>hejna vran,
 
-\Ch{Ami}{všude samá} \Ch{G}{kráva, samej} \Ch{D}{vůl.}
+<Ami>všude samá <G>kráva, samej <D>vůl.
 
-\Ch{Ami}{Máme kino,} máme \Ch{Emi}{hospodu,}
+<Ami>Máme kino, máme <Emi>hospodu,
 
-\Ch{Ami}{v obci všeobecnou} \Ch{Emi}{pohodu,}
+<Ami>v obci všeobecnou <Emi>pohodu,
 
-\Ch{Ami}{máme hujer,} \Ch{G}{žito, chléb} i \Ch{D}{sůl.}
+<Ami>máme hujer, <G>žito, chléb i <D>sůl.
 \ks
 
 \zr
-\Ch{F}{Když se} u nás chlapi \Ch{C}{poperou,} tak jenom \Ch{G}{nožem} a nebo \Ch{Dmi}{sekerou,}
+<F>Když se u nás chlapi <C>poperou, tak jenom <G>nožem a nebo <Dmi>sekerou,
 
-v zimě tam \Ch{F}{dlouhý noci} \Ch{C}{jsou a tuhej} \Ch{Dmi}{mráz.}
+v zimě tam <F>dlouhý noci <C>jsou a tuhej <Dmi>mráz.
 
-\Ch{F}{Jak jsou} naše cesty \Ch{C}{zavátý,} tak vezmem \Ch{G}{vidle} a nebo \Ch{Dmi}{lopaty,}
+<F>Jak jsou naše cesty <C>zavátý, tak vezmem <G>vidle a nebo <Dmi>lopaty,
 
-když něco \Ch{F}{nejde,} co na tom \Ch{C}{sejde,} my máme \Ch{Dmi}{čas.}
+když něco <F>nejde, co na tom <C>sejde, my máme <Dmi>čas.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Karel_Zich____Alenka_v_říši_divů.tex
+++ b/tp-songs/02_pop_rock/Karel_Zich____Alenka_v_říši_divů.tex
@@ -1,28 +1,28 @@
 % -*-coding: utf-8 -*-
 
 \zp{Alenka v říši divů}{Karel Zich}
-  \zs
+ \zs
 
-\Ch{G}{Telegram} s adresou svět, \Ch{C}{píšu v něm} pět vlídných 
-\Ch{D}{} jedné \Ch{G}{dívce.} \Ch{D}{}
+<G>Telegram s adresou svět, <C>píšu v něm pět vlídných vět
+<D> jedné <G>dívce. <D>
 
-\Ch{G}{Kdopak} ví, kam jej zítra pošta doručí \Ch{C}{a kolik} náhod mu poručí?  
-\Ch{D}{Chtěl} bych jen vidět zář očí, které \Ch{G}{budou} jej číst. \Ch{D}
+<G>Kdopak ví, kam jej zítra pošta doručí <C>a kolik náhod mu poručí? 
+<D>Chtěl bych jen vidět zář očí, které <G>budou jej číst. <D>
 
 \ks
 \zr
 
-\Ch{G}{A} šel bych cestou prašnou, co nikdo nezmě\Ch{C}{ří},
+<G>A šel bych cestou prašnou, co nikdo nezmě<C>ří,
 
 sám jedenkrát bych s plnou brašnou cinknul u dveří,
 
-bude \Ch{D}{v} očích mít úžas jak Alen\Ch{G}{ka} \Ch{D}{v} říši divů.
+bude <D>v očích mít úžas jak Alen<G>ka <D>v říši divů.
 
-I \Ch{G}{když} dá mi košem, až řádky bude \Ch{C}{číst},
+I <G>když dá mi košem, až řádky bude <C>číst,
 
 já chtěl bych být tím listonošem, neboť jsem si jist, bude
 
-\Ch{D}{v} očích mít úžas \Ch{C}{jak} Alen\Ch{D}{ka} v \Ch{G}{říši} divů. 
+<D>v očích mít úžas <C>jak Alen<D>ka v <G>říši divů. 
 
 \kr
 \zs
@@ -33,7 +33,7 @@ a celý den přemítám o dívce neznámé, proč už se dávno neznáme, snad a
 najde poselství mé. 
 
 \ks
-\zr  \kr
+\zr \kr
 \zs
 
 Odmítli můj telegram a řekli, že poslat jej není kam, adresa schází
@@ -43,6 +43,6 @@ najde poselství mé.
 
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Karel_Zich____Alenka_v_říši_divů.tex
+++ b/tp-songs/02_pop_rock/Karel_Zich____Alenka_v_říši_divů.tex
@@ -3,11 +3,11 @@
 \zp{Alenka v říši divů}{Karel Zich}
   \zs
 
-Tele\Ch{G}{gram} s adresou \Ch{C}{svět}, píšu v něm pět vlí\Ch{D}{dných} 
-\Ch{G}{vět} \Ch{D}{} jedné dívce.
+\Ch{G}{Telegram} s adresou svět, \Ch{C}{píšu v něm} pět vlídných 
+\Ch{D}{} jedné \Ch{G}{dívce.} \Ch{D}{}
 
-K\Ch{G}{dopak} ví, kam jej zítra pošta do\Ch{C}{ručí} a kolik náhod mu poručí?  
-\Ch{D}{Chtěl} bych jen vidět zář očí, \Ch{G}{které} budo\Ch{D}{u} jej číst. 
+\Ch{G}{Kdopak} ví, kam jej zítra pošta doručí \Ch{C}{a kolik} náhod mu poručí?  
+\Ch{D}{Chtěl} bych jen vidět zář očí, které \Ch{G}{budou} jej číst. \Ch{D}
 
 \ks
 \zr

--- a/tp-songs/02_pop_rock/Karel_Zich____Je_to_paráda.tex
+++ b/tp-songs/02_pop_rock/Karel_Zich____Je_to_paráda.tex
@@ -1,27 +1,27 @@
 % -*-coding: utf-8 -*-
 
 \zp{Je to paráda}{Karel Zich}
-  \zs
+ \zs
 
-\Ch{C}{Uvař} kafe nebo nalej \Ch{Ami}{čaj,} \Ch{C}{paráda.} \Ch{Ami}{}
-\Ch{C}{Aspoň} chvíli na něco si \Ch{Ami}{hraj}, \Ch{C}{paráda.} \Ch{Ami}{}
+<C>Uvař kafe nebo nalej <Ami>čaj, <C>paráda. <Ami>
+<C>Aspoň chvíli na něco si <Ami>hraj, <C>paráda. <Ami>
 
-\Ch{Dmi}{Na oblohu,} \Ch{G}{kde} není \Ch{C}{mrak,} \Ch{Ami}{}
-\Ch{Dmi}{na gramofon,} \Ch{G}{na} kaze\Ch{C}{ťák}, \Ch{Ami}{}
+<Dmi>Na oblohu, <G>kde není <C>mrak, <Ami>
+<Dmi>na gramofon, <G>na kaze<C>ťák, <Ami>
 
-\Ch{Dmi}{hraj} si prostě \Ch{G}{na} co chceš, \Ch{C}{tak} jak to \Ch{Ami}{cítíš},
-\Ch{Dmi}{přidám} se hned, a \Ch{G}{jak}. 
+<Dmi>hraj si prostě <G>na co chceš, <C>tak jak to <Ami>cítíš,
+<Dmi>přidám se hned, a <G>jak. 
 
 \ks
 \zr
 
-Je to \Ch{C}{paráda,} lehnout si \Ch{Emi}{na záda} a \Ch{Dmi}{číst si,}
+Je to <C>paráda, lehnout si <Emi>na záda a <Dmi>číst si,
 
-s rukama \Ch{F}{za} hlavou usínat s \Ch{G}{představou}, že jsem \Ch{C}{čísi}.\Ch{F}{ } \Ch{G}{ }
+s rukama <F>za hlavou usínat s <G>představou, že jsem <C>čísi.<F> <G> 
 
-Je to \Ch{C}{paráda,} s nikým se \Ch{Emi}{nehádat} a číst \Ch{Dmi}{knížku}
+Je to <C>paráda, s nikým se <Emi>nehádat a číst <Dmi>knížku
  
-a mít \Ch{F}{představu}, že pro svou \Ch{G}{zábavu} zdolám \Ch{C}{výšku}.\Ch{G}{ } 
+a mít <F>představu, že pro svou <G>zábavu zdolám <C>výšku.<G> 
 
 \kr
 \zs
@@ -34,7 +34,7 @@ Nejlépe se zbavuju tíhy
 při deskách ohraných. 
 
 \ks
-\zr    \kr
+\zr \kr
 \zs
 
 Sedm nocí v týdnu nejdu spát, paráda. 

--- a/tp-songs/02_pop_rock/Katapult____Až.tex
+++ b/tp-songs/02_pop_rock/Katapult____Až.tex
@@ -3,17 +3,17 @@
 \zp{Až}{Katapult}
 
 \zs
-\Ch{A}{Až} se bude psát rok dva tisíce šest,
+<A>Až se bude psát rok dva tisíce šest,
 
-\Ch{D}{až} se všichni přestěhujem do obrovských měst,
+<D>až se všichni přestěhujem do obrovských měst,
 
-\Ch{A}{až} dálnicí zeměkouli opředem,
+<A>až dálnicí zeměkouli opředem,
 
-\Ch{D}{až} budem pyšni na všechno, co dovedem,
+<D>až budem pyšni na všechno, co dovedem,
 
-\Ch{E}{pak} bude možná pozdě na to chtít se ptát:
+<E>pak bude možná pozdě na to chtít se ptát:
 
-\uv{Co děti, mají si kde \Ch{A}{hrát}?}
+\uv{Co děti, mají si kde <A>hrát?}
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/Kryštof____Obchodník_s_deštěm.tex
+++ b/tp-songs/02_pop_rock/Kryštof____Obchodník_s_deštěm.tex
@@ -2,26 +2,26 @@
 
 \zp{Obchodník s deštěm}{Kryštof}
 \zs
-\Ch{D}{Jako} vášeň, která hasne \Ch{Hmi}{v kou}ři
-namačkaná bez osty\Ch{D}{chu,} zástup živo\Ch{Hmi}{čichů,} \\
-jako jas dálkových svě\Ch{G}{tel,} jako nad talířem \Ch{A}{večer}
+<D>Jako vášeň, která hasne <Hmi>v kouři
+namačkaná bez osty<D>chu, zástup živo<Hmi>čichů, \\
+jako jas dálkových svě<G>tel, jako nad talířem <A>večer
 mi mizíš.
 
-\Ch{D}{A mizíš} někde v dávnu,
-jsi \Ch{Hmi}{láska} co mě \Ch{D}{škrtí}, já na pokraji smrti \\
-\Ch{Hmi}{ve svém} paralelním svě\Ch{G}{tě} toužím \Ch{A}{po} odvetě
+<D>A mizíš někde v dávnu,
+jsi <Hmi>láska co mě <D>škrtí, já na pokraji smrti \\
+<Hmi>ve svém paralelním svě<G>tě toužím <A>po odvetě
 a křičím.
 \ks
 \zr
 
-\Ch{G}{Slova} jsou jen \Ch{A}{kapky} deště a ty \Ch{Hmi}{voláš,} ať prším ještě,
+<G>Slova jsou jen <A>kapky deště a ty <Hmi>voláš, ať prším ještě,
 
-\Ch{G}{slova} jsou jen \Ch{A}{kapky} deště a ty \Ch{Hmi}{voláš.}
+<G>slova jsou jen <A>kapky deště a ty <Hmi>voláš.
 
-\Ch{G}{Slova} jsou jen \Ch{A}{kapky} deště a ty \Ch{Hmi}{voláš,} ať prším 
+<G>Slova jsou jen <A>kapky deště a ty <Hmi>voláš, ať prším 
 ještě,
 
-\Ch{G}{slova} jsou jen \Ch{A}{kapky} deště.
+<G>slova jsou jen <A>kapky deště.
 
 \kr
 \zs
@@ -41,7 +41,7 @@ a křičí.
 \kr
 \zs
 
-\Ch{G}{ } \Ch{A}{ } \Ch{Hmi}{ }
+<G> <A> <Hmi> 
 \ks
 \zr
 \kr

--- a/tp-songs/02_pop_rock/Lucie____Amerika.tex
+++ b/tp-songs/02_pop_rock/Lucie____Amerika.tex
@@ -2,28 +2,28 @@
 
 \zp{Amerika}{Lucie}
 
-\Ch{Emi}{}
+<Emi>
 \zs
-\Ch{G}{Nandej} mi \Ch{D}{do} hlavy tvý \Ch{Ami}{brouky}
+<G>Nandej mi <D>do hlavy tvý <Ami>brouky
 
-a Bůh nám seber bezna\Ch{G}{děj.}
+a Bůh nám seber bezna<G>děj.
 
-V duši zbylo \Ch{D}{světlo} z jedný \Ch{Ami}{holky,}
+V duši zbylo <D>světlo z jedný <Ami>holky,
 
-tak mi teď za to vyna\Ch{G}{dej.}
+tak mi teď za to vyna<G>dej.
 
-Zima a \Ch{D}{promarněný} \Ch{Ami}{touhy,}
+Zima a <D>promarněný <Ami>touhy,
 
-do vrásek stromů padá \Ch{G}{déšť.}
+do vrásek stromů padá <G>déšť.
 
-Zbejvaj roky, \Ch{D}{asi} ne moc \Ch{Ami}{dlouhý.}
+Zbejvaj roky, <D>asi ne moc <Ami>dlouhý.
 
 \ks
 \zr
 
-Do vlasů mi zabrou\Ch{C}{kej}... pa pa pa \Ch{G}{pa,}
+Do vlasů mi zabrou<C>kej... pa pa pa <G>pa,
 
-/: pa pa pa \Ch{Emi}{pa,} pa pa pa \Ch{G}{pa.} :/
+/: pa pa pa <Emi>pa, pa pa pa <G>pa. :/
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Lucie____Medvídek.tex
+++ b/tp-songs/02_pop_rock/Lucie____Medvídek.tex
@@ -3,30 +3,30 @@
 \zp{Medvídek}{Lucie}
 
 \zs
-\Ch{D}{Dlouhá} noc a mně se stýská moc,
+<D>Dlouhá noc a mně se stýská moc,
 pro tebe malý dárek mám.
 
-Přes hory, \Ch{Emi}{přes} ploty,
-medvídek z \Ch{A7}{Bogo}ty už \Ch{D}{letí.}
+Přes hory, <Emi>přes ploty,
+medvídek z <A7>Bogoty už <D>letí.
 
 Medvídek plyšový na cestě
 křížový -- Bůh ho ochrání
 
-před smečkou \Ch{Emi}{římskejch} psů
-a jejich \Ch{A7}{úřadů} --
-ti \Ch{G}{pos}ílá lásku, co \Ch{A}{v bříšku} má.
+před smečkou <Emi>římskejch psů
+a jejich <A7>úřadů --
+ti <G>posílá lásku, co <A>v bříšku má.
 \ks
 
 
 \zr
-\Ch{B}{Medvídek} z Bogoty \Ch{D}{usnul} a sní,
-\Ch{B}{na} kříži z Golgoty \Ch{D}{spí.}
+<B>Medvídek z Bogoty <D>usnul a sní,
+<B>na kříži z Golgoty <D>spí.
 
-Za třicet \Ch{Emi}{stříbrných}
-z medvídka \Ch{A7}{padá} sníh,
+Za třicet <Emi>stříbrných
+z medvídka <A7>padá sníh,
 
-no a ti \Ch{G}{římští} psi
-ho sjíždě\Ch{A}{jí} na saních o Váno\Ch{D}{cích.}
+no a ti <G>římští psi
+ho sjíždě<A>jí na saních o Váno<D>cích.
 \kr
 
 \zs
@@ -46,14 +46,14 @@ nikdo se nedoví o svatozáři trnový.
 \zr \kr
 
 \zs
-\Ch{Hmi}{Medvídku,} probuď se, prober se, vstaň,
+<Hmi>Medvídku, probuď se, prober se, vstaň,
 psi se už sbíhají, připrav si dlaň.
 
-\Ch{A}{Slunce} zas vychází, cítíš tu zář?
+<A>Slunce zas vychází, cítíš tu zář?
 Tlapky dáš v pěst, nebo nastavíš tvář.
 
-\Ch{B}{Římskejm} psům a jejich \Ch{D}{úřadům}
-Maxipes \Ch{B}{Herodes} vánoční \Ch{A}{slib} dal dnes.
+<B>Římskejm psům a jejich <D>úřadům
+Maxipes <B>Herodes vánoční <A>slib dal dnes.
 \ks
 
 \zr \kr

--- a/tp-songs/02_pop_rock/Lucie____Sen.tex
+++ b/tp-songs/02_pop_rock/Lucie____Sen.tex
@@ -2,16 +2,16 @@
 
 \zp{Sen}{Lucie}
 
-\Ch{C#}{} \Ch{E}{} \Ch{G#}{} \Ch{F#}{} \Ch{E}{} \Ch{E}{} \Ch{F#}{} \Ch{F#}{} \Ch{F#}{} \Ch{E}{} \Ch{F#}{} \Ch{G#}{}
+<C#> <E> <G#> <F#> <E> <E> <F#> <F#> <F#> <E> <F#> <G#>
 
 \zs
-Stíny \Ch{E}{dnů} a snů se k obratníku \Ch{A}{stáčí,}
+Stíny <E>dnů a snů se k obratníku <A>stáčí,
 
-ruce \Ch{E}{snů} černejch se snaží zakrýt \Ch{A}{oči,}
+ruce <E>snů černejch se snaží zakrýt <A>oči,
 
-světlo \Ch{F#mi}{tvý pro}zradí, proč já \Ch{E}{vím,}
+světlo <F#mi>tvý prozradí, proč já <E>vím,
 
-s novým \Ch{F#mi}{dnem,} že se \Ch{A}{zas} navrá\Ch{H}{tí.}
+s novým <F#mi>dnem, že se <A>zas navrá<H>tí.
 \ks
 
 \zs
@@ -25,17 +25,17 @@ a měsíc nový stíny vyplaší.
 \ks
 
 \zr
-Proud motý\Ch{E}{lů} unáší strach,
+Proud motý<E>lů unáší strach,
 
-na listy \Ch{A}{sedá} hvěznej prach,
+na listy <A>sedá hvěznej prach,
 
-proletí \Ch{C#mi}{ohněm} a mizí stále \Ch{H}{dál.}
+proletí <C#mi>ohněm a mizí stále <H>dál.
 
-Neslišný \Ch{E}{kroky} stepujou,
+Neslišný <E>kroky stepujou,
 
-v nebeským \Ch{A}{rytmu} swingujou,
+v nebeským <A>rytmu swingujou,
 
-že se \Ch{C#mi}{ráno}, že se ráno vytra\Ch{H}{tí.}
+že se <C#mi>ráno, že se ráno vytra<H>tí.
 \kr
 
 \zs
@@ -48,14 +48,14 @@ všechno ví, z povzdálí vedou naše kroky
 a měsíc nový stíny vyplaší.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
-Proud motý\Ch{E}{lů} unáší strach,
+Proud motý<E>lů unáší strach,
 
-na listy \Ch{A}{sedá} hvěznej prach
+na listy <A>sedá hvěznej prach
 
-a nový \Ch{C#mi}{stíny, a nový stíny} vypla\Ch{H}{ší.}
+a nový <C#mi>stíny, a nový stíny vypla<H>ší.
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Lucie____Černí_andělé.tex
+++ b/tp-songs/02_pop_rock/Lucie____Černí_andělé.tex
@@ -2,17 +2,17 @@
 
 \zp{Černí andělé}{Lucie}
 
-\Ch{A}{} \Ch{G}{} \Ch{D}{} \Ch{A}{} \Ch{G}{} \Ch{D}{} \Ch{A}{} \Ch{G}{} \Ch{D}{} \Ch{A}{} \Ch{G}{} \Ch{D}{}
+<A> <G> <D> <A> <G> <D> <A> <G> <D> <A> <G> <D>
 
 \zs
-\Ch{A}{Sex} je náš, dělá \Ch{G}{dobře} mně i \Ch{D}{tobě,}
+<A>Sex je náš, dělá <G>dobře mně i <D>tobě,
 
-\Ch{A}{otčenáš}, bejby, \Ch{G}{odříkej} až v \Ch{D}{hrobě.}
+<A>otčenáš, bejby, <G>odříkej až v <D>hrobě.
 
-\Ch{A}{Středověk} neskončil, \Ch{D}{středověk} \Ch{G}{trvá,}
+<A>Středověk neskončil, <D>středověk <G>trvá,
 
-\Ch{A}{jsme} černí andělé a \Ch{D}{ty} jsi byla \Ch{G}{prvá.} \Ch{A}{} 
-\Ch{G}{} \Ch{D}{}
+<A>jsme černí andělé a <D>ty jsi byla <G>prvá. <A> 
+<G> <D>
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/Lucie____Šrouby_do_hlavy.tex
+++ b/tp-songs/02_pop_rock/Lucie____Šrouby_do_hlavy.tex
@@ -2,16 +2,16 @@
 
 \zp{Šrouby do hlavy}{Lucie}
 
-\Ch{Emi}{} \Ch{C}{} \Ch{D}{} \Ch{Hmi}{} \Ch{C}{} \Ch{Ami}{} \Ch{H7}{} \Ch{Emi}{}
+<Emi> <C> <D> <Hmi> <C> <Ami> <H7> <Emi>
 
 \zs
-\Ch{C}{V} řádce temnejch domů \Ch{Hmi}{jen tvý} okno svítí,
+<C>V řádce temnejch domů <Hmi>jen tvý okno svítí,
 
-\Ch{Emi}{celý} město šlo už \Ch{A7}{dávno} spát,
+<Emi>celý město šlo už <A7>dávno spát,
 
-tak \Ch{C}{si} to vem -- a \Ch{Hmi}{já tu} jsem
+tak <C>si to vem -- a <Hmi>já tu jsem
 
-a \Ch{Emi}{mám} to vzdát.
+a <Emi>mám to vzdát.
 \ks
 
 \zs
@@ -25,14 +25,14 @@ Chci vrátit čas.
 \ks
 
 \zr
-\Ch{C}{Zná} jen pár \Ch{G}{fíglů},
-\Ch{D}{jak} se valej holkám šrouby \Ch{Emi}{do hla}vy,
+<C>Zná jen pár <G>fíglů,
+<D>jak se valej holkám šrouby <Emi>do hlavy,
 
-\Ch{C}{pár} hloupejch \Ch{G}{fíglů},
-\Ch{D}{ty} mu na ně skočíš,
+<C>pár hloupejch <G>fíglů,
+<D>ty mu na ně skočíš,
 
-\Ch{A7}{za} pár dní to chlápka otrá\Ch{Emi}{ví.}
-\Ch{C}{} \Ch{D}{} \Ch{Hmi}{} \Ch{C}{} \Ch{Ami}{} \Ch{H7}{} \Ch{Emi}{}
+<A7>za pár dní to chlápka otrá<Emi>ví.
+<C> <D> <Hmi> <C> <Ami> <H7> <Emi>
 \kr
 
 \zs
@@ -55,16 +55,16 @@ tak čert ho vem, teď já tu jsem
 jak žhavej drát.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Zná jen pár fíglů,
 jak se valej holkám šrouby do hlavy.
 
 pár známejch fíglů,
-\Ch{D}{já} tu ve tmě házím
+<D>já tu ve tmě házím
 
-\Ch{A7}{zapálený} sirky do trá\Ch{Emi}{vy.}
+<A7>zapálený sirky do trá<Emi>vy.
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Michal_Prokop____Bitva_o_Karlův_most.tex
+++ b/tp-songs/02_pop_rock/Michal_Prokop____Bitva_o_Karlův_most.tex
@@ -3,27 +3,27 @@
 \zp{Bitva o Karlův most}{Michal Prokop}
 
 \zs
-\Ch{C}{Má} vlasy \Ch{G}{dlouhý} do půl \Ch{C}{pasu,}
+<C>Má vlasy <G>dlouhý do půl <C>pasu,
 
-{k tur}istům \Ch{F}{jistou} \Ch{C}{náklonnost,}
+{k tur}istům <F>jistou <C>náklonnost,
 
-{barokní} \Ch{G}{sochy} v letním \Ch{C}{jasu}
+{barokní} <G>sochy v letním <C>jasu
 
-{sedí} tu \Ch{F}{jako} hejno \Ch{C}{vos.}
+{sedí} tu <F>jako hejno <C>vos.
 
-/: \Ch{Ami}{Má vl}asy \Ch{Emi}{do pas}u a \Ch{F}{jen} tak pro \Ch{C}{radost}
+/: <Ami>Má vlasy <Emi>do pasu a <F>jen tak pro <C>radost
 
-{nabízí} \Ch{G}{ortel} nebo \Ch{C(F)}{spásu} :/ v bitvě o Karlův \Ch{C}{most.}
+{nabízí} <G>ortel nebo <C(F)>spásu :/ v bitvě o Karlův <C>most.
 \ks
 
 \zr
-\Ch{Emi}{To pro} te\Ch{F}{be} král Karel \Ch{C}{Čtvrtý,}
+<Emi>To pro te<F>be král Karel <C>Čtvrtý,
 
-\Ch{F}{má} \Ch{Emi}{lásko} vlasa\Ch{Dmi}{tá,}
+<F>má <Emi>lásko vlasa<Dmi>tá,
 
-/: \Ch{G}{dáv}\Ch{C}{al} do malty \Ch{F}{žloutek}
+/: <G>dáv<C>al do malty <F>žloutek
 
-a mrhal \Ch{Dmi}{úsilím} a \Ch{C}{pruty} \Ch{F}{ze} zla\Ch{C}{ta.} :/
+a mrhal <Dmi>úsilím a <C>pruty <F>ze zla<C>ta. :/
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Michal_Prokop____Kolej_Yesterday.tex
+++ b/tp-songs/02_pop_rock/Michal_Prokop____Kolej_Yesterday.tex
@@ -3,13 +3,13 @@
 \zp{Kolej Yesterday}{Michal Prokop}
 
 \zs
-To \Ch{Dmi}{bejvávaly} \Ch{C}{na koleji} \Ch{Dmi}{časy,}
-už ráno \Ch{C}{začal} večí\Ch{F}{rek,}
+To <Dmi>bejvávaly <C>na koleji <Dmi>časy,
+už ráno <C>začal večí<F>rek,
 
-\Ch{Eb}{někdo} dal dvacet, někdo \Ch{Dmi}{stovku}
-\Ch{Eb}{a sta}věli jsme Eiffe\Ch{Dmi}{lovku}
+<Eb>někdo dal dvacet, někdo <Dmi>stovku
+<Eb>a stavěli jsme Eiffe<Dmi>lovku
 
-ze snů a \Ch{B}{peří,} \Ch{C}{ze} si\Ch{Dmi}{rek.}
+ze snů a <B>peří, <C>ze si<Dmi>rek.
 \ks
 
 \zs
@@ -21,10 +21,10 @@ vracel se s kytkou za uchem.
 \ks
 
 \zr
-\Ch{A}{Prázdnou} \Ch{D}{ulicí} \Ch{C}{na ko}\Ch{G}{lej,}
+<A>Prázdnou <D>ulicí <C>na ko<G>lej,
 
-jo, to je \Ch{C}{dávno}, yester\Ch{F}{day,} Yesterday.
-\Ch{Emi}{} \Ch{A}{} \Ch{Dmi}{}
+jo, to je <C>dávno, yester<F>day, Yesterday.
+<Emi> <A> <Dmi>
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Mig_21____Slepic_pírka.tex
+++ b/tp-songs/02_pop_rock/Mig_21____Slepic_pírka.tex
@@ -3,37 +3,37 @@
 \zp{Slepic pírka}{Mig 21}
 
 \zs
-\Ch{F#mi}{Vyplašený} zajíc běhal
-\Ch{D}{po polích,}
+<F#mi>Vyplašený zajíc běhal
+<D>po polích,
 
-\Ch{F}{pak nalezl} \Ch{E}{smrt v pažích}
-\Ch{A}{tetovaných.}
+<F>pak nalezl <E>smrt v pažích
+<A>tetovaných.
 
-\Ch{F#mi}{Kočovali} ulicí i
-\Ch{D}{náměstím,}
+<F#mi>Kočovali ulicí i
+<D>náměstím,
 
-\Ch{F}{asi} \Ch{E}{za} štěstím,
-či \Ch{A}{neštěstím.}
+<F>asi <E>za štěstím,
+či <A>neštěstím.
 \ks
 
 \zr
-\Ch{F#mi}{Bulharku} Jarku, tatarku z párku,
-\Ch{D}{motorku} z korku, Maďarku, Norku,
+<F#mi>Bulharku Jarku, tatarku z párku,
+<D>motorku z korku, Maďarku, Norku,
 
-\Ch{F}{Japo}nku, Polku, \Ch{E}{Mong}olku z vdolku,
-\Ch{A}{uze}nou rolku, zelenou jolku,
+<F>Japonku, Polku, <E>Mongolku z vdolku,
+<A>uzenou rolku, zelenou jolku,
 
-\Ch{F#mi}{jenom} ne tuhle cikánskou holku,
-\Ch{D}{jen}om ne tuhle cikánskou holku,
+<F#mi>jenom ne tuhle cikánskou holku,
+<D>jenom ne tuhle cikánskou holku,
 
-\Ch{F}{jeno}m ne tuhle \Ch{E}{cikán}skou holku,
-tu \Ch{A}{ne! ne!}
+<F>jenom ne tuhle <E>cikánskou holku,
+tu <A>ne! ne!
 
-\Ch{F#mi}{Ne ne} ne ne ne ne ne ne ne, \Ch{D}{neměl} jsem,
-\Ch{F}{tu} cikánskou \Ch{E}{holku} potkat \Ch{A}{za} lesem,
+<F#mi>Ne ne ne ne ne ne ne ne ne, <D>neměl jsem,
+<F>tu cikánskou <E>holku potkat <A>za lesem,
 
-\Ch{F#mi}{ukrade}ných slepic pírka, \Ch{D}{zdvihá} dým,
-\Ch{F}{potom} stoupá k \Ch{E}{nebi} a já \Ch{A}{stoupám} s ním.
+<F#mi>ukradených slepic pírka, <D>zdvihá dým,
+<F>potom stoupá k <E>nebi a já <A>stoupám s ním.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Mig_21____Snadné_je_žít.tex
+++ b/tp-songs/02_pop_rock/Mig_21____Snadné_je_žít.tex
@@ -2,15 +2,15 @@
 
 \zp{Snadné je žít}{Mig 21}
 
-\Ch{Dmaj7}{} \Ch{D6}{} \Ch{Dmaj7}{} \Ch{D6}{}
+<Dmaj7> <D6> <Dmaj7> <D6>
 
 \zr
-\Ch{Dmaj7}{Když ti} \Ch{D6}{vítr} \Ch{Dmaj7}{napne} \Ch{D6}{plachtu},
+<Dmaj7>Když ti <D6>vítr <Dmaj7>napne <D6>plachtu,
 
-\Ch{Dmaj7}{když ti} \Ch{D6}{plachta} \Ch{Emi}{popožene} jachtu,
+<Dmaj7>když ti <D6>plachta <Emi>popožene jachtu,
 
-když ti jachtou jízda dodá \Ch{Dmaj7}{klid.}
-\Ch{D6}{} \Ch{Dmaj7}{} \Ch{D6}{}
+když ti jachtou jízda dodá <Dmaj7>klid.
+<D6> <Dmaj7> <D6>
 \kr
 
 \zs
@@ -20,15 +20,15 @@ když ti květy dívka k nosu nosí,
 
 když ti rosy kapku dává pít,
 
-\Ch{B}{jak} snadné je \Ch{Dmaj7}{žít,}
-\Ch{D6}{}
-\Ch{Dmaj7}{}
-\Ch{D6}{}
+<B>jak snadné je <Dmaj7>žít,
+<D6>
+<Dmaj7>
+<D6>
 
-\Ch{B}{snadné} je \Ch{Dmaj7}{žít.}
-\Ch{D6}{}
-\Ch{Dmaj7}{}
-\Ch{D6}{}
+<B>snadné je <Dmaj7>žít.
+<D6>
+<Dmaj7>
+<D6>
 \ks
 
 \zr \kr

--- a/tp-songs/02_pop_rock/Mňága_a_Žďorp____Hodinový_hotel.tex
+++ b/tp-songs/02_pop_rock/Mňága_a_Žďorp____Hodinový_hotel.tex
@@ -3,15 +3,15 @@
 \zp{Hodinový hotel}{Mňága a Žďorp}
 
 \zs
-\Ch{C}{Tlusté} koberce plné \Ch{Emi}{prachu,}
+<C>Tlusté koberce plné <Emi>prachu,
 
-\Ch{A}{poprvé} s holkou, \Ch{F}{trochu} \Ch{G}{strachu}
+<A>poprvé s holkou, <F>trochu <G>strachu
 
-\Ch{C}{a} stará dáma od vedle zas \Ch{Emi}{vyvádí,}
+<C>a stará dáma od vedle zas <Emi>vyvádí,
 
-\Ch{A}{zbyde} tu po ní zvadlé \Ch{F}{kapradí}
+<A>zbyde tu po ní zvadlé <F>kapradí
 
-a pár \Ch{G}{prázdných} flašek.
+a pár <G>prázdných flašek.
 
 \ks
 \zs
@@ -28,9 +28,9 @@ vzduch voní kouřem.
 \ks
 
 \zr
-/: \Ch{C}{Svět} je, \Ch{Emi}{svět} je jenom hodinový \Ch{A}{hotel}
+/: <C>Svět je, <Emi>svět je jenom hodinový <A>hotel
 
-a můj \Ch{F}{pokoj} je \Ch{G}{studený} a \Ch{C}{prázdný.} :/
+a můj <F>pokoj je <G>studený a <C>prázdný. :/
 \kr
 
 \zs
@@ -54,6 +54,6 @@ a vedle v pokoji někdo šeptá: \uv{Jak ti je?,}
 za oknem prší a déšť stejně nic nesmyje...
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Mňága_a_Žďorp____Měsíc.tex
+++ b/tp-songs/02_pop_rock/Mňága_a_Žďorp____Měsíc.tex
@@ -3,13 +3,13 @@
 \zp{Měsíc}{Mňága a Žďorp}
 
 \zs
-\Ch{Emi}{Děkuju} ti za to, \Ch{D}{žes} mi \Ch{G}{ještě} zavo\Ch{C}{lala}, \Ch{G}{} \Ch{D}{}
+<Emi>Děkuju ti za to, <D>žes mi <G>ještě zavo<C>lala, <G> <D>
 
-\Ch{Emi}{moje} duše černá \Ch{D}{už} to \Ch{G}{ani} neče\Ch{C}{kala}, \Ch{G}{} \Ch{D}{}
+<Emi>moje duše černá <D>už to <G>ani neče<C>kala, <G> <D>
 
-\Ch{Emi}{jenže}, moje drahá, \Ch{D}{je} to \Ch{G}{všechno} trochu \Ch{C}{na} nic, \Ch{G}{} \Ch{D}{}
+<Emi>jenže, moje drahá, <D>je to <G>všechno trochu <C>na nic, <G> <D>
 
-\Ch{Emi}{já už} jsem se rozhod', \Ch{D}{zítra} \Ch{G}{budu} znovu \Ch{C}{panic}. \Ch{G}{} \Ch{D}{}
+<Emi>já už jsem se rozhod', <D>zítra <G>budu znovu <C>panic. <G> <D>
 \ks
 
 \zs
@@ -23,9 +23,9 @@ jenže už je konec, však víš to. -- Vím to!
 \ks
 
 \zr
-3× /: \Ch{Emi}{Měsíc}, \Ch{D}{} \Ch{G}{svítí} \Ch{C}{měsíc}. \Ch{G}{} \Ch{D}{} :/
+3× /: <Emi>Měsíc, <D> <G>svítí <C>měsíc. <G> <D> :/
 
-\Ch{Emi}{Měsíc.}
+<Emi>Měsíc.
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Mňága_a_Žďorp____Písnička_pro_tebe.tex
+++ b/tp-songs/02_pop_rock/Mňága_a_Žďorp____Písnička_pro_tebe.tex
@@ -3,13 +3,13 @@
 \zp{Písnička pro tebe}{Mňága a Žďorp}
 
 \zs
-\Ch{F}{To} je ta \Ch{C}{písnič}\Ch{G}{ka} pro te\Ch{C}{be,}
+<F>To je ta <C>písnič<G>ka pro te<C>be,
 
-\Ch{F}{z} \Ch{C}{autobu}\Ch{G}{sá}\Ch{C}{ku,}
+<F>z <C>autobu<G>sá<C>ku,
 
-mrazi\Ch{F}{vé} \Ch{C}{a} modravé \Ch{G}{obrysy} \Ch{C}{mraků,}
+mrazi<F>vé <C>a modravé <G>obrysy <C>mraků,
 
-\Ch{F}{ptá}\Ch{C}{ků} a pane\Ch{G}{lá}\Ch{C}{ků.}
+<F>ptá<C>ků a pane<G>lá<C>ků.
 \ks
 
 \zs
@@ -33,13 +33,13 @@ to je ta písnička pro tebe.
 \ks
 
 \zs
-\Ch{F}{To} je ta \Ch{C}{písnič}\Ch{G}{ka} pro te\Ch{C}{be,}
+<F>To je ta <C>písnič<G>ka pro te<C>be,
 
-\Ch{F}{z} \Ch{C}{autobu}\Ch{G}{sá}\Ch{C}{ku,}
+<F>z <C>autobu<G>sá<C>ku,
 
-mrazi\Ch{F}{vé} \Ch{C}{a} modravé \Ch{G}{obrysy} \Ch{C}{mraků,}
+mrazi<F>vé <C>a modravé <G>obrysy <C>mraků,
 
-\Ch{F}{ptá}\Ch{C}{ků} a pane\Ch{G}{lá}\Ch{C}{ků.}
+<F>ptá<C>ků a pane<G>lá<C>ků.
 \ks
 
 7× /: pro tebe ... :/

--- a/tp-songs/02_pop_rock/Nightwork____Globální_oteplování.tex
+++ b/tp-songs/02_pop_rock/Nightwork____Globální_oteplování.tex
@@ -3,29 +3,29 @@
 \zp{Globální oteplování}{Nightwork}
 
 \zs
-\Ch{E}{Když} jsem ještě \Ch{F#mi}{býval} malej \Ch{G#mi}{kluk,}
-kluci, já měl \Ch{F#mi}{sen.}
+<E>Když jsem ještě <F#mi>býval malej <G#mi>kluk,
+kluci, já měl <F#mi>sen.
 
-\Ch{E}{Sníval} jsem ho \Ch{F#mi}{každý,} \Ch{G#mi}{každý} všední 
-\Ch{F#mi}{den.}
+<E>Sníval jsem ho <F#mi>každý, <G#mi>každý všední 
+<F#mi>den.
 
-\Ch{C#mi}{Jednoho} dne \Ch{G#mi}{v ned}ěli,
+<C#mi>Jednoho dne <G#mi>v neděli,
 
-když naši \Ch{F#mi}{za bab}ičkou odjeli,
+když naši <F#mi>za babičkou odjeli,
 
-\Ch{A}{Pátral} jsem \Ch{C#mi}{v mám}ině \Ch{G#mi}{šatníku,}
+<A>Pátral jsem <C#mi>v mámině <G#mi>šatníku,
 
-\Ch{F#mi}{střevíce} padly k mému \Ch{A}{kotníku}.
+<F#mi>střevíce padly k mému <A>kotníku.
 
-Teplý letní \Ch{C#mi}{den,}
+Teplý letní <C#mi>den,
 
-venku samci \Ch{G#mi}{motýli}, řekl jsem si \Ch{F#mi}{po chvíli...} \Ch{A}{}
+venku samci <G#mi>motýli, řekl jsem si <F#mi>po chvíli... <A>
 \ks
 
 \zr
-/: Já jsem \Ch{E}{gay,} jsem \Ch{F#mi}{gay, jsem} \Ch{A}{teplej,} :/
+/: Já jsem <E>gay, jsem <F#mi>gay, jsem <A>teplej, :/
 
-buď taky \Ch{E}{gay}...
+buď taky <E>gay...
 \kr
 
 \zs
@@ -48,7 +48,7 @@ vždyť fotosyntéza by bez nás nebyla.
 Venku samci motýlí tulipány pylují, řekněme si po chvíli...
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Teplej sysel, teplá vydra, mečoun je gay taky,

--- a/tp-songs/02_pop_rock/Olympic____Dej_mi_víc_své_lásky.tex
+++ b/tp-songs/02_pop_rock/Olympic____Dej_mi_víc_své_lásky.tex
@@ -3,15 +3,15 @@
 \zp{Dej mi víc své lásky}{Olympic}
 
 \zs
-\Ch{Emi}{Vymyslel} jsem spoustu nápadů, a\Ch{G}{ú,}
+<Emi>Vymyslel jsem spoustu nápadů, a<G>ú,
 
-co \Ch{Emi}{podporujou} hloupou nála\Ch{D}{du}, a\Ch{H7}{ú,}
+co <Emi>podporujou hloupou nála<D>du, a<H7>ú,
 
-\Ch{Emi}{hodit} klíče do kanálu,
+<Emi>hodit klíče do kanálu,
 
-\Ch{A}{sjet} po zadku \Ch{Ami}{holou} skálu,
+<A>sjet po zadku <Ami>holou skálu,
 
-v \Ch{Emi}{noci chodit} \Ch{H7}{strašit} do hra\Ch{Emi}{du,} a\Ch{H7}{ú.}
+v <Emi>noci chodit <H7>strašit do hra<Emi>du, a<H7>ú.
 \ks
 
 \zs
@@ -23,17 +23,17 @@ v bílé plachtě chodím pozadu, aú,
 
 s citem pro věc, jako vždycky,
 
-vyrábím tu hradní záhadu, a\Ch{D7}{ú.}
+vyrábím tu hradní záhadu, a<D7>ú.
 \ks
 
 \zr
-\Ch{G}{Má drahá,} dej mi víc, \Ch{H7}{má drahá,} dej mi víc,
+<G>Má drahá, dej mi víc, <H7>má drahá, dej mi víc,
 
-\Ch{Emi}{má drahá,} \Ch{C}{dej} mi víc své \Ch{G}{lásky}, a\Ch{D7}{ú,}
+<Emi>má drahá, <C>dej mi víc své <G>lásky, a<D7>ú,
 
-\Ch{G}{já nechci} skoro nic, \Ch{H7}{já nechci} skoro nic,
+<G>já nechci skoro nic, <H7>já nechci skoro nic,
 
-\Ch{Emi}{já chci} jen \Ch{C}{pohladit} tvé \Ch{G}{vlásky}, a\Ch{H7}{ú.}
+<Emi>já chci jen <C>pohladit tvé <G>vlásky, a<H7>ú.
 \kr
 
 \zs
@@ -45,10 +45,10 @@ natrhám ti sedmikrásky,
 
 tebe celou s tvými vlásky
 
-zamknu si na sedm západů, a\Ch{D7}{ú.}
+zamknu si na sedm západů, a<D7>ú.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Olympic____Giordano_Bruno.tex
+++ b/tp-songs/02_pop_rock/Olympic____Giordano_Bruno.tex
@@ -3,13 +3,13 @@
 \zp{Giordano Bruno}{Olympic}
 
 \zs
-\Ch{Ami}{Pomalu} \Ch{G}{otevíráš} \Ch{Fmaj7}{oči,}
+<Ami>Pomalu <G>otevíráš <Fmaj7>oči,
 
-\Ch{Ami}{to osa}\Ch{G}{hávaš nový} \Ch{Fmaj7}{den,}
+<Ami>to osa<G>hávaš nový <Fmaj7>den,
 
-\Ch{Ami}{jen tma se} \Ch{G}{kolem tebe} \Ch{Fmaj7}{točí,}
+<Ami>jen tma se <G>kolem tebe <Fmaj7>točí,
 
-\Ch{F}{jak rád} bys \Ch{G}{oknem} viděl \Ch{C}{ven.} \Ch{E}{}
+<F>jak rád bys <G>oknem viděl <C>ven. <E>
 \ks
 
 \zs
@@ -19,13 +19,13 @@ zítra je konec -- z toho zebe, protože Zem se otáčí.
 \ks
 
 \zr
-\Ch{Ami}{Ó --} \Ch{G}{ó -- o}\Ch{Fmaj7}{ó,} \Ch{Ami}{ó --} \Ch{G}{ó -- o}\Ch{Fmaj}{ó...}
+<Ami>Ó -- <G>ó -- o<Fmaj7>ó, <Ami>ó -- <G>ó -- o<Fmaj>ó...
 
-\Ch{G}{Polámaný} v díře krysí, \Ch{E}{čekáš} na smrt jako by si \Ch{Ami}{krad'.}
+<G>Polámaný v díře krysí, <E>čekáš na smrt jako by si <Ami>krad'.
 
-\Ch{G}{Jen ten,} kdo se pravdy bojí, \Ch{E}{ten} před Bohem neobstojí \Ch{Ami}{snad,}
+<G>Jen ten, kdo se pravdy bojí, <E>ten před Bohem neobstojí <Ami>snad,
 
-o\Ch{G}{ó -- o}\Ch{Fmaj7}{ó,} \Ch{Ami}{ó --} \Ch{G}{ó -- o}\Ch{Fmaj7}{ó...}
+o<G>ó -- o<Fmaj7>ó, <Ami>ó -- <G>ó -- o<Fmaj7>ó...
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Olympic____Jasná_zpráva.tex
+++ b/tp-songs/02_pop_rock/Olympic____Jasná_zpráva.tex
@@ -2,14 +2,14 @@
 
 \zp{Jasná zpráva}{Olympic}
 
-/: \Ch{G}{} \Ch{Emi}{} \Ch{C}{} \Ch{D}{} \Ch{Ami}{} \Ch{C}{} \Ch{G}{} :/
+/: <G> <Emi> <C> <D> <Ami> <C> <G> :/
 
 \zs
-\Ch{G}{Skončili} jsme, jasná zpráva,
+<G>Skončili jsme, jasná zpráva,
 
-\Ch{Emi}{proč o tebe} \Ch{C}{zakopávám} \Ch{D}{dál?}
+<Emi>proč o tebe <C>zakopávám <D>dál?
 
-\Ch{Ami}{Projít bytem} \Ch{C}{já abych se} \Ch{G}{bál.}
+<Ami>Projít bytem <C>já abych se <G>bál.
 \ks
 
 \zs
@@ -21,15 +21,15 @@ kam se kouknu, kousek tebe mám.
 \ks
 
 \zr
-\Ch{Emi}{Pěnu s vůní} \Ch{Hmi}{jablečnou,} \Ch{Emi}{vyvanulý} \Ch{Hmi}{sprej,}
+<Emi>Pěnu s vůní <Hmi>jablečnou, <Emi>vyvanulý <Hmi>sprej,
 
-\Ch{Emi}{telefon, cos'} \Ch{G}{ustřihla mu} \Ch{D}{šnůru,}
+<Emi>telefon, cos' <G>ustřihla mu <D>šnůru,
 
-\Ch{Emi}{knížku krásně} \Ch{Hmi}{zbytečnou,} \Ch{Emi}{co má lživý} \Ch{Hmi}{děj --}
+<Emi>knížku krásně <Hmi>zbytečnou, <Emi>co má lživý <Hmi>děj --
 
-\Ch{Emi}{píše se v ní,} \Ch{G}{jak se} lítá \Ch{D}{vzhůru,}
+<Emi>píše se v ní, <G>jak se lítá <D>vzhůru,
 
-lítá \Ch{Ami}{vzhůru, ve dvou} \Ch{D}{vzhůru.}
+lítá <Ami>vzhůru, ve dvou <D>vzhůru.
 \kr
 
 \zs
@@ -40,7 +40,7 @@ mám strach projít vlastním bytem sám,
 kam se kouknu, kousek tebe mám.
 \ks
 
-/: \Ch{G}{} \Ch{Emi}{} \Ch{C}{} \Ch{D}{} \Ch{Ami}{} \Ch{C}{} \Ch{G}{} :/
+/: <G> <Emi> <C> <D> <Ami> <C> <G> :/
 
 \zr\kr
 
@@ -52,6 +52,6 @@ není komu z okna mávat víc,
 jasná zpráva, rub, co nemá líc.
 \ks
 
-/: \Ch{G}{} \Ch{Emi}{} \Ch{C}{} \Ch{D}{} \Ch{Ami}{} \Ch{C}{} \Ch{G}{} :/
+/: <G> <Emi> <C> <D> <Ami> <C> <G> :/
 
 \kp

--- a/tp-songs/02_pop_rock/Olympic____Já_budu_chodit_po_špičkách.tex
+++ b/tp-songs/02_pop_rock/Olympic____Já_budu_chodit_po_špičkách.tex
@@ -3,23 +3,23 @@
 \zp{Já budu chodit po špičkách}{Olympic}
 
 \zs
-\Ch{D}{Zavři oči} \Ch{G}{a jdi spát,}
+<D>Zavři oči <G>a jdi spát,
 
-\Ch{Emi}{vždyť už bude} \Ch{A}{brzo den,}
+<Emi>vždyť už bude <A>brzo den,
 
-\Ch{D}{nech si} o mně \Ch{G}{něco zdát,}
+<D>nech si o mně <G>něco zdát,
 
-\Ch{Emi}{ať je krásný} \Ch{A}{ten tvůj sen.}
+<Emi>ať je krásný <A>ten tvůj sen.
 \ks
 
 \zr
-\Ch{Emi}{Já budu chodit} \Ch{A}{po špičkách,}
+<Emi>Já budu chodit <A>po špičkách,
 
-\Ch{Emi}{snad tě tím} nevzbu\Ch{A}{dím,}
+<Emi>snad tě tím nevzbu<A>dím,
 
-\Ch{Emi}{až slunce} \Ch{A}{vyjde v tmách,}
+<Emi>až slunce <A>vyjde v tmách,
 
-\Ch{G}{polibkem} tě \Ch{A}{probudím.}
+<G>polibkem tě <A>probudím.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Olympic____Okno_mé_lásky.tex
+++ b/tp-songs/02_pop_rock/Olympic____Okno_mé_lásky.tex
@@ -3,13 +3,13 @@
 \zp{Okno mé lásky}{Olympic}
 
 \zs
-\Ch{C}{Kdo tě líbá,} když ne \Ch{F}{já,}
+<C>Kdo tě líbá, když ne <F>já,
 
-\Ch{C}{kdo tě hlídá,} když ne \Ch{F}{já?}
+<C>kdo tě hlídá, když ne <F>já?
 
-\Ch{C}{Okno} v přízemí je \Ch{B}{zavřené} i \Ch{F}{dnes,}
+<C>Okno v přízemí je <B>zavřené i <F>dnes,
 
-lásko \Ch{C}{má.}
+lásko <C>má.
 \ks
 
 \zs
@@ -19,13 +19,13 @@ Okno v přízemí je zavřené i dnes, lásko má.
 \ks
 
 \zr
-\Ch{Ami}{A v jeho} \Ch{G}{lesku} vidím \Ch{F}{přicházet}
+<Ami>A v jeho <G>lesku vidím <F>přicházet
 
-\Ch{Ami}{sebe ve} \Ch{G}{věku} patnáct \Ch{F}{let}
+<Ami>sebe ve <G>věku patnáct <F>let
 
-\Ch{Ami}{a znovu} \Ch{G}{říkám} spoustu \Ch{F}{něžných vět:}
+<Ami>a znovu <G>říkám spoustu <F>něžných vět:
 
-\uv{\Ch{C}{Ty,} \Ch{F}{já,} \Ch{C}{jsme} \Ch{F}{my,} \Ch{C}{my} a \Ch{G}{náš} je \Ch{F}{svět.}}
+\uv{<C>Ty, <F>já, <C>jsme <F>my, <C>my a <G>náš je <F>svět.}
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Olympic____Osmý_den.tex
+++ b/tp-songs/02_pop_rock/Olympic____Osmý_den.tex
@@ -3,13 +3,13 @@
 \zp{Osmý den}{Olympic}
 
 \zs
-Z \Ch{G}{kraje} týdne málo jsem \Ch{C}{ti} \Ch{G}{vhod,} \Ch{C}{}
+Z <G>kraje týdne málo jsem <C>ti <G>vhod, <C>
 
-ve středu pak ztrácíš ke mně \Ch{C}{kód,}
+ve středu pak ztrácíš ke mně <C>kód,
 
-\Ch{Ami}{sedmý den} jsem s tebou, i když \Ch{D}{sám,}
+<Ami>sedmý den jsem s tebou, i když <D>sám,
 
-osmý den \Ch{G}{schází nám.} \Ch{C}{} \Ch{G}{} \Ch{C}{}
+osmý den <G>schází nám. <C> <G> <C>
 \ks
 
 \zs
@@ -19,13 +19,13 @@ v neděli už nevím, že tě mám, osmý den schází nám.
 \ks
 
 \zr
-\Ch{D}{Tužku} nemít, \Ch{C}{nic mi} nepo\Ch{G}{víš,}
+<D>Tužku nemít, <C>nic mi nepo<G>víš,
 
-\Ch{D}{řekni} prosím \Ch{C}{aspoň} příslo\Ch{G}{ví.}
+<D>řekni prosím <C>aspoň příslo<G>ví.
 
-\Ch{D}{Osmý} den je \Ch{C}{nutný} -- já to \Ch{Ami}{vím,}
+<D>Osmý den je <C>nutný -- já to <Ami>vím,
 
-\Ch{C}{sedm} nocí \Ch{Ami}{spíš, jen} \Ch{G}{spíš,} \Ch{C}{vždyť} \Ch{G}{víš.}
+<C>sedm nocí <Ami>spíš, jen <G>spíš, <C>vždyť <G>víš.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Olympic____Otázky.tex
+++ b/tp-songs/02_pop_rock/Olympic____Otázky.tex
@@ -3,12 +3,12 @@
 \zp{Otázky}{Olympic}
 
 
-\Ch{C}{} \Ch{F}{} \Ch{G}{} \Ch{C}{} \Ch{C}{} \Ch{F}{} \Ch{G}{} \Ch{C}{}
+<C> <F> <G> <C> <C> <F> <G> <C>
 
 \zs
-\Ch{C}{Kolik} mám ještě {dní}, \Ch{F}{než} přijde poslední,
+<C>Kolik mám ještě {dní}, <F>než přijde poslední,
 
-\Ch{G}{jak }dlouho budu zpívat a \Ch{C}{hrát?}
+<G>jak dlouho budu zpívat a <C>hrát?
 
 Kolik je na zemi cest, kterou mám dát se vést,
 
@@ -16,22 +16,22 @@ nebo už myslet mám na návrat?
 \ks
 
 \zr
-\Ch{C}{Posečkej}, lásko \Ch{C7}{má}, oka\Ch{F}{mžik,}
-\Ch{D7}{vždyť} svět je veliký ota\Ch{G}{zník,}
+<C>Posečkej, lásko <C7>má, oka<F>mžik,
+<D7>vždyť svět je veliký ota<G>zník,
 
 pořád se jenom ptáš a odpovědi, tý se nedočkáš.
 \kr
 
 \zr
-\Ch{E}{Já} jen vím, v zimě strom \Ch{Ami}{nekvete},
+<E>Já jen vím, v zimě strom <Ami>nekvete,
 
-v \Ch{F}{létě} sníh \Ch{E}{nepadá,} v noci je \Ch{Ami}{tma,}
+v <F>létě sníh <E>nepadá, v noci je <Ami>tma,
 
-\Ch{Ami}{rád tě} mám,
-jen \Ch{F}{neptej} se \Ch{C}{proč}, nevím \Ch{G}{sám.}
+<Ami>rád tě mám,
+jen <F>neptej se <C>proč, nevím <G>sám.
 \kr
 
-\Ch{C}{} \Ch{F}{} \Ch{G}{} \Ch{C}{} \Ch{C}{} \Ch{F}{} \Ch{G}{} \Ch{C}{}
+<C> <F> <G> <C> <C> <F> <G> <C>
 
 \zs
 Kde je tvůj dětský smích a proč je láska hřích?
@@ -45,7 +45,7 @@ a proč je tolik prázdných slov,
 proč chce kazdý být největší?
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Já jen vím, řeky proud hučí dál,

--- a/tp-songs/02_pop_rock/Olympic____Slzy_tvý_mámy.tex
+++ b/tp-songs/02_pop_rock/Olympic____Slzy_tvý_mámy.tex
@@ -4,14 +4,14 @@
 
 
 \zs
-\Ch{Ami}{Chvilku} vzpomínej, \Ch{Dmi}{je to} všechno jen pár let,
+<Ami>Chvilku vzpomínej, <Dmi>je to všechno jen pár let,
 
-\Ch{G}{na kytaru} v duchu hrej, \Ch{C}{tvoje} parta \Ch{Emi/H}{je tu hned,}
+<G>na kytaru v duchu hrej, <C>tvoje parta <Emi/H>je tu hned,
 
-z \Ch{Ami}{cigaret} jde modrej dým, \Ch{A7}{hraje} magne\Ch{Dmi}{ťák,}
+z <Ami>cigaret jde modrej dým, <A7>hraje magne<Dmi>ťák,
 
-holka sedla na tvůj klín, \Ch{Ami}{nevíš} ani \Ch{Emi}{jak,}
-nevíš \Ch{Ami}{jak.} \Ch{G}{} \Ch{Ami}{} \Ch{G}{} \Ch{Ami}{}
+holka sedla na tvůj klín, <Ami>nevíš ani <Emi>jak,
+nevíš <Ami>jak. <G> <Ami> <G> <Ami>
 \ks
 
 \zs
@@ -25,26 +25,26 @@ když jsi v noci vyšel ven, snad ses trochu třás, trochu třás.
 \ks
 
 \zs
-\Ch{A}{Když} tě našel noční \Ch{G}{hlí}dač, byl by \Ch{F}{to} jen příběh 
-\Ch{C}{bláz}nivýho kluka,
+<A>Když tě našel noční <G>hlídač, byl by <F>to jen příběh 
+<C>bláznivýho kluka,
 
-\Ch{F}{nebejt} nože \Ch{C}{ve} tvejch dětskej rukách,
+<F>nebejt nože <C>ve tvejch dětskej rukách,
 
-\Ch{F}{nebejt} strachu, \Ch{C}mohlo to bejt \Ch{E}{vše}chno \Ch{Ami}{jináč.} 
-\Ch{E}{}
+<F>nebejt strachu, <C>mohlo to bejt <E>všechno <Ami>jináč. 
+<E>
 \ks
 
 \zr
-\Ch{Ami}{Slzy} tvý mámy \Ch{G}{šed}ivý \Ch{Emi}{sték}ají na \Ch{Ami}{polš}tář.  \Ch{A7}
+<Ami>Slzy tvý mámy <G>šedivý <Emi>stékají na <Ami>polštář. <A7>
 
 
-\Ch{Dmi}{Kdo} tě zná, se vůbec \Ch{G}{ned}iví, že stárne \Ch{C}{jej}í tvář.
-\Ch{E4}{} \Ch{E}{}
+<Dmi>Kdo tě zná, se vůbec <G>nediví, že stárne <C>její tvář.
+<E4> <E>
 
-\Ch{Ami}{Neček}ej úsměv od ženy, který si \Ch{Dmi}{všech}no vzal,
+<Ami>Nečekej úsměv od ženy, který si <Dmi>všechno vzal,
 
-jen pro tvý \Ch{Ami}{touhy} zborcený, pro \Ch{G}{léta} ztrace\Ch{Emi}{ný, ty 
-oči} \Ch{Ami}{pláčou} dál.
+jen pro tvý <Ami>touhy zborcený, pro <G>léta ztrace<Emi>ný, ty 
+oči <Ami>pláčou dál.
 \kr
 
 \zs
@@ -60,7 +60,7 @@ snad se někdo ušklíb jen,
 \ks
 
 \zs
-\Ch{A...}{I když} byl někdo k tobě krutej, proč jsi znovu začal mezi svejma?
+<A...>I když byl někdo k tobě krutej, proč jsi znovu začal mezi svejma?
 
 Tvůj pocit křivdy se pak těžko smejvá,
 

--- a/tp-songs/02_pop_rock/Olympic____Snad_jsem_to_zavinil_já.tex
+++ b/tp-songs/02_pop_rock/Olympic____Snad_jsem_to_zavinil_já.tex
@@ -3,21 +3,21 @@
 \zp{Snad jsem to zavinil já}{Olympic}
 
 \zs
-\Ch{Ami}{Zas jsi} tak \Ch{C}{smutná},
+<Ami>Zas jsi tak <C>smutná,
 
-kdo se \Ch{D}{má} na to \Ch{Dmi}{kou}\Ch{E}{kat,}
+kdo se <D>má na to <Dmi>kou<E>kat,
 
-nic \Ch{Ami}{jíst ti} ne\Ch{C}{chutná,}
+nic <Ami>jíst ti ne<C>chutná,
 
-v hlavě \Ch{D}{máš} asi \Ch{Dmi}{brou}\Ch{E}{ka.}
+v hlavě <D>máš asi <Dmi>brou<E>ka.
 \ks
 
 \zr
-Tak \Ch{C}{nezou}\Ch{H}{fej,} \Ch{B}{nic} to \Ch{Ami}{není,}
+Tak <C>nezou<H>fej, <B>nic to <Ami>není,
 
-\Ch{C}{za} chví\Ch{H}{li} \Ch{B}{se} to \Ch{Ami}{změní.}
+<C>za chví<H>li <B>se to <Ami>změní.
 
-\Ch{F}{Snad} jsem \Ch{G}{to} zavinil \Ch{C}{já.} \Ch{E}{}
+<F>Snad jsem <G>to zavinil <C>já. <E>
 \kr
 
 \zs
@@ -30,19 +30,19 @@ tou tmou, obarvenou
 na černo smutnou touhou.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 = 2.
 \ks
 
-\zr  \kr
+\zr \kr
 
-/: \Ch{Ami}{Já,} \Ch{C}{já,} \Ch{D}{já,} \Ch{Dmi7}{já,} :/
+/: <Ami>Já, <C>já, <D>já, <Dmi7>já, :/
 
-3× /: \Ch{Ami}{já,} \Ch{C}{} \Ch{D}{} \Ch{Dmi}{} :/
+3× /: <Ami>já, <C> <D> <Dmi> :/
 
-\Ch{Ami}{já}!
+<Ami>já!
 
 \kp
 

--- a/tp-songs/02_pop_rock/Olympic____Želva.tex
+++ b/tp-songs/02_pop_rock/Olympic____Želva.tex
@@ -3,13 +3,13 @@
 \zp{Želva}{Olympic}
 
 \zs
-\Ch{G}{Ne} moc \Ch{C}{snadno} se \Ch{G}{želva} \Ch{C}{po} dně \Ch{G}{honí}, \Ch{C}{} \Ch{G}{} \Ch{C}{}
+<G>Ne moc <C>snadno se <G>želva <C>po dně <G>honí, <C> <G> <C>
 
-\Ch{G}{velmi} \Ch{C}{radno} je \Ch{G}{plavat} \Ch{C}{na} dno za \Ch{G}{ní}, \Ch{C}{} \Ch{G}{}  \Ch{C}{}
+<G>velmi <C>radno je <G>plavat <C>na dno za <G>ní, <C> <G> <C>
 
-{jenom} \Ch{D}{počkej}, až se zeptá, na to, \Ch{Emi}{co tě} v mozku lechtá,
+{jenom} <D>počkej, až se zeptá, na to, <Emi>co tě v mozku lechtá,
 
-\Ch{G}{nic} se \Ch{C}{neboj} a \Ch{G}{vem} si \Ch{C}{něco} od \Ch{G}{ní}. \Ch{C}{} \Ch{G}{} \Ch{C}{}
+<G>nic se <C>neboj a <G>vem si <C>něco od <G>ní. <C> <G> <C>
 \ks
 
 \zs
@@ -23,10 +23,10 @@ Víš, má drahá, a zbytek je pod vanou.
 \ks
 
 \zr
-\Ch{G}{Když} si \Ch{D}{někdo} \Ch{C}{pozor} ne\Ch{G}{dá,} jak se \Ch{D}{vlastně} \Ch{C}{želva} hle\Ch{G}{dá,}
+<G>Když si <D>někdo <C>pozor ne<G>dá, jak se <D>vlastně <C>želva hle<G>dá,
 
-\Ch{C}{ona} ho na {něco} nachy\Ch{D}{tá}, \Ch{C}{i kd}yž si to pozděj’c 
-vyčí\Ch{D}{tá}.
+<C>ona ho na {něco} nachy<D>tá, <C>i když si to pozděj’c 
+vyčí<D>tá.
 \kr
 
 \zs
@@ -39,7 +39,7 @@ jeho úsměv se vytratí a to se mu nevyplatí,
 má se nebát želev a spousty vodní.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Petr_Hapka____Šaškové_počmáraní.tex
+++ b/tp-songs/02_pop_rock/Petr_Hapka____Šaškové_počmáraní.tex
@@ -3,13 +3,13 @@
 \zp{Šaškové počmáraní}{Petr Hapka}
 
 \zs
-\Ch{C}{Koukněte} na toho \Ch{H7}{fintila,}
+<C>Koukněte na toho <H7>fintila,
 
-\Ch{Dmi7}{pod krkem} žlutého \Ch{G7}{motýla,}
+<Dmi7>pod krkem žlutého <G7>motýla,
 
-\Ch{Dmi7}{zelený} klobouček \Ch{G7}{do týla,}
+<Dmi7>zelený klobouček <G7>do týla,
 
-\Ch{D7}{šoupne} si \Ch{G7}{na bílou} \Ch{C}{pleš.} \Ch{G+}{}
+<D7>šoupne si <G7>na bílou <C>pleš. <G+>
 \ks
 
 \zs
@@ -19,17 +19,17 @@ hlavně že vyhrávám barvami,
 
 hlavně že vyhrávám barvami,
 
-zase jsem šťastnej jak \Ch{C}{veš.}  \Ch{C7}{}
+zase jsem šťastnej jak <C>veš. <C7>
 \ks
 
 \zr
-Co po mně \Ch{F}{chceš,} pravdu či \Ch{Fmi}{lež?}
+Co po mně <F>chceš, pravdu či <Fmi>lež?
 
-Zkus ty dvě \Ch{C}{rozeznat} a pak se \Ch{C7}{směj.}
+Zkus ty dvě <C>rozeznat a pak se <C7>směj.
 
-Barevný \Ch{F}{svět} láme mi \Ch{Fmi}{hřbet,}
+Barevný <F>svět láme mi <Fmi>hřbet,
 
-\Ch{Emi}{přesto} chci \Ch{Ebdim}{být šašek} \Ch{Dmi7}{počmára}\Ch{G7}{nej.}
+<Emi>přesto chci <Ebdim>být šašek <Dmi7>počmára<G7>nej.
 \kr
 
 \zs
@@ -103,21 +103,21 @@ dojemně pitomá show.
 \ks
 
 \ifdefined\TPBAND
-    Basa:
-    
-    | C G H F |
-    
-    | D A G H |
-    
-    | D A G H |
-    
-    | D G C G | 
-    
-    \zr
-    | F F | f  f | C H B A |
-    
-    | F F | f  e | d\# d |
-    \kr
+ Basa:
+ 
+ | C G H F |
+ 
+ | D A G H |
+ 
+ | D A G H |
+ 
+ | D G C G | 
+ 
+ \zr
+ | F F | f f | C H B A |
+ 
+ | F F | f e | d\# d |
+ \kr
 \fi
 
 \kp

--- a/tp-songs/02_pop_rock/Pražský_výběr____Pražákům_je_hej.tex
+++ b/tp-songs/02_pop_rock/Pražský_výběr____Pražákům_je_hej.tex
@@ -3,7 +3,7 @@
 \zp{Pražákům je hej}{Pražský výběr}
 
 \zs
-\Ch{Hmi}{Celetná}, Týnská, na Příkopech,
+<Hmi>Celetná, Týnská, na Příkopech,
 ploužím se městem po výkopech,
 
 V Tůni a V Jámě, Moráň, Výtoň,
@@ -11,15 +11,15 @@ procházka Prahou, to je výkon.
 \ks
 
 \zr
-\Ch{D}{Pra}žákům, těm je tu \Ch{A}{hej,}
-ty nikam nezablou\Ch{Hmi}{děj,}
+<D>Pražákům, těm je tu <A>hej,
+ty nikam nezablou<Hmi>děj,
 
-s \Ch{D}{batohem} na zádech, \Ch{A}{sám,}
-na strejdu Karla se \Ch{Hmi}{ptám.}
+s <D>batohem na zádech, <A>sám,
+na strejdu Karla se <Hmi>ptám.
 \kr
 
 \zs
-\Ch{Hmi}{Tu Že}livského, tam Celetná,
+<Hmi>Tu Želivského, tam Celetná,
 jak se v tom country teď vyznat mám?
 
 Podolí, Strahov, Anděl, ó jej,
@@ -27,32 +27,32 @@ už mě tu víckrát neuviděj.
 \ks
 
 \zr
-\Ch{D}{Pra}žákům, těm je tu \Ch{A}{hej,}
-ty nikam nezablou\Ch{Hmi}{děj.}
+<D>Pražákům, těm je tu <A>hej,
+ty nikam nezablou<Hmi>děj.
 
-\Ch{D}{Plz}eňská a Francouz\Ch{A}{ská,}
-Těšnov a Novodvor\Ch{Hmi}{ská,}
+<D>Plzeňská a Francouz<A>ská,
+Těšnov a Novodvor<Hmi>ská,
 
-\Ch{D}{Betl}émská, Jarov, Soud\Ch{A}{ní,}
-Žitná, Ruská a Dol\Ch{Hmi}{ní,}
+<D>Betlémská, Jarov, Soud<A>ní,
+Žitná, Ruská a Dol<Hmi>ní,
 
-Saf\Ch{F}{ra,} saf\Ch{F#}{ra...}
+Saf<F>ra, saf<F#>ra...
 
 Mám rád disko, disko, disko...
 \kr
 
 
 \zr
-\Ch{D}{Plz}eňská a Francouz\Ch{A}{ská,}
-Těšnov a Novodvor\Ch{Hmi}{ská,}
+<D>Plzeňská a Francouz<A>ská,
+Těšnov a Novodvor<Hmi>ská,
 
-\Ch{D}{Bet}lémská, Jarov, Sou\Ch{A}{dní,}
-Žitná, Ruská a Dol\Ch{Hmi}{ní.}
+<D>Betlémská, Jarov, Sou<A>dní,
+Žitná, Ruská a Dol<Hmi>ní.
 \kr
 
 \zr
-\Ch{D}{Pra}žákům, těm je tu \Ch{A}{hej,}
-ty nikam nezablou\Ch{Hmi}{děj.}
+<D>Pražákům, těm je tu <A>hej,
+ty nikam nezablou<Hmi>děj.
 \kr
 \kp
 

--- a/tp-songs/02_pop_rock/Premiér____Hrobař.tex
+++ b/tp-songs/02_pop_rock/Premiér____Hrobař.tex
@@ -3,11 +3,11 @@
 \zp{Hrobař}{Premiér}
 
 \zs
-V \Ch{G}{mládí} jsem se učil hrobařem,
+V <G>mládí jsem se učil hrobařem,
 
-\Ch{Emi}{jezdit} s hlínou, jezdit s trakařem,
+<Emi>jezdit s hlínou, jezdit s trakařem,
 
-\Ch{C}{kopat} hroby byl můj ide\Ch{D7}{ál.}
+<C>kopat hroby byl můj ide<D7>ál.
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/Ready_Kirken____1_+_1.tex
+++ b/tp-songs/02_pop_rock/Ready_Kirken____1_+_1.tex
@@ -2,13 +2,13 @@
 
 \zp{1 + 1}{Ready Kirken}
 \zs
-\Ch{Emi}{Už ani} nedivím se, \Ch{Hmi}{jak věci} otáčí se,
+<Emi>Už ani nedivím se, <Hmi>jak věci otáčí se,
 
-z \Ch{Emi}{radosti} splín si klidně \Ch{Hmi}{vrhá} stín.
+z <Emi>radosti splín si klidně <Hmi>vrhá stín.
 
-\Ch{D}{Sám} sebe nepoznávám, \Ch{Ami}{dobrovolně} se vzdávám,
+<D>Sám sebe nepoznávám, <Ami>dobrovolně se vzdávám,
 
-\Ch{D}{můj} přítel strach už troubí \Ch{Ami}{na poplach.}
+<D>můj přítel strach už troubí <Ami>na poplach.
 \ks
 \zs
 Člověk, když nachází se opět na známém místě,
@@ -17,16 +17,16 @@ výchozí bod mu vlastně přijde vhod.
 
 Stačí tak strašně málo, aby se ukázalo:
 
-\Ch{C}{pro} jedno \Ch{D}{kví}tí se slunce \Ch{E}{ner}ozsvítí.
+<C>pro jedno <D>kvítí se slunce <E>nerozsvítí.
 \ks
 \zr
-\Ch{G}{Někde} si najdu malej \Ch{D}{byt}
+<G>Někde si najdu malej <D>byt
 
-a tam si budu jen tak \Ch{Ami}{žít a} \Ch{C}{snít.}
+a tam si budu jen tak <Ami>žít a <C>snít.
 
-\Ch{G}{To} je můj utajený \Ch{D}{svět,}
+<G>To je můj utajený <D>svět,
 
-1+1, tam a \Ch{Ami}{zpět, a} \Ch{C}{zpět.}
+1+1, tam a <Ami>zpět, a <C>zpět.
 \kr
 \zs
 Možná že štěstí mívá, kdo to tak neprožívá,

--- a/tp-songs/02_pop_rock/Richard_Müller____Nebude_to_ľahké.tex
+++ b/tp-songs/02_pop_rock/Richard_Müller____Nebude_to_ľahké.tex
@@ -3,24 +3,24 @@
 \zp{Nebude to ľahké}{Richard Müller}
 
 
-\Ch{Ami}{} \Ch{G}{} \Ch{Ami}{} \Ch{G}{}
+<Ami> <G> <Ami> <G>
 
 \zs
-\Ch{Ami}{Vraj} zmenila si \Ch{G}{číslo} \Ch{Ami}{a do} zámku \Ch{G}{nepasuje} viac môj \Ch{Fmaj7}{kľúč.} \Ch{F}{}
+<Ami>Vraj zmenila si <G>číslo <Ami>a do zámku <G>nepasuje viac môj <Fmaj7>kľúč. <F>
 
-\Ch{Ami}{Hlavou} mi \Ch{G}{blysklo}, \Ch{Ami}{asi chceš,} \Ch{G}{aby} som bol už \Ch{Fmaj7}{fuč.}
+<Ami>Hlavou mi <G>blysklo, <Ami>asi chceš, <G>aby som bol už <Fmaj7>fuč.
 \ks
 
 \zr
-\Ch{C}{Nebude} to \Ch{G}{také} ľahké, \Ch{Fmaj7}{drahá,} \Ch{F}{} \Ch{Fmaj7}{}
+<C>Nebude to <G>také ľahké, <Fmaj7>drahá, <F> <Fmaj7>
 
-\Ch{C}{mňa} sa nezba\Ch{G}{víš,} s tým sa \Ch{Fmaj7}{lúč,}
+<C>mňa sa nezba<G>víš, s tým sa <Fmaj7>lúč,
 
-\Ch{C}{nebude} to \Ch{G}{také} ľahké, \Ch{Fmaj7}{drahá,}
+<C>nebude to <G>také ľahké, <Fmaj7>drahá,
 
-\Ch{G}{nemôžeš} ma \Ch{Fmaj7}{vymeniť} ako \Ch{G}{rúž} --
+<G>nemôžeš ma <Fmaj7>vymeniť ako <G>rúž --
 
-som tvoj \Ch{Ami}{muž}. \Ch{G}{} \Ch{Ami}{} \Ch{G}{}
+som tvoj <Ami>muž. <G> <Ami> <G>
 \kr
 
 \zs
@@ -29,7 +29,7 @@ Vraj koketuješ s iným -- dolámem mu kosti, nos a sny.
 Tak dopúšťaš sa viny, tak vrav, povedz, čo máš s ním.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Vraj trháš moje fotky, majetok náš rozdelí až súd.
@@ -37,19 +37,19 @@ Vraj trháš moje fotky, majetok náš rozdelí až súd.
 Ja exujem veľké vodky, márne sa snažím zachovať kľud.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
-\Ch{F}{Predsa} sme si \Ch{G}{súdení}, \Ch{F}{ja} nemôžem žiť \Ch{G}{bez} ženy,
+<F>Predsa sme si <G>súdení, <F>ja nemôžem žiť <G>bez ženy,
 
-\Ch{F}{ja} nemôžem žiť \Ch{G}{bez} teba, to mi \Ch{Ami}{ver.}
+<F>ja nemôžem žiť <G>bez teba, to mi <Ami>ver.
 
-\Ch{F}{A v} kostole \Ch{G}{pred} Pánom \Ch{F}{sľubovala} \Ch{G}{si} nám dvom
+<F>A v kostole <G>pred Pánom <F>sľubovala <G>si nám dvom
 
-\Ch{F}{nekonečnú} \Ch{G}{lásku}, vernosť, \Ch{Ami}{mier,} \Ch{G}{mier,} \Ch{F}{mier}, óóó...
+<F>nekonečnú <G>lásku, vernosť, <Ami>mier, <G>mier, <F>mier, óóó...
 \ks
 
-\zr     \kr
+\zr \kr
 
 \zs
 Vraj zmenila si číslo a do zámku nepasuje viac môj...

--- a/tp-songs/02_pop_rock/Richard_Müller____Po_schodoch.tex
+++ b/tp-songs/02_pop_rock/Richard_Müller____Po_schodoch.tex
@@ -3,9 +3,9 @@
 \zp{Po schodoch}{Richard Müller}
 
 \zs
-\Ch{Dmi}{Výťah} opäť nechodí, tak \Ch{C}{zdolať} 13 poschodí
+<Dmi>Výťah opäť nechodí, tak <C>zdolať 13 poschodí
 
-\Ch{B}{zostáva} mi \Ch{C}{znova} po svo\Ch{Dmi}{jich.}
+<B>zostáva mi <C>znova po svo<Dmi>jich.
 
 Na schodoch čosi šramotí a neón kde tu nesvieti,
 
@@ -23,13 +23,13 @@ všetko počuť cestou po schodoch.
 \ks
 
 \zr
-Cestou \Ch{Dmi}{po sch}odoch, \Ch{Ami}{po sch}odoch
+Cestou <Dmi>po schodoch, <Ami>po schodoch
 
-\Ch{Dmi}{poznávam} \Ch{C}{poschodia,}
+<Dmi>poznávam <C>poschodia,
 
-poznám \Ch{Dmi}{po sch}odoch, \Ch{Ami}{po zvu}koch,
+poznám <Dmi>po schodoch, <Ami>po zvukoch,
 
-\Ch{B}{čo} sme kto \Ch{A}{za} ľu\Ch{Dmi}{dia.}
+<B>čo sme kto <A>za ľu<Dmi>dia.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Richard_Müller____Srdce_jako_kníže_Rohan.tex
+++ b/tp-songs/02_pop_rock/Richard_Müller____Srdce_jako_kníže_Rohan.tex
@@ -3,30 +3,30 @@
 \zp{Srdce jako kníže Rohan}{Richard Müller}
 
 \zs
-\Ch{F}{Měsíc} je jak Zlatá bula \Ch{C}{Sicilská,}
-\Ch{Ami}{stvrzuje} se, že kdo chce, se \Ch{G}{dopíská,}
+<F>Měsíc je jak Zlatá bula <C>Sicilská,
+<Ami>stvrzuje se, že kdo chce, se <G>dopíská,
 
-\Ch{F}{pod} lampou jen krátce, v přítmí \Ch{C}{dlouze} zas,
-\Ch{Ami}{otevře} ti Kobera a \Ch{G}{můžeš} mezi nás.
-\Ch{F} {} \Ch{C}{} \Ch{Ami}{} \Ch{G}{} \Ch{F}{} \Ch{C}{} \Ch{Ami}{} \Ch{G}{}
+<F>pod lampou jen krátce, v přítmí <C>dlouze zas,
+<Ami>otevře ti Kobera a <G>můžeš mezi nás.
+<F> <C> <Ami> <G> <F> <C> <Ami> <G>
 \ks
 
 \zs
-\Ch{F}{Moje} teta, tvoje teta, \Ch{C}{parole,}
-\Ch{Ami}{dvaatřicet} karet křepčí \Ch{G}{na} stole,
+<F>Moje teta, tvoje teta, <C>parole,
+<Ami>dvaatřicet karet křepčí <G>na stole,
 
-\Ch{F}{měsíc} svítí sám a chleba \Ch{C}{nežere,}
-\Ch{Ami}{ty to} ale koukej trefit, \Ch{G}{frajere,} protože...
+<F>měsíc svítí sám a chleba <C>nežere,
+<Ami>ty to ale koukej trefit, <G>frajere, protože...
 \ks
 
 \zr
-\Ch{F}{Dnes} je valcha u starýho \Ch{C}{Růžičky,}
-\Ch{Ami}{dej si} prachy do pořádný \Ch{G}{ruličky,}
+<F>Dnes je valcha u starýho <C>Růžičky,
+<Ami>dej si prachy do pořádný <G>ruličky,
 
-\Ch{F}{co} je na tom, že to není \Ch{C}{extra} nóbl byt,
-\Ch{Ami}{srdce} jako kníže Rohan \Ch{G}{musíš} mít.
+<F>co je na tom, že to není <C>extra nóbl byt,
+<Ami>srdce jako kníže Rohan <G>musíš mít.
 
-\Ch{F}{} \Ch{C}{} \Ch{Ami}{} \Ch{G}{}
+<F> <C> <Ami> <G>
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Richard_Müller____Štěstí_je_krásná_věc.tex
+++ b/tp-songs/02_pop_rock/Richard_Müller____Štěstí_je_krásná_věc.tex
@@ -3,23 +3,23 @@
 \zp{Štěstí je krásná věc}{Richard Müller}
 
 \zs
-\Ch{C}{Například} východ slunce \Ch{Emi7}{a vítr} ve vět\Ch{F}{vích} \Ch{Dmi}{} \Ch{G7}{}
+<C>Například východ slunce <Emi7>a vítr ve vět<F>vích <Dmi> <G7>
 
-\Ch{C}{anebo} píseň tichou \Ch{Emi7}{jak pad}ající \Ch{F}{sníh,} \Ch{Dmi}{} \Ch{G}{}
+<C>anebo píseň tichou <Emi7>jak padající <F>sníh, <Dmi> <G>
 
-\Ch{Dmi}{tak to} prý nelze \Ch{G7}{koupit} za \Ch{C}{žádný} pení\Ch{F}{ze,}
+<Dmi>tak to prý nelze <G7>koupit za <C>žádný pení<F>ze,
 
-jenže \Ch{C}{zbejvá} spousta \Ch{F}{věcí,} \Ch{C}{a ty} \Ch{D7}{koupit} \Ch{G}{lze}.
+jenže <C>zbejvá spousta <F>věcí, <C>a ty <D7>koupit <G>lze.
 \ks
 
 \zs
-\Ch{G7}{Jó, vždyť} \Ch{C}{víš}, \Ch{Emi}{štěstí} je krásná \Ch{F}{věc,} \Ch{Dmi}{} \Ch{G7}{}
+<G7>Jó, vždyť <C>víš, <Emi>štěstí je krásná <F>věc, <Dmi> <G7>
 
-vždyť \Ch{C}{víš,} \Ch{Emi}{štěstí} je krásná \Ch{F}{věc.} \Ch{Dmi}{} \Ch{G}{}
+vždyť <C>víš, <Emi>štěstí je krásná <F>věc. <Dmi> <G>
 
-\Ch{Dmi}{Štěstí} je tak \Ch{G}{krásná} a \Ch{C}{přepychová} \Ch{F}{věc,}
+<Dmi>Štěstí je tak <G>krásná a <C>přepychová <F>věc,
 
-ale \Ch{C}{prachy} si \Ch{G7}{za něj} nekou\Ch{C}{píš.}\Ch{G7}{}
+ale <C>prachy si <G7>za něj nekou<C>píš.<G7>
 \ks
 
 \zs
@@ -52,6 +52,6 @@ A proto když se dočtu o zemětřesení
 nebo o bouračce, no tak řeknu: \uv{K neuvěření.}
 \ks
 
-\zr  \kr  \zr  \kr
+\zr \kr \zr \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Slávek_Janoušek____Halleyova_kometa.tex
+++ b/tp-songs/02_pop_rock/Slávek_Janoušek____Halleyova_kometa.tex
@@ -3,13 +3,13 @@
 \zp{Halleyova kometa}{Slávek Janoušek}
 
 \zs
-\Ch{G}{Courám} se vesmírem \Ch{Hmi}{už celá staletí,}
+<G>Courám se vesmírem <Hmi>už celá staletí,
 
-\Ch{Ami}{daleko do tmy} a zas \Ch{C}{šup ke} Slunci \Ch{G}{do tepla,} jsem svěží,
+<Ami>daleko do tmy a zas <C>šup ke Slunci <G>do tepla, jsem svěží,
 
-a silák Jupiter \Ch{Hmi}{přede mnou} baletí,
+a silák Jupiter <Hmi>přede mnou baletí,
 
-\Ch{Ami}{často mě} zdrží, ale \Ch{C}{vždy jsem} mu \Ch{G}{utekla,} jsem silná.
+<Ami>často mě zdrží, ale <C>vždy jsem mu <G>utekla, jsem silná.
 \ks
 
 \zs
@@ -19,7 +19,7 @@ jsou se vším hned hotoví, pro ně jsem stařičká, kus ledu, co letí, pak s
 \ks
 
 \zr
-/: \Ch{G}{Užívejte} světa, \Ch{Hmi}{blíží se} kometa, \Ch{Ami}{užívejte světa,} \Ch{C}{blíží se} \Ch{G}{kometa.} :/
+/: <G>Užívejte světa, <Hmi>blíží se kometa, <Ami>užívejte světa, <C>blíží se <G>kometa. :/
 \kr
 
 \zs
@@ -49,7 +49,7 @@ jedni se sami trávili, druzí létali v balónu, žít či se věšet, to já j
 
 Většina vzývala Františka Josefa, báťušku cara či císaře Viléma, jsou bezva,
 
-a když válka začala, s kým má být kometa?  Ach -- co se starám, s těma či s tamtěma?
+a když válka začala, s kým má být kometa? Ach -- co se starám, s těma či s tamtěma?
 \ks
 
 \zr\kr
@@ -69,7 +69,7 @@ kdekdo je potkává, do kosmu lítají, dokonce prý mi poletí naproti, jsou be
 
 Courám se vesmírem, kdeco mě potěší, lidi si myslí, že vše je tu pro ně snad, jsou bezva,
 
-prý se psaným papírem spor o vesmír vyřeší, kdoví, co najdu v roce dva tisíce \Ch{G}{šedesát} \Ch{D}{dva...}
+prý se psaným papírem spor o vesmír vyřeší, kdoví, co najdu v roce dva tisíce <G>šedesát <D>dva...
 \ks
 
 \zr

--- a/tp-songs/02_pop_rock/Standa_Hložek,_Petr_Kotvald____Holky_z_naší_školky.tex
+++ b/tp-songs/02_pop_rock/Standa_Hložek,_Petr_Kotvald____Holky_z_naší_školky.tex
@@ -3,25 +3,25 @@
 \zp{Holky z naší školky}{Standa Hložek, Petr Kotvald}
 
 \zs
-\Ch{D}{Majdalénka}, \Ch{G}{Apolénka} s \Ch{A}{Veronikou}
+<D>Majdalénka, <G>Apolénka s <A>Veronikou
 
-a taky \Ch{D}{Věrka}, Zdenka, \Ch{G}{Majka}, Lenka s \Ch{A}{Monikou,}
+a taky <D>Věrka, Zdenka, <G>Majka, Lenka s <A>Monikou,
 
-no jasně, \Ch{D}{Klára}, Hančí, \Ch{G}{Bára}, Mančí \Ch{A}{již} nevím čí,
+no jasně, <D>Klára, Hančí, <G>Bára, Mančí <A>již nevím čí,
 
-to všechno \Ch{D}{byly} holky z \Ch{G}{naší} školky \Ch{A}{senzační.}
+to všechno <D>byly holky z <G>naší školky <A>senzační.
 \ks
 
 \zr
-\Ch{D}{Jé,} \Ch{A}{jé,} \Ch{G}{jé,}
-\Ch{A}{kdepak ty} \Ch{D}{fajn} holky \Ch{G}{jsou}
-a kde \Ch{D}{maj'} hračky \Ch{G}{svý,}
-ty naše \Ch{Emi7}{lásky} tříle\Ch{A}{tý?}
+<D>Jé, <A>jé, <G>jé,
+<A>kdepak ty <D>fajn holky <G>jsou
+a kde <D>maj' hračky <G>svý,
+ty naše <Emi7>lásky tříle<A>tý?
 
-\Ch{D}{Pá,} \Ch{A}{pá,} \Ch{G}{pá,}
-\Ch{A}{řekli jsme} \Ch{D}{pá před} škol\Ch{G}{kou},
-bylo \Ch{D}{nám} právě \Ch{G}{šest}
-a začla \Ch{Emi7}{další} dívčí \Ch{A}{šou.}
+<D>Pá, <A>pá, <G>pá,
+<A>řekli jsme <D>pá před škol<G>kou,
+bylo <D>nám právě <G>šest
+a začla <Emi7>další dívčí <A>šou.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Sto_zvířat____Škola.tex
+++ b/tp-songs/02_pop_rock/Sto_zvířat____Škola.tex
@@ -2,46 +2,46 @@
 
 \zp{Škola}{Sto zvířat}
 
-/: \Ch{Dmi}{} \Ch{A}{} :/ 
+/: <Dmi> <A> :/ 
 
 \zs
-Ty \Ch{Dmi}{vole,} \Ch{A}{na základní} \Ch{Dmi}{škole}
-mám \Ch{A}{průsery a} \Ch{Dmi}{koule} 
+Ty <Dmi>vole, <A>na základní <Dmi>škole
+mám <A>průsery a <Dmi>koule 
 
-a s \Ch{A}{naší účou} \Ch{Dmi}{problém,}
-je to \Ch{A}{golem a} má \Ch{Dmi}{knír.} \Ch{A}{} \Ch{Dmi}{} \Ch{A}{}
+a s <A>naší účou <Dmi>problém,
+je to <A>golem a má <Dmi>knír. <A> <Dmi> <A>
 
-Z \Ch{Dmi}{týhle úči} \Ch{A}{v palici mi} \Ch{Dmi}{hučí,}
-prej \Ch{A}{hejbnul jsem jí} \Ch{Dmi}{žlučí} 
+Z <Dmi>týhle úči <A>v palici mi <Dmi>hučí,
+prej <A>hejbnul jsem jí <Dmi>žlučí 
 
-a \Ch{A}{proto,} za to \Ch{Dmi}{ručím,}
-mě teď \Ch{A}{mučí pořád} \Ch{Dmi}{víc.} \Ch{A}{} \Ch{Dmi}{} \Ch{A}{}
+a <A>proto, za to <Dmi>ručím,
+mě teď <A>mučí pořád <Dmi>víc. <A> <Dmi> <A>
 \ks
 
 \zs
 
-Mě snad \Ch{Gmi}{šlehne,} \Ch{Dmi}{ta se odsud} \Ch{Gmi}{nehne,}
-ať \Ch{Dmi}{zem se} po ní \Ch{Gmi}{slehne!} 
+Mě snad <Gmi>šlehne, <Dmi>ta se odsud <Gmi>nehne,
+ať <Dmi>zem se po ní <Gmi>slehne! 
 
-Už \Ch{Dmi}{kuchařky} nám \Ch{Gmi}{stehnem}
-hrachovou \Ch{Dmi}{kaši} \Ch{Gmi}{zahřívaj.}\Ch{Dmi}{} \Ch{Gmi}{} \Ch{Dmi}{}
+Už <Dmi>kuchařky nám <Gmi>stehnem
+hrachovou <Dmi>kaši <Gmi>zahřívaj.<Dmi> <Gmi> <Dmi>
 
-\Ch{Dmi}{Děsná nuda,} \Ch{A}{zákazy} a \Ch{Dmi}{pruda}
-a \Ch{A}{za katedrou} \Ch{Dmi}{zrůda}
+<Dmi>Děsná nuda, <A>zákazy a <Dmi>pruda
+a <A>za katedrou <Dmi>zrůda
 
-mě \Ch{A}{fotrovi zas'} \Ch{Dmi}{udá,}
-ten mě \Ch{A}{sundá,} to já \Ch{Dmi}{znám.} \Ch{A}{} \Ch{Dmi}{} \Ch{A}{} 
+mě <A>fotrovi zas' <Dmi>udá,
+ten mě <A>sundá, to já <Dmi>znám. <A> <Dmi> <A> 
 
 \ks
 
 \zr
-Základ\Ch{F}{ní} škola ti \Ch{Dmi}{dává}
-mnohem \Ch{F}{víc,} než bys tušil, na mou \Ch{A}{duši!}
+Základ<F>ní škola ti <Dmi>dává
+mnohem <F>víc, než bys tušil, na mou <A>duši!
 
-Teď \Ch{F}{víš,} když ráno \Ch{Dmi}{vstáváš,}
-že prostě \Ch{F}{máš držet hubu,} 
+Teď <F>víš, když ráno <Dmi>vstáváš,
+že prostě <F>máš držet hubu, 
 
-sklopit \Ch{A}{hlavu,} zmizet \Ch{G}{v davu} ako\Ch{A}{rát!}
+sklopit <A>hlavu, zmizet <G>v davu ako<A>rát!
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Trabant____Černej_pasažér.tex
+++ b/tp-songs/02_pop_rock/Trabant____Černej_pasažér.tex
@@ -3,12 +3,12 @@
 \zp{Černej pasažér}{Trabant}
 
 \zs
-Mám \Ch{Dmi}{kufr} plnej přebytečnejch \Ch{A}{krámů} a mapu zabalenou do plát\Ch{Dmi}{na,} 
+Mám <Dmi>kufr plnej přebytečnejch <A>krámů a mapu zabalenou do plát<Dmi>na, 
 
-můj vlak však jede na opačnou \Ch{A}{stranu} a moje jízdenka je dávno neplat\Ch{Dmi}{ná.} 
+můj vlak však jede na opačnou <A>stranu a moje jízdenka je dávno neplat<Dmi>ná. 
 \ks
 
-\Ch{F}{} \Ch{Dmi}{} \Ch{F}{} \Ch{Dmi}{} 
+<F> <Dmi> <F> <Dmi> 
 
 \zs
 Někde ve vzpomínkách stojí dům, ještě vidím, jak se kouří z komína,
@@ -20,20 +20,20 @@ Moje minulost se na mě šklebí a srdce bolí, když si vzpomenu,
 že stromy, který měly dorůst k nebi, tu leží vyvrácený z kořenů.
 \ks
 
-\Ch{F}{} \Ch{Dmi}{} \Ch{F}{} \Ch{Dmi}{} 
+<F> <Dmi> <F> <Dmi> 
 
 \zr
-Jsem černej \Ch{B}{pasažér,}
+Jsem černej <B>pasažér,
 
-\Ch{C}{nemám} \Ch{F}{cíl} ani směr,
+<C>nemám <F>cíl ani směr,
 
-vezu se \Ch{B}{načerno} \Ch{C}{životem} a \Ch{F}{nevím,}
+vezu se <B>načerno <C>životem a <F>nevím,
 
-jsem černej \Ch{B}{pasažér,}
+jsem černej <B>pasažér,
 
-\Ch{C}{nemám} \Ch{F}{cíl} ani směr,
+<C>nemám <F>cíl ani směr,
 
-vezu se \Ch{B}{odnikud} \Ch{C}{nikam} a \Ch{A7}{nevím,} kde skončím.
+vezu se <B>odnikud <C>nikam a <A7>nevím, kde skončím.
 \kr
 
 \zs
@@ -42,7 +42,7 @@ Mám to všechno na barevný fotce někdy z minulýho století,
 tu jedinou a pocit bezdomovce si s sebou nesu stále v paměti.
 \ks
 
-\Ch{F}{} \Ch{Dmi}{} \Ch{F}{} \Ch{Dmi}{} 
+<F> <Dmi> <F> <Dmi> 
 
 \zr \kr
 
@@ -50,9 +50,9 @@ tu jedinou a pocit bezdomovce si s sebou nesu stále v paměti.
 
 \zs
 
-/: Na, na, na, naj, naj, naj, naj, \Ch{A}{naj}
+/: Na, na, na, naj, naj, naj, naj, <A>naj
  
-Na, na, na, naj, naj, naj, naj, \Ch{Dmi}{naj} :/
+Na, na, na, naj, naj, naj, naj, <Dmi>naj :/
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Tři_sestry____Básník.tex
+++ b/tp-songs/02_pop_rock/Tři_sestry____Básník.tex
@@ -2,28 +2,28 @@
 
 \zp{Básník}{Tři sestry}
 
-\Ch{G}{} \Ch{G}{} \Ch{G}{} \Ch{Hmi}{}
+<G> <G> <G> <Hmi>
 
 \zs
-\Ch{G}{Chodím} po Tatrách a dole roste hrách
+<G>Chodím po Tatrách a dole roste hrách
 
-a \Ch{Hmi}{spacák} jen mám, toulám se \Ch{D}{sám.}
+a <Hmi>spacák jen mám, toulám se <D>sám.
 
-V \Ch{G}{noci,} když je mráz, luna bourá hráz
+V <G>noci, když je mráz, luna bourá hráz
 
-těch \Ch{Hmi}{astrálních} vět, jsem doktor všech věd.
+těch <Hmi>astrálních vět, jsem doktor všech věd.
 
-Vče\Ch{G}{ra} jsem ještě pil, teď slyším zvuky pil
+Vče<G>ra jsem ještě pil, teď slyším zvuky pil
 
-a v \Ch{Hmi}{dáli} zvon bije, už nejsem zombie.
+a v <Hmi>dáli zvon bije, už nejsem zombie.
 \ks
 
 \zr
-/: \Ch{Ami}{Vím}, já to \Ch{D}{vím},
-jsem \Ch{G}{básník}, já jsem básník. :/
+/: <Ami>Vím, já to <D>vím,
+jsem <G>básník, já jsem básník. :/
 \kr
 
-\Ch{G}{} \Ch{G}{} \Ch{G}{} \Ch{Hmi}{}
+<G> <G> <G> <Hmi>
 
 \zs
 Quo Vadis v ruksaku a blízkost hvězdokup
@@ -39,7 +39,7 @@ Poruším celibát, nemusím se cely bát,
 to je víc než jistý, před Bohem jsem čistý.
 \ks
 
-\zr   \kr  \zr  \kr  \zr  \kr
+\zr \kr \zr \kr \zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Tři_sestry____Mexiko.tex
+++ b/tp-songs/02_pop_rock/Tři_sestry____Mexiko.tex
@@ -3,9 +3,9 @@
 \zp{Mexiko}{Tři sestry}
 
 \zs
-\Ch{Ami}{Kolem} kaktusy, je horko, tak to si na hlavu nasadím sombrero \Ch{G}{grande.}
+<Ami>Kolem kaktusy, je horko, tak to si na hlavu nasadím sombrero <G>grande.
 
-\Ch{Ami}{Viva} zapata, mně hoří za pata-ma, mám v Porto Pueblo \Ch{G}{rande.}
+<Ami>Viva zapata, mně hoří za pata-ma, mám v Porto Pueblo <G>rande.
 \ks
 
 \zs
@@ -15,9 +15,9 @@ do kapsy tortilly a láhev tequilly, má milá mi přihřeje nachos.
 \ks
 
 \zr
-\Ch{Ami}{Mexiko}, Mexiko, sombrero grande, \Ch{G}{tequilla,}
+<Ami>Mexiko, Mexiko, sombrero grande, <G>tequilla,
 
-\Ch{G}{donde} esta zapateria, čeká mě \Ch{Ami}{milá.}
+<G>donde esta zapateria, čeká mě <Ami>milá.
 \kr
 
 \zs
@@ -32,7 +32,7 @@ Jsem Speedy Gonzalez, však radši bych zalez' tam, kde je nejbližší kojotí 
 Však nehledě k tomu, že pospíchám domů, mě vyhlíží krásná señora.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Vylétla kulka, z mé hlavy je půlka, než jsem spad, už bylo od krve poncho.
@@ -40,6 +40,6 @@ Vylétla kulka, z mé hlavy je půlka, než jsem spad, už bylo od krve poncho.
 Teď nade mnou stojí, už pět neděl svoji, má milá a sousedů Pancho.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Tři_sestry____Sovy_v_mazutu.tex
+++ b/tp-songs/02_pop_rock/Tři_sestry____Sovy_v_mazutu.tex
@@ -2,30 +2,30 @@
 
 \zp{Sovy v mazutu}{Tři sestry}
 
-/: \Ch{G}{} \Ch{D}{} \Ch{C}{} \Ch{D}{} :/
+/: <G> <D> <C> <D> :/
 
-Rec:    \Ch{G}{Tak} jsme byli \Ch{D}{včera} na Portě \Ch{C}{} \Ch{D}{}
+Rec: <G>Tak jsme byli <D>včera na Portě <C> <D>
 
-\Ch{G}{a} když jsme se vraceli \Ch{D}{cestou} domů, \Ch{C}{}
+<G>a když jsme se vraceli <D>cestou domů, <C>
 
-\Ch{D}{tak} jsme viděli \Ch{G}{dřevorubce,}
+<D>tak jsme viděli <G>dřevorubce,
 
-jak porážejí \Ch{D}{strom} -- \Ch{C}{a} ten strom \Ch{D}{plakal}. \Ch{G}{} \Ch{D}{} \Ch{C}{} \Ch{D}{}
+jak porážejí <D>strom -- <C>a ten strom <D>plakal. <G> <D> <C> <D>
 
 \zs
-\Ch{G}{Proč} medvěd \Ch{D}{pláče} v \Ch{C}{dutině} \Ch{D}{stromu,}
+<G>Proč medvěd <D>pláče v <C>dutině <D>stromu,
 
-\Ch{G}{veverky} v \Ch{G}{depresi} v \Ch{C}{hloží} \Ch{D}{sedí},
+<G>veverky v <G>depresi v <C>hloží <D>sedí,
 
-\Ch{G}{květiny} \Ch{D}{vadnou} i \Ch{C}{tramp} ztratil \Ch{D}{žracák},
+<G>květiny <D>vadnou i <C>tramp ztratil <D>žracák,
 
-\Ch{G}{trenýrky}, \Ch{D}{sekyru}, pre\Ch{C}{zervativy}, \Ch{D}{spacák}.
+<G>trenýrky, <D>sekyru, pre<C>zervativy, <D>spacák.
 \ks
 
 \zr
-/: Protože \Ch{G}{hů} a \Ch{D}{hů} a \Ch{C}{hů,} sovy v \Ch{D}{mazutu} \Ch{G}{houkaj}, \Ch{D}{} \Ch{C}{} \Ch{D}{}
+/: Protože <G>hů a <D>hů a <C>hů, sovy v <D>mazutu <G>houkaj, <D> <C> <D>
 
-\Ch{G}{ú- a} \Ch{D}{ú- a} \Ch{C}{úplně} \Ch{D}{blbě} \Ch{G}{koukaj.} \Ch{D}{} \Ch{C}{} \Ch{D}{} :/
+<G>ú- a <D>ú- a <C>úplně <D>blbě <G>koukaj. <D> <C> <D> :/
 \kr
 
 \zs
@@ -38,7 +38,7 @@ včera byl na bábě a dnes neví, čí jsou,
 a jestli jsou to zmije nebo schizofrénie.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Visací_zámek____Traktor.tex
+++ b/tp-songs/02_pop_rock/Visací_zámek____Traktor.tex
@@ -3,16 +3,16 @@
 \zp{Traktor}{Visací zámek}
 
 \zr
-/: \Ch{G}{Jede} traktor, \Ch{A#}{je to} Zetor,
-\Ch{C}{jede} do hor \Ch{G}{orat} brambor. :/
+/: <G>Jede traktor, <A#>je to Zetor,
+<C>jede do hor <G>orat brambor. :/
 \kr
 
 \zs
-\Ch{G}{Zemědělci} brambor \Ch{A#}{zasejí}, potom \Ch{C}{pohnojí}, pak zas \Ch{G}{vyrejí.}
+<G>Zemědělci brambor <A#>zasejí, potom <C>pohnojí, pak zas <G>vyrejí.
 
-\Ch{G}{Mládenec} si kapsu \Ch{A#}{namastí}, prachama \Ch{C}{zachrastí} na děvu \Ch{G}{povětrnou.}
+<G>Mládenec si kapsu <A#>namastí, prachama <C>zachrastí na děvu <G>povětrnou.
 
-/: \Ch{F}{Krimina}\Ch{G}{lita}, \Ch{F}{krimina}\Ch{G}{lita}, \Ch{F}{krimina}\Ch{G}{lita} \Ch{C}{mlá}\Ch{A#}{de}\Ch{G}{že.} :/
+/: <F>Krimina<G>lita, <F>krimina<G>lita, <F>krimina<G>lita <C>mlá<A#>de<G>že. :/
 \ks
 
 \zs
@@ -32,7 +32,7 @@ Svýho činu ihned lituje, za mříže putuje i s děvou povětrnou!
 \ks
 
 \zr
-4× /: \Ch{G}{Jede} traktor, \Ch{A#}{je to} Zetor, \Ch{C}{jede} do hor \Ch{G}{orat} brambor. :/
+4× /: <G>Jede traktor, <A#>je to Zetor, <C>jede do hor <G>orat brambor. :/
 \kr
 
 \kp

--- a/tp-songs/02_pop_rock/Visací_zámek____Známka_punku.tex
+++ b/tp-songs/02_pop_rock/Visací_zámek____Známka_punku.tex
@@ -3,7 +3,7 @@
 \zp{Známka punku}{Visací zámek}
 
 \zs
-\Ch{E}{Holinky} \Ch{D}{nosil} \Ch{A}{vždycky} \Ch{G}{naru}\Ch{F#}{by}, myslel si, že je to známka punku,
+<E>Holinky <D>nosil <A>vždycky <G>naru<F#>by, myslel si, že je to známka punku,
 
 kohoutí hnát si zapích' do huby, MSŽJTZP,
 
@@ -13,7 +13,7 @@ co hořelo, to vyhulil, MSŽJTZP.
 \ks
 
 \zr
-3× /: \Ch{H}{} \Ch{C}{} \Ch{H}{} :/ \Ch{C}{} \Ch{D}{} \Ch{C}{}
+3× /: <H> <C> <H> :/ <C> <D> <C>
 
 Ale holky říkaly,
 že punk je jinde,
@@ -23,7 +23,7 @@ ale holky říkaly:
 \kr
 
 \zs
-\Ch{E}{Přeplněnej} \Ch{D}{autobus} \Ch{A}{nechával} vždycky \Ch{G}{uj}\Ch{F#}{et,} MSŽJTZP,
+<E>Přeplněnej <D>autobus <A>nechával vždycky <G>uj<F#>et, MSŽJTZP,
 
 kytky v jeho zahradě mohly volně bujet, MSŽJTZP,
 
@@ -32,10 +32,10 @@ uznával jen kapely, co neuměly hrát, MSŽJTZP,
 kolem krku nosil umělohmotnej drát, MSŽJTZP.
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
-\Ch{E}{} \Ch{G}{} \Ch{F#}{} \Ch{A}{}
+<E> <G> <F#> <A>
 
 No ale kdo není boží nadělení,
 
@@ -47,7 +47,7 @@ každý zboží má svýho kupce.
 \ks
 
 \zs
-\Ch{E}{Křivák} \Ch{D}{nosila} \Ch{A}{vždycky} \Ch{G}{naru}\Ch{F#}{by},
+<E>Křivák <D>nosila <A>vždycky <G>naru<F#>by,
 myslela, že je to známka punku,
 
 rtěnku si nanášela rovnou na zuby, MŽJTZP,

--- a/tp-songs/02_pop_rock/Vladimír_Mišík____Variace_na_renesanční_téma.tex
+++ b/tp-songs/02_pop_rock/Vladimír_Mišík____Variace_na_renesanční_téma.tex
@@ -3,35 +3,35 @@
 \zp{Variace na renesanční téma}{Vladimír Mišík}
 
 \zs
-\Ch{Ami}{Láska} je jako \Ch{F}{Večernice} \Ch{G}{plující} černou \Ch{Ami}{oblohou,}
+<Ami>Láska je jako <F>Večernice <G>plující černou <Ami>oblohou,
 
-zavřete dveře \Ch{F}{na} petlice, \Ch{G}{zhasněte} v domě všechny \Ch{Ami}{svíce}
+zavřete dveře <F>na petlice, <G>zhasněte v domě všechny <Ami>svíce
 
-a opevněte svoje \Ch{F}{těla}, \Ch{G}{vy,} kterým srdce \Ch{Ami}{zkameněla.}
+a opevněte svoje <F>těla, <G>vy, kterým srdce <Ami>zkameněla.
 
-\Ch{C}{} \Ch{G}{} \Ch{Ami}{} \Ch{C/G}{} \Ch{D}{} \Ch{Dmi}{} \Ch{Emi7}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{}
+<C> <G> <Ami> <C/G> <D> <Dmi> <Emi7> <Ami> <Ami7> <Ami6> <Ami> <Ami7> <Ami6>
 \ks
 
 \zs
-\Ch{Ami}{Láska} je jako krásná \Ch{F}{loď}, \Ch{G}{která} ztratila \Ch{Ami}{kapitána},
+<Ami>Láska je jako krásná <F>loď, <G>která ztratila <Ami>kapitána,
 
-námořníkům se třesou \Ch{F}{ruce} a \Ch{G}{bojí} se, co bude \Ch{Ami}{zrána}.
+námořníkům se třesou <F>ruce a <G>bojí se, co bude <Ami>zrána.
 
-Láska je jako bolest z \Ch{F}{probuzení} a \Ch{G}{horké} ruce \Ch{Ami}{hvězd},
+Láska je jako bolest z <F>probuzení a <G>horké ruce <Ami>hvězd,
 
-které ti oknem \Ch{F}{do} vězení \Ch{G}{květiny} sypou \Ch{Ami}{ze sv}atebních cest.
+které ti oknem <F>do vězení <G>květiny sypou <Ami>ze svatebních cest.
 
-\Ch{C}{} \Ch{G}{} \Ch{Ami}{} \Ch{C/G}{} \Ch{D}{} \Ch{Dmi}{} \Ch{Emi7}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{}
+<C> <G> <Ami> <C/G> <D> <Dmi> <Emi7> <Ami> <Ami7> <Ami6> <Ami> <Ami7> <Ami6>
 \ks
 
 \zs
-\Ch{Ami}{Láska} je jako \Ch{F}{večernice} \Ch{G}{plující} černou \Ch{Ami}{oblohou,}
+<Ami>Láska je jako <F>večernice <G>plující černou <Ami>oblohou,
 
-náš život hoří \Ch{F}{jako} svíce a \Ch{G}{mrtví} milovat \Ch{Ami}{nemohou},
+náš život hoří <F>jako svíce a <G>mrtví milovat <Ami>nemohou,
 
-\Ch{G}{mrtví} milovat \Ch{Ami}{nemohou}...
+<G>mrtví milovat <Ami>nemohou...
 
-\Ch{C}{} \Ch{G}{} \Ch{Ami}{} \Ch{C/G}{} \Ch{D}{} \Ch{Dmi}{} \Ch{Emi7}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{} \Ch{Ami}{} \Ch{Ami7}{} \Ch{Ami6}{}
+<C> <G> <Ami> <C/G> <D> <Dmi> <Emi7> <Ami> <Ami7> <Ami6> <Ami> <Ami7> <Ami6>
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Václav_Neckář____Holka_ta_okatá.tex
+++ b/tp-songs/02_pop_rock/Václav_Neckář____Holka_ta_okatá.tex
@@ -3,21 +3,21 @@
 \zp{Holka ta okatá}{Václav Neckář}
 
 \zr
-\Ch{G}{Holka} ta okatá, \Ch{C}{co z vody} \Ch{G}{cáká},
-holka ta okatá \Ch{C}{lahodí} \Ch{G}{všem.}
+<G>Holka ta okatá, <C>co z vody <G>cáká,
+holka ta okatá <C>lahodí <G>všem.
 
-\Ch{G}{Holka} ta okatá \Ch{C}{i tebe} \Ch{G}{láká,}
-holka ta okatá -- \Ch{C}{tak} si ji \Ch{G}{vem.}
+<G>Holka ta okatá <C>i tebe <G>láká,
+holka ta okatá -- <C>tak si ji <G>vem.
 \kr
 
 \zs
-Vždyť \Ch{C}{za dva}-tři dny \Ch{G}{snad} tě \Ch{C}{pošle} čelem \Ch{G}{vzad}
+Vždyť <C>za dva-tři dny <G>snad tě <C>pošle čelem <G>vzad
 
-a \Ch{D}{pak ti} bude \Ch{G}{líto,} žes' \Ch{D}{do pasti} jí \Ch{G}{pad'.}
+a <D>pak ti bude <G>líto, žes' <D>do pasti jí <G>pad'.
 
-Já \Ch{C}{bejval} její \Ch{G}{kluk} a \Ch{C}{kluků} měla \Ch{G}{klub,}
+Já <C>bejval její <G>kluk a <C>kluků měla <G>klub,
 
-je \Ch{D}{pohledná} a \Ch{G}{ví to} a \Ch{D}{mně už} je to \Ch{G}{fuk,}
+je <D>pohledná a <G>ví to a <D>mně už je to <G>fuk,
 
 že ty a ta, ta holka okatá, že jdete spolu krok co krok,
 což je tedy šok!

--- a/tp-songs/02_pop_rock/Václav_Neckář____Stín_katedrál.tex
+++ b/tp-songs/02_pop_rock/Václav_Neckář____Stín_katedrál.tex
@@ -7,7 +7,7 @@
 
 <D>Svůj <G>ideál, <D>sen, co si <E>dávám <A>zdát.
 
-Z <D>ú-<G>směvů šál, <D>dům, nebo básní <C>rým, <G>jé - <A>jé - <D>jé,
+Z <D>ú<G>směvů šál, <D>dům, nebo básní <C>rým, <G>jé - <A>jé - <D>jé,
 
 <G>co Ti dál <D>mám, řekni, <E>dárkem <A>dát.
 \ks

--- a/tp-songs/02_pop_rock/Václav_Neckář____Stín_katedrál.tex
+++ b/tp-songs/02_pop_rock/Václav_Neckář____Stín_katedrál.tex
@@ -3,29 +3,29 @@
 \zp{Stín katedrál}{Václav Neckář}
 
 \zs
-\Ch{D}{Stín} \Ch{G}{katedrál,} \Ch{D}{půl} nebe s \Ch{D4}{Bůh} \Ch{D}{ví} \Ch{C}{čím,} \Ch{G}{jé -} \Ch{A}{jé.}
+<D>Stín <G>katedrál, <D>půl nebe s <D4>Bůh <D>ví <C>čím, <G>jé - <A>jé.
 
-\Ch{D}{Svůj} \Ch{G}{ideál,} \Ch{D}{sen,} co si \Ch{E}{dávám} \Ch{A}{zdát.}
+<D>Svůj <G>ideál, <D>sen, co si <E>dávám <A>zdát.
 
-Z \Ch{D}{ú-}\Ch{G}{směvů} šál, \Ch{D}{dům,} nebo básní \Ch{C}{rým,} \Ch{G}{jé -} \Ch{A}{jé -} \Ch{D}{jé,}
+Z <D>ú-<G>směvů šál, <D>dům, nebo básní <C>rým, <G>jé - <A>jé - <D>jé,
 
-\Ch{G}{co Ti dál} \Ch{D}{mám, řekni,} \Ch{E}{dárkem} \Ch{A}{dát.}
+<G>co Ti dál <D>mám, řekni, <E>dárkem <A>dát.
 \ks
 
 \zr
-\Ch{F}{Přej si,} co \Ch{G}{chceš,} zlatý \Ch{C}{důl} nebo \Ch{G}{věž,}
+<F>Přej si, co <G>chceš, zlatý <C>důl nebo <G>věž,
 
-Sladkou \Ch{F}{sůl,} smutný \Ch{G}{ráj,} suchý \Ch{C}{déšť.}
+Sladkou <F>sůl, smutný <G>ráj, suchý <C>déšť.
 
-\Ch{F}{Ber,} tady \Ch{G}{máš} mořskou \Ch{C}{pláň} nebo \Ch{G}{pláž,}
+<F>Ber, tady <G>máš mořskou <C>pláň nebo <G>pláž,
 
-hudbu \Ch{F}{sfér,} jenom \Ch{G}{ber,} se mnou \Ch{A}{též,} \Ch{G}{jé -} \Ch{A7}{jé.}
+hudbu <F>sfér, jenom <G>ber, se mnou <A>též, <G>jé - <A7>jé.
 \kr
 
 \zs
 Můj ideál, víš, to co já mám rád, jé - jé,
 
-stín katedrál, sen, co si k \Ch{E}{ránu} \Ch{G}{dá}\Ch{A}{vám} \Ch{D}{zdát.}
+stín katedrál, sen, co si k <E>ránu <G>dá<A>vám <D>zdát.
 \ks
 
 \zr\kr
@@ -35,7 +35,7 @@ Můj ideál, víš, to co já mám rád, jé - jé,
 
 stín katedrál, sen, co si k ránu dávám zdát,
 
-3× /: \Ch{G}{ten,} co se \Ch{A}{nám} bude \Ch{D}{zdát.} :/
+3× /: <G>ten, co se <A>nám bude <D>zdát. :/
 \ks
 
 \kp

--- a/tp-songs/02_pop_rock/Václav_Neckář____Tu_kytaru_jsem_koupil_kvůli_tobě.tex
+++ b/tp-songs/02_pop_rock/Václav_Neckář____Tu_kytaru_jsem_koupil_kvůli_tobě.tex
@@ -2,21 +2,21 @@
 
 \zp{Tu kytaru jsem koupil kvůli tobě}{Václav Neckář}
 
-\Ch{E}{Jak} můžeš být tak \Ch{C#7}{krutá},
-\Ch{F#mi}{copak} nemáš kouska citu v \Ch{H6}{těle?}
-\Ch{E6}{ } \Ch{E6}{ } \Ch{E}{ } \Ch{E6}{ } \Ch{E}{ } \Ch{E6}{ } \Ch{E6}{ } \Ch{E}{ } \Ch{E6}{ } \Ch{E}{ }
+<E>Jak můžeš být tak <C#7>krutá,
+<F#mi>copak nemáš kouska citu v <H6>těle?
+<E6> <E6> <E> <E6> <E> <E6> <E6> <E> <E6> <E> 
 
 \zs
-\Ch{E}{Tu} kytaru jsem koupil
+<E>Tu kytaru jsem koupil
 kvůli tobě
 
 a dal jsem za ni
-celej tátův \Ch{H7}{plat},
+celej tátův <H7>plat,
 
-ne\Ch{E}{dávno} ještě \Ch{E7}{byla} ve vý\Ch{A}{robě} \Ch{Ami}{}
+ne<E>dávno ještě <E7>byla ve vý<A>robě <Ami>
 
-a já už \Ch{E}{věděl,}
-\Ch{H7}{co ti} budu \Ch{E}{hrát}.\Ch{H7}{ }
+a já už <E>věděl,
+<H7>co ti budu <E>hrát.<H7> 
 \ks
 \zs
 To ještě rostla v javorovém lese
@@ -29,14 +29,14 @@ a já už trnul, jestli někdy snese
 \ks
 
 \zs
-S tou \Ch{C#mi}{kytarou} teď stojím před tvým \Ch{G#mi}{domem},
+S tou <C#mi>kytarou teď stojím před tvým <G#mi>domem,
 
-měj \Ch{A}{soucit} aspoň k tomu javo\Ch{H}{ru},\Ch{H7}{ }
+měj <A>soucit aspoň k tomu javo<H>ru,<H7> 
 
-jen \Ch{E}{kvůli} tobě \Ch{E7}{přestal} býti \Ch{A}{stromem}, \Ch{Ami}{ }
+jen <E>kvůli tobě <E7>přestal býti <A>stromem, <Ami> 
 
-{tak} už nás \Ch{E}{oba} \Ch{H7}{pozvi} naho\Ch{E}{ru},
-\Ch{H7}{pozvi} naho\Ch{E}{ru}, \Ch{D}{pozvi} \Ch{D#}{naho}\Ch{E}{ru}.
+{tak} už nás <E>oba <H7>pozvi naho<E>ru,
+<H7>pozvi naho<E>ru, <D>pozvi <D#>naho<E>ru.
 \ks
 \kp
 

--- a/tp-songs/02_pop_rock/Wanastovi_vjecy____Andělé.tex
+++ b/tp-songs/02_pop_rock/Wanastovi_vjecy____Andělé.tex
@@ -3,23 +3,23 @@
 \zp{Andělé}{Wanastovi Vjecy}
 
 \zs
-\Ch{H}{Co tě to} \Ch{F#}{hned po ránu} \Ch{E}{napadá?}
+<H>Co tě to <F#>hned po ránu <E>napadá?
 
-\Ch{H}{Nohy, ruce} -- \Ch{F#}{komu je chceš} \Ch{E}{dát?}
+<H>Nohy, ruce -- <F#>komu je chceš <E>dát?
 
-\Ch{H}{Je to v krvi,} \Ch{F#}{co tvou hlavu} \Ch{E}{přepadá,}
+<H>Je to v krvi, <F#>co tvou hlavu <E>přepadá,
 
-\Ch{H}{chtělas' padnout} \Ch{F#}{do hrobu} a \Ch{E}{spát.}
+<H>chtělas' padnout <F#>do hrobu a <E>spát.
 \ks
 
 \zr
-\Ch{D}{Poranění} \Ch{A}{andělé jdou} \Ch{G}{do polí,}
+<D>Poranění <A>andělé jdou <G>do polí,
 
-\Ch{D}{stěhovaví} \Ch{A}{lidi ulí}\Ch{G}{taj.}
+<D>stěhovaví <A>lidi ulí<G>taj.
 
-\Ch{D}{Panenku} \Ch{A}{bodni} -- ji to \Ch{G}{nebolí,}
+<D>Panenku <A>bodni -- ji to <G>nebolí,
 
-\Ch{D}{svět je, mami,} \Ch{A}{prapodivnej} \Ch{G}{kraj.}
+<D>svět je, mami, <A>prapodivnej <G>kraj.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Xindl_X____V_blbým_věku.tex
+++ b/tp-songs/02_pop_rock/Xindl_X____V_blbým_věku.tex
@@ -3,11 +3,11 @@
 \zp{V blbým věku}{Xindl X}
 
 \zs
-Ujel mi \Ch{C}{vlak} i poslední \Ch{G}{metro}, ještě jsem \Ch{Ami}{nebyl} in a už jsem \Ch{D}{retro}. 
+Ujel mi <C>vlak i poslední <G>metro, ještě jsem <Ami>nebyl in a už jsem <D>retro. 
 
-Než jsem se z \Ch{F}{pulce} vyloup v \Ch{G}{samce}, co má \Ch{C}{všechno} pod pal\Ch{Ami}{cem}, 
+Než jsem se z <F>pulce vyloup v <G>samce, co má <C>všechno pod pal<Ami>cem, 
 
-v \Ch{F}{den} svý šance na poslední jamce zaspal \Ch{G}{jsem}. 
+v <F>den svý šance na poslední jamce zaspal <G>jsem. 
 \ks
 
 \zs
@@ -19,17 +19,17 @@ a počkám si, až retro zase přijde do módy.
 \ks
 
 \zs
-Jó, \Ch{F}{stále} \Ch{G}{mě} to ba\Ch{Ami}{ví, sázet} se s osudem, \Ch{F}{byť} čas utíká víc, než je \Ch{G}{milo}. 
+Jó, <F>stále <G>mě to ba<Ami>ví, sázet se s osudem, <F>byť čas utíká víc, než je <G>milo. 
 
-\Ch{F}{Stále} \Ch{G}{věřím}, že ze \Ch{Ami}{mě ještě} něco bude, \Ch{F}{no jo}, ale co když už \Ch{E}{bylo}? 
+<F>Stále <G>věřím, že ze <Ami>mě ještě něco bude, <F>no jo, ale co když už <E>bylo? 
 \ks
 
 \zr
-Včera mi \Ch{Ami}{bylo} málo, \Ch{F}{dneska} je mi \Ch{C}{moc}, jak se to \Ch{G}{stalo}, nevím, 
+Včera mi <Ami>bylo málo, <F>dneska je mi <C>moc, jak se to <G>stalo, nevím, 
 
-\Ch{Ami}{každopádně} \Ch{F}{jsem} zas v blbým \Ch{G}{věku} a jedu \Ch{Ami}{mimo} trať a \Ch{F}{říkám} si: \uv{Tak \Ch{C}{ať}, 
+<Ami>každopádně <F>jsem zas v blbým <G>věku a jedu <Ami>mimo trať a <F>říkám si: \uv{Tak <C>ať, 
 
-vždyť všechny \Ch{G}{mosty} vedou \Ch{F}{beztak} po stý \Ch{G}{přes} tu stejnou \Ch{Ami}{řeku}.}
+vždyť všechny <G>mosty vedou <F>beztak po stý <G>přes tu stejnou <Ami>řeku.}
 
 Včera mi bylo málo, dneska je mi moc, jak se to stalo, nevím.
 
@@ -39,7 +39,7 @@ a jsem radši vám všem pro smích, než abych byl sobě k breku.
 
 
 
-/: \Ch{F}{Na --} \Ch{G}{na --} \Ch{A}{na}... Včera mi \Ch{F}{bylo} málo, \Ch{G}{dneska} je mi \Ch{Ami}{moc}. :/
+/: <F>Na -- <G>na -- <A>na... Včera mi <F>bylo málo, <G>dneska je mi <Ami>moc. :/
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Yvonne_Přenosilová____Boty_proti_lásce.tex
+++ b/tp-songs/02_pop_rock/Yvonne_Přenosilová____Boty_proti_lásce.tex
@@ -3,19 +3,19 @@
 \zp{Boty proti lásce}{Yvonne Přenosilová}
 
 \zs
-\Ch{E}{Zas} mi říkal, že má něco pro mě,
+<E>Zas mi říkal, že má něco pro mě,
 
 a to něco, to prý láska je.
 
-\Ch{A7}{Já} však nechci žádnou lásku v domě, jé,
+<A7>Já však nechci žádnou lásku v domě, jé,
 
-\Ch{E}{přináší} jen žal a výdaje.
+<E>přináší jen žal a výdaje.
 
-Mám \Ch{G}{proti} lásce \Ch{E}{boty,}
+Mám <G>proti lásce <E>boty,
 
-ty \Ch{G}{chrání} paní \Ch{E}{svou,}
+ty <G>chrání paní <E>svou,
 
-\Ch{G}{ty boty} vždycky \Ch{E}{jdou}
+<G>ty boty vždycky <E>jdou
 
 a všechno hezké pošlapou.
 \ks

--- a/tp-songs/02_pop_rock/Yvonne_Přenosilová____Sklípek.tex
+++ b/tp-songs/02_pop_rock/Yvonne_Přenosilová____Sklípek.tex
@@ -3,11 +3,11 @@
 \zp{Sklípek}{Yvonne Přenosilová}
 
 \zs
-\Ch{Gmi}{Půjdem} spolu do sklípku,
+<Gmi>Půjdem spolu do sklípku,
 
-sedneme si v koutku, kde je \Ch{D7}{stín,}
+sedneme si v koutku, kde je <D7>stín,
 
-vlídný \Ch{Gmi}{stín.}
+vlídný <Gmi>stín.
 \ks
 
 \zs
@@ -19,9 +19,9 @@ dobrých vín.
 \ks
 
 \zr
-\Ch{B}{Rudou} lásku budem spolu \Ch{F}{pít,} \Ch{D}{}
+<B>Rudou lásku budem spolu <F>pít, <D>
 
-\Ch{Gmi}{vinný} sklep ti zrychlí tep a \Ch{A7}{zas mě} budeš \Ch{D7}{chtít.}
+<Gmi>vinný sklep ti zrychlí tep a <A7>zas mě budeš <D7>chtít.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Zdeněk_Borovec____Dům_u_vycházejícího_slunce.tex
+++ b/tp-songs/02_pop_rock/Zdeněk_Borovec____Dům_u_vycházejícího_slunce.tex
@@ -3,13 +3,13 @@
 \zp{Dům u vycházejícího slunce}{Zdeněk Borovec}
 
 \zs
-Snad \Ch{Ami}{znáš ten} \Ch{C}{dům za} \Ch{D}{New Orleans,} \Ch{F}{}
+Snad <Ami>znáš ten <C>dům za <D>New Orleans, <F>
 
-ve \Ch{Ami}{štítu} \Ch{C}{znak} slunce \Ch{E}{má,}
+ve <Ami>štítu <C>znak slunce <E>má,
 
-je to \Ch{Ami}{dům, kde} \Ch{C}{lká sto} \Ch{D}{chlapců} ubo\Ch{F}{hých}
+je to <Ami>dům, kde <C>lká sto <D>chlapců ubo<F>hých
 
-a \Ch{Ami}{kde jsem} \Ch{E}{zkejs' i} \Ch{Ami}{já.} \Ch{E}{}
+a <Ami>kde jsem <E>zkejs' i <Ami>já. <E>
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/Zuzana_Norisová____Pátá.tex
+++ b/tp-songs/02_pop_rock/Zuzana_Norisová____Pátá.tex
@@ -2,23 +2,23 @@
 
 \zp{Pátá}{Zuzana Norisová}
 \zs
-\Ch{C}{Hodina} bývá dlouho \Ch{F}{trpěli}\Ch{G}{vá} a potom \Ch{C}{odbíjí} \Ch{F}{pá}\Ch{C}{tá,}
+<C>Hodina bývá dlouho <F>trpěli<G>vá a potom <C>odbíjí <F>pá<C>tá,
 
-\Ch{C}{a tak} tu zpívám slova \Ch{F}{mlčenli}\Ch{G}{vá o tom,} že \Ch{C}{pomíjí} \Ch{F}{pá}\Ch{C}{tá.}
+<C>a tak tu zpívám slova <F>mlčenli<G>vá o tom, že <C>pomíjí <F>pá<C>tá.
 \ks
 
 \zr
-\Ch{C}{Zvon}ek zvoní, škola končí, \Ch{Ami}{po sch}odech se běží,
+<C>Zvonek zvoní, škola končí, <Ami>po schodech se běží,
 
-\Ch{C}{Nov}ák leze po jabloni \Ch{Ami}{a je} náhle svěží, \Ch{G}{bláz}nivej den
+<C>Novák leze po jabloni <Ami>a je náhle svěží, <G>bláznivej den
 
-a já smíchem umírám, kdosi mě \Ch{Ami}{kárá} a páni, já \Ch{D7}{nenabírám,}
+a já smíchem umírám, kdosi mě <Ami>kárá a páni, já <D7>nenabírám,
 
-neboť \Ch{C}{pá}\Ch{Ami}{tá} \Ch{F}{právě} teď o\Ch{G}{dbila,}
+neboť <C>pá<Ami>tá <F>právě teď o<G>dbila,
 
-\Ch{C}{pá}\Ch{Ami}{tá} \Ch{F}{právě} teď \Ch{G}{odbila,}
+<C>pá<Ami>tá <F>právě teď <G>odbila,
 
-\Ch{C}{pá}\Ch{Ami}{tá} \Ch{F}{právě} teď \Ch{G}{odbila} \Ch{C}{nám.} (Pátá.)
+<C>pá<Ami>tá <F>právě teď <G>odbila <C>nám. (Pátá.)
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/Zuzana_Norisová____Ššš.tex
+++ b/tp-songs/02_pop_rock/Zuzana_Norisová____Ššš.tex
@@ -2,18 +2,18 @@
 
 \zp{Ššš}{Zuzana Norisová}
 
-\Ch{G}{} \Ch{Ami}{} \Ch{C}{} \Ch{D}{} \Ch{G}{} \Ch{Ami}{} \Ch{C}{} \Ch{D}{}
+<G> <Ami> <C> <D> <G> <Ami> <C> <D>
 
 \zs
-\Ch{G}{Akáty} \Ch{Ami}{šumí,} když \Ch{C}{padá} \Ch{D}{déšť,}
+<G>Akáty <Ami>šumí, když <C>padá <D>déšť,
 
-\Ch{G}{padá} mi \Ch{Ami}{do vla}sů, \Ch{C}{chce} mi je \Ch{D}{splést},
+<G>padá mi <Ami>do vlasů, <C>chce mi je <D>splést,
 
-\Ch{G}{neví,} že \Ch{Ami}{láskou} chci \Ch{C}{hlavu} si \Ch{D}{plést},
+<G>neví, že <Ami>láskou chci <C>hlavu si <D>plést,
 
-tak mu to \Ch{Ami}{š- š-} \Ch{D}{š,} \Ch{Ami}{š- š-} \Ch{D}{š-,}
+tak mu to <Ami>š- š- <D>š, <Ami>š- š- <D>š-,
 
-\Ch{Ami}{š- š- š- š-} \Ch{D7}{š- š-} \Ch{G}{šepotám}.
+<Ami>š- š- š- š- <D7>š- š- <G>šepotám.
 \ks
 
 \zs

--- a/tp-songs/02_pop_rock/film_Kouř____Je_to_fajn,_fajnový.tex
+++ b/tp-songs/02_pop_rock/film_Kouř____Je_to_fajn,_fajnový.tex
@@ -9,7 +9,7 @@ Rec: Ahoj, ahoj, ahoj, tak jsme zase tady spolu jako každou středu, jako každ
 
 
 \zs
-\Ch{Ami}{Jedu} dál stále s tebou,
+<Ami>Jedu dál stále s tebou,
 
 víme kam cesty vedou,
 
@@ -21,22 +21,22 @@ nálada prostě skvělá,
 
 je to fajn, fajn, fajn, je to fajn, fajnový,
 
-vozím s \Ch{G}{sebou} hity tuto\Ch{Ami}{vý.}
+vozím s <G>sebou hity tuto<Ami>vý.
 \ks
 
 
 
 
 \zr
-\Ch{Ami}{Máme} se \Ch{G}{dneska} fajn, \Ch{Ami}{je nám} \Ch{G}{hej,}
+<Ami>Máme se <G>dneska fajn, <Ami>je nám <G>hej,
 
-\Ch{Ami}{přijel} k \Ch{G}{nám pan} \Ch{Ami}{diskžo}\Ch{G}{kej,}
+<Ami>přijel k <G>nám pan <Ami>diskžo<G>kej,
 
-\Ch{Ami}{pouští} \Ch{G}{nám} hity, \Ch{Ami}{co se} tolik \Ch{G}{líbí,}
+<Ami>pouští <G>nám hity, <Ami>co se tolik <G>líbí,
 
-\Ch{Ami}{přijel} boží \Ch{G}{jez}dec, do \Ch{Ami}{kroku} nám \Ch{G}{svítí,}
+<Ami>přijel boží <G>jezdec, do <Ami>kroku nám <G>svítí,
 
-je to \Ch{Ami}{fajn}...
+je to <Ami>fajn...
 
 Je to fajn...
 \kr

--- a/tp-songs/02_pop_rock/film_Pražská_5____Strom_kýve_pahýly.tex
+++ b/tp-songs/02_pop_rock/film_Pražská_5____Strom_kýve_pahýly.tex
@@ -3,23 +3,23 @@
 \zp{Strom kýve pahýly}{film Pražská 5}
 
 \zs
-\Ch{A}{Když} slunce \Ch{Hmi7}{zapadá,} tak \Ch{A}{moje} nála\Ch{D}{da} \Ch{E7}{kles}\Ch{A}{á,} \Ch{Hmi7}{} \Ch{A}{} \Ch{D}{} \Ch{E7}{}
+<A>Když slunce <Hmi7>zapadá, tak <A>moje nála<D>da <E7>kles<A>á, <Hmi7> <A> <D> <E7>
 
-\Ch{A}{strom} kýve \Ch{Hmi7}{větvemi,} pří\Ch{A}{telem} on je \Ch{D}{mi,} \Ch{E7}{ple}\Ch{A}{sá,} \Ch{Hmi7}{} \Ch{A}{} \Ch{D}{} \Ch{E7}{}
+<A>strom kýve <Hmi7>větvemi, pří<A>telem on je <D>mi, <E7>ple<A>sá, <Hmi7> <A> <D> <E7>
 
-\Ch{A}{já} však mám v duši žal, čert \Ch{Hmi7}{ví, kde} se tam vzal,
+<A>já však mám v duši žal, čert <Hmi7>ví, kde se tam vzal,
 
-te\Ch{A}{pe,} te\Ch{Hmi7}{pe, te}\Ch{A}{pe,} te\Ch{D}{pe.} \Ch{E7}{}
+te<A>pe, te<Hmi7>pe, te<A>pe, te<D>pe. <E7>
 \ks
 
 \zr
-\Ch{A}{Strom} kýve \Ch{Hmi7}{pahýly,} chtěl \Ch{A}{bych} jen na chví\Ch{D}{li te}be,
+<A>Strom kýve <Hmi7>pahýly, chtěl <A>bych jen na chví<D>li tebe,
 
-\Ch{A}{strom} kýve \Ch{Hmi7}{pahýly,} chtěl \Ch{A}{bych} jen na chví\Ch{D}{li te}be,
+<A>strom kýve <Hmi7>pahýly, chtěl <A>bych jen na chví<D>li tebe,
 
-\Ch{A}{rosu} mám v \Ch{Hmi7}{kanadách,} v mých \Ch{A}{černých} kana\Ch{D}{dách} zebe,
+<A>rosu mám v <Hmi7>kanadách, v mých <A>černých kana<D>dách zebe,
 
-\Ch{A}{rosu} mám v \Ch{Hmi7}{kanadách,} v mých \Ch{A}{černých} kana\Ch{D}{dách} zebe.
+<A>rosu mám v <Hmi7>kanadách, v mých <A>černých kana<D>dách zebe.
 \kr
 
 \zs

--- a/tp-songs/02_pop_rock/neznámý____Seděla_u_vody.tex
+++ b/tp-songs/02_pop_rock/neznámý____Seděla_u_vody.tex
@@ -3,19 +3,19 @@
 \zp{Seděla u vody}{(neznámý)}
 
 \zs
-\Ch{E}{To} co bylo včera, to není každý den,
+<E>To co bylo včera, to není každý den,
 
 potkal jsem vám holku, byla krásná jako sen.
 \ks
 
 \zr
-A já ji \Ch{A}{tak rád} mám, je je jé,
+A já ji <A>tak rád mám, je je jé,
 
-a já jí \Ch{E}{tak} rád mám, je je jé.
+a já jí <E>tak rád mám, je je jé.
 
-\Ch{H7}{A z tý} velký lásky \Ch{A}{narostly} mi vlásky,
+<H7>A z tý velký lásky <A>narostly mi vlásky,
 
-\Ch{E}{stal} se ze mě \Ch{A}{chuli}\Ch{E}{gán.}
+<E>stal se ze mě <A>chuli<E>gán.
 \kr
 
 \zr \kr

--- a/tp-songs/02_pop_rock/Žlutý_pes____Modrá.tex
+++ b/tp-songs/02_pop_rock/Žlutý_pes____Modrá.tex
@@ -2,16 +2,16 @@
 
 \zp{Modrá}{Žlutý pes}
 
-\Ch{G}{} \Ch{D}{} \Ch{C}{} \Ch{D}{} \Ch{Ami}{} \Ch{G}{} \Ch{D}{}
+<G> <D> <C> <D> <Ami> <G> <D>
 
 \zs
-\Ch{G}{Modrá} je \Ch{D}{planeta,} kde \Ch{C}{můžeme} \Ch{D}{žít,}
+<G>Modrá je <D>planeta, kde <C>můžeme <D>žít,
 
-\Ch{G}{modrá} je \Ch{D}{voda,} kterou \Ch{C}{musíme }\Ch{D}{pít,}
+<G>modrá je <D>voda, kterou <C>musíme <D>pít,
 
-\Ch{G}{modrá} je \Ch{D}{obloha,} když \Ch{C}{vodejde} \Ch{D}{mrak,}
+<G>modrá je <D>obloha, když <C>vodejde <D>mrak,
 
-modrá je \Ch{F}{dobrá,} \Ch{C}{už je to} \Ch{G}{tak.}
+modrá je <F>dobrá, <C>už je to <G>tak.
 \ks
 
 \zs
@@ -25,13 +25,13 @@ senzačně modrá je moje vojenská knížka.
 \ks
 
 \zr
-Jako \Ch{C}{nálada,} když zahrajou poslední \Ch{G}{kus,}
+Jako <C>nálada, když zahrajou poslední <G>kus,
 
-modrá je \Ch{F}{naděje,} \Ch{C}{láska} \Ch{F}{i moje} \Ch{G}{blues.}
+modrá je <F>naděje, <C>láska <F>i moje <G>blues.
 
-Je to \Ch{C}{barva,} kterou mám prostě \Ch{G}{rád,}
+Je to <C>barva, kterou mám prostě <G>rád,
 
-modrá je \Ch{F}{dobrá,} už \Ch{C}{je} to \Ch{G}{tak.}
+modrá je <F>dobrá, už <C>je to <G>tak.
 \kr
 
 \zs
@@ -54,7 +54,7 @@ Je to barva, kterou mám prostě rád,
 modrá je dobrá, už je to tak.
 \ks
 
-\Ch{F}{} \Ch{F}{} \Ch{C}{} \Ch{C}{} \Ch{F}{} \Ch{F}{} \Ch{Ami}{} \Ch{G}{} \Ch{D}{} \Ch{D}{}
+<F> <F> <C> <C> <F> <F> <Ami> <G> <D> <D>
 
 \kp
 

--- a/tp-songs/02_pop_rock/Žlutý_pes____Náruživá.tex
+++ b/tp-songs/02_pop_rock/Žlutý_pes____Náruživá.tex
@@ -3,13 +3,13 @@
 \zp{Náruživá}{Žlutý pes}
 
 \zs
-\Ch{D}{Nečekala} na nic a nebyla \Ch{G}{hloupá}
+<D>Nečekala na nic a nebyla <G>hloupá
 
-a \Ch{A}{já} jsem ji výjimečně do voka \Ch{D}{pad,}
+a <A>já jsem ji výjimečně do voka <D>pad,
 
-\Ch{D}{najednou} koukám, jak se život \Ch{G}{houpá}
+<D>najednou koukám, jak se život <G>houpá
 
-\Ch{A}{a} nikdo neví, co se může \Ch{D}{stát.}
+<A>a nikdo neví, co se může <D>stát.
 \ks
 
 \zs
@@ -23,9 +23,9 @@ a vona se mnou pěkně zamává.
 \ks
 
 \zr
-{Je} totiž \Ch{D}{náruži}\Ch{A}{vá} a \Ch{G}{nekouká}, co kolem \Ch{D}{lítá,}
+{Je} totiž <D>náruži<A>vá a <G>nekouká, co kolem <D>lítá,
 
-\Ch{D}{život} uží\Ch{A}{vá} tak, jak to umí a \Ch{G}{jak} se jí to líbí.
+<D>život uží<A>vá tak, jak to umí a <G>jak se jí to líbí.
 \kr
 
 \zs
@@ -48,7 +48,7 @@ já bych ji pořád jenom líbal,
 vona to vidí taky tak.
 \ks
 
-\zr  \kr  \zr  \kr
+\zr \kr \zr \kr
 
 \kp
 

--- a/tp-songs/02_pop_rock/Žlutý_pes____Sametová.tex
+++ b/tp-songs/02_pop_rock/Žlutý_pes____Sametová.tex
@@ -3,10 +3,10 @@
 \zp{Sametová}{Žlutý pes}
 
 \zs
-\Ch{G}{Vzpomínám}, když tehdá \Ch{C}{před} léty
-\Ch{G}{začaly} lítat \Ch{C}{rakety,}
+<G>Vzpomínám, když tehdá <C>před léty
+<G>začaly lítat <C>rakety,
 
-\Ch{G}{zdál} se to bejt \Ch{Emi}{docela} dobrej \Ch{C}{nápad.} \Ch{D}{}
+<G>zdál se to bejt <Emi>docela dobrej <C>nápad. <D>
 
 Saxofony hrály unyle a frčely švédský košile,
 
@@ -24,9 +24,9 @@ a rock'n'roll byl zrovna narozený dítě.
 \ks
 
 \zr
-\Ch{G}{Vzpomínáš}, takys' tu \Ch{D}{žila} a \Ch{Emi}{nedělej}, že jsi \Ch{C}{jiná,}
+<G>Vzpomínáš, takys' tu <D>žila a <Emi>nedělej, že jsi <C>jiná,
 
-taková \Ch{G}{malá} pilná \Ch{D}{včela}, taková \Ch{C}{celá} \Ch{D}{sametová.}  \Ch{G}{} \Ch{C}{} \Ch{G}{} \Ch{C}{} \Ch{G}{}
+taková <G>malá pilná <D>včela, taková <C>celá <D>sametová. <G> <C> <G> <C> <G>
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/4_Non_Blondes____Whats_Up.tex
+++ b/tp-songs/03_zahranicni/4_Non_Blondes____Whats_Up.tex
@@ -1,17 +1,17 @@
 \zp{What's up}{4 Non Blondes}
 
 \zs
-\Ch{A}{Twent'}-five years and my life is still
+<A>Twent'-five years and my life is still
 
-\Ch{Hmi}{Trying} to get up that great big hill of \Ch{D}{hope}
+<Hmi>Trying to get up that great big hill of <D>hope
 
-For a desti\Ch{A}{nation}
+For a desti<A>nation
 
 I realized quickly when I knew that I should
 
-That the \Ch{Hmi}{world} was made of this brotherhood of \Ch{D}{man}
+That the <Hmi>world was made of this brotherhood of <D>man
 
-For whatever that \Ch{A}{means}
+For whatever that <A>means
 \ks
 
 \zs
@@ -34,7 +34,7 @@ Scream at the top of my lungs: ``What's going on?''
 I say: ``Hey, what's going on?'' :/
 \kr
 
-\Ch{A}{Ooh,} \Ch{Hmi}{ooh,} \Ch{D}{ooh} \Ch{A}{}
+<A>Ooh, <Hmi>ooh, <D>ooh <A>
 
 \zs
 And I try, oh my God do I try, I try all the time, in this institution
@@ -42,7 +42,7 @@ And I try, oh my God do I try, I try all the time, in this institution
 And I pray, oh my God do I pray, I pray every single day for a revolution
 \ks
 
-\zs                      
+\zs 
 = 2.
 \ks
 

--- a/tp-songs/03_zahranicni/Afric_Simone____Hafanana.tex
+++ b/tp-songs/03_zahranicni/Afric_Simone____Hafanana.tex
@@ -4,17 +4,17 @@
 
 \zr
 
-\Ch{Ami}{La la...}  \Ch{E7}{}   \Ch{Ami}{}  \Ch{F}{}   \Ch{C}{}  \Ch{G}{}  \Ch{C}{}
+<Ami>La la... <E7> <Ami> <F> <C> <G> <C>
 \kr
 
 \zs
-Du\Ch{Ami}{lunga} lu menadzi hafana\Ch{E7}{na}
+Du<Ami>lunga lu menadzi hafana<E7>na
 
-Hanana kukanela shala\Ch{Ami}{lala}
+Hanana kukanela shala<Ami>lala
 
-Du\Ch{Ami}{lunga} lu menadzi hafana\Ch{F}{na}
+Du<Ami>lunga lu menadzi hafana<F>na
 
-Hanana kuka\Ch{C}{nela} \Ch{G}{shala}la\Ch{C}{la}
+Hanana kuka<C>nela <G>shalala<C>la
 \ks
 
 
@@ -29,13 +29,13 @@ Hanana kukanela shalalala
 \ks
 
 \zs
-/: \Ch{F}{Hey!} \Ch{C}{Whake} you dayuda
+/: <F>Hey! <C>Whake you dayuda
 
-\Ch{E7}{Ulungu} ha\Ch{Ami}{fanana}
+<E7>Ulungu ha<Ami>fanana
 
-\Ch{F}{Whake} you di \Ch{C}{whake} you dayuda
+<F>Whake you di <C>whake you dayuda
 
-\Ch{G}{Oola} oola nawhe\Ch{C}{na} :/ \Ch{E7}{}
+<G>Oola oola nawhe<C>na :/ <E7>
 \ks
 
 \zr \kr

--- a/tp-songs/03_zahranicni/Alanis_Morisette____Hand_in_my_pocket.tex
+++ b/tp-songs/03_zahranicni/Alanis_Morisette____Hand_in_my_pocket.tex
@@ -3,23 +3,23 @@
 \zp{Hand in my pocket}{Alanis Morisette}
 
 \zs
-I'm \Ch{A}{broke} but I'm \Ch{Asus2}{happy,}
-I'm \Ch{Asus4}{sore but I'm} \Ch{Asus2}{kind}
+I'm <A>broke but I'm <Asus2>happy,
+I'm <Asus4>sore but I'm <Asus2>kind
 
-I'm \Ch{A}{short} but I'm \Ch{Asus2}{healthy,} \Ch{A}{yeah,}
-I'm \Ch{A}{high} but I'm \Ch{Asus2}{grounded}
+I'm <A>short but I'm <Asus2>healthy, <A>yeah,
+I'm <A>high but I'm <Asus2>grounded
 
-I'm \Ch{Asus4}{sane but I'm} \Ch{Asus2}{overwhelmed,}
-I'm \Ch{A}{lost} but I'm \Ch{Asus2}{hopeful}, \Ch{A}{baby}
+I'm <Asus4>sane but I'm <Asus2>overwhelmed,
+I'm <A>lost but I'm <Asus2>hopeful, <A>baby
 \ks
 
 \zr
-And \Ch{Asus2}{what} it all comes \Ch{G6}{down} to \Ch{D}{}
+And <Asus2>what it all comes <G6>down to <D>
 
-Is that ev'rything's gonna be \Ch{Asus2}{fine, fine,} \Ch{A}{fine}
+Is that ev'rything's gonna be <Asus2>fine, fine, <A>fine
 
-Cause I got \Ch{G6}{one} hand in my pocket
-and the \Ch{D}{other} one is givin' a high \Ch{A}{five}
+Cause I got <G6>one hand in my pocket
+and the <D>other one is givin' a high <A>five
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Alanis_Morisette____Ironic.tex
+++ b/tp-songs/03_zahranicni/Alanis_Morisette____Ironic.tex
@@ -3,22 +3,22 @@
 \zp{Ironic}{Alanis Morisette}
 
 \zs
-An \Ch{F#}{old} \Ch{H}{man} \Ch{F#}{turned} ninety-\Ch{G#mi}{eight}.
+An <F#>old <H>man <F#>turned ninety-<G#mi>eight.
 He won the lottery and died the next day
 
 It's a black fly in your chardonnay.
 It's a death row pardon two minutes too late
 
-Isn't it \Ch{F#}{ironic?}\Ch{H}{} Don't you \Ch{F#}{think} \Ch{G#mi}{}
+Isn't it <F#>ironic?<H> Don't you <F#>think <G#mi>
 \ks
 
 \zr
-It's like \Ch{F#}{ra}\Ch{H}{in} on your \Ch{F#}{wedding} \Ch{G#mi}{day.}
-It's a free \Ch{F#}{ri}\Ch{H}{de} when you've \Ch{F#}{already} \Ch{G#mi}{paid}
+It's like <F#>ra<H>in on your <F#>wedding <G#mi>day.
+It's a free <F#>ri<H>de when you've <F#>already <G#mi>paid
 
-It's the good ad\Ch{F#}{vi}\Ch{H}{ce} that you \Ch{F#}{just} didn't \Ch{G#mi}{take}
+It's the good ad<F#>vi<H>ce that you <F#>just didn't <G#mi>take
 
-\Ch{A}{And} who would have \Ch{G#mi}{thought}... it \Ch{F#}{figures}
+<A>And who would have <G#mi>thought... it <F#>figures
 \kr
 
 \zs
@@ -33,16 +33,16 @@ And as the plane crashed down he thought ``Well isn't this nice...''
 And isn't it ironic? Don't you think?
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
-Well, \Ch{H}{life} has a funny way of sneaking \Ch{F#}{up} on you
+Well, <H>life has a funny way of sneaking <F#>up on you
 
-When you think everything is okay and \Ch{G#mi}{everything's} going right
+When you think everything is okay and <G#mi>everything's going right
 
-And \Ch{H}{life} has a funny way of helping \Ch{F#}{you} out when
+And <H>life has a funny way of helping <F#>you out when
 
-You think everything's gone wrong and \Ch{G#mi}{everything} blows up in your face
+You think everything's gone wrong and <G#mi>everything blows up in your face
 \ks
 
 \zs
@@ -59,12 +59,12 @@ And isn't it ironic? Don't you think?
 A little too ironic. And yeah I really do think
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
-\Ch{H}{Life} has a funny way of sneaking up on \Ch{F#}{you}
+<H>Life has a funny way of sneaking up on <F#>you
 
-\Ch{H}{Life} has a funny, funny way \Ch{F#}{of} helping you \Ch{H}{out}, helping you out
+<H>Life has a funny, funny way <F#>of helping you <H>out, helping you out
 \ks
 
 \kp

--- a/tp-songs/03_zahranicni/Alexandrovci____Kaťuša.tex
+++ b/tp-songs/03_zahranicni/Alexandrovci____Kaťuša.tex
@@ -5,17 +5,17 @@
 
 \zs
 
-%\Ch{Dmi}{Расцветали} яблони и \Ch{A7}{груши,} поплыли туманы над 
-%\Ch{Dmi}{рекой,}
+%<Dmi>Расцветали яблони и <A7>груши, поплыли туманы над 
+%<Dmi>рекой,
 
-%/: \Ch{Dmi}{Вы-}\Ch{B}{хо-}\Ch{F}{дила} \Ch{Gmi}{на берег} Ка\Ch{Dmi}{тюша,}
-%\Ch{Gmi}{на вы}\Ch{Dmi}{сокий} \Ch{A7}{берег на} кру\Ch{Dmi}той. :/
+%/: <Dmi>Вы-<B>хо-<F>дила <Gmi>на берег Ка<Dmi>тюша,
+%<Gmi>на вы<Dmi>сокий <A7>берег на кру<Dmi>той. :/
 
-\Ch{Dmi}{Razcvětaly} jabloni i \Ch{A7}{gruši,} poplyli tumany nad 
-re\Ch{Dmi}{koj,}
+<Dmi>Razcvětaly jabloni i <A7>gruši, poplyli tumany nad 
+re<Dmi>koj,
 
-/: \Ch{Dmi}{vy-}\Ch{B}{cha}\Ch{F}{dila} \Ch{Gmi}{na běreg} Ka\Ch{Dmi}{ťuša,} 
-\Ch{Gmi}{na vy}\Ch{Dmi}{sokij} \Ch{A7}{běreg, na} kru\Ch{Dmi}{toj.}  :/
+/: <Dmi>vy-<B>cha<F>dila <Gmi>na běreg Ka<Dmi>ťuša, 
+<Gmi>na vy<Dmi>sokij <A7>běreg, na kru<Dmi>toj. :/
 \ks
 
 \zs
@@ -39,9 +39,9 @@ Oj, ty pěsňa, pěseňka děvičja, ty leti za jasnym solncem vslěd.
 \ks
 
 \zs
-%Пусть он вспомнит девушку простую, пусть услышит, как она поет,    
+%Пусть он вспомнит девушку простую, пусть услышит, как она поет, 
 
-%Пусть он землю бережет родную, а любовь Катюша сбережет.   
+%Пусть он землю бережет родную, а любовь Катюша сбережет. 
 
 Pusť on vzpomnit děvušku prastuju, pusť uslyšit, kak ona pajot.
 

--- a/tp-songs/03_zahranicni/Alexandrovci____Kaťuša.tex
+++ b/tp-songs/03_zahranicni/Alexandrovci____Kaťuša.tex
@@ -8,13 +8,13 @@
 %<Dmi>Расцветали яблони и <A7>груши, поплыли туманы над 
 %<Dmi>рекой,
 
-%/: <Dmi>Вы-<B>хо-<F>дила <Gmi>на берег Ка<Dmi>тюша,
+%/: <Dmi>Вы<B>хо<F>дила <Gmi>на берег Ка<Dmi>тюша,
 %<Gmi>на вы<Dmi>сокий <A7>берег на кру<Dmi>той. :/
 
 <Dmi>Razcvětaly jabloni i <A7>gruši, poplyli tumany nad 
 re<Dmi>koj,
 
-/: <Dmi>vy-<B>cha<F>dila <Gmi>na běreg Ka<Dmi>ťuša, 
+/: <Dmi>vy<B>cha<F>dila <Gmi>na běreg Ka<Dmi>ťuša, 
 <Gmi>na vy<Dmi>sokij <A7>běreg, na kru<Dmi>toj. :/
 \ks
 

--- a/tp-songs/03_zahranicni/Animals____House_of_the_Rising_Sun.tex
+++ b/tp-songs/03_zahranicni/Animals____House_of_the_Rising_Sun.tex
@@ -3,13 +3,13 @@
 \zp{House of the rising sun}{Animals}
 
 \zs
-There \Ch{Ami}{is a} \Ch{C}{house} in \Ch{D}{New Orleans} \Ch{F}{}
+There <Ami>is a <C>house in <D>New Orleans <F>
 
-They \Ch{Ami}{call the} \Ch{C}{Rising} \Ch{E}{Sun}
+They <Ami>call the <C>Rising <E>Sun
 
-And it's \Ch{Ami}{been the} \Ch{C}{ruin of} \Ch{D}{many a poor} \Ch{F}{boy}
+And it's <Ami>been the <C>ruin of <D>many a poor <F>boy
 
-And \Ch{Ami}{God I} \Ch{E}{know I'm} \Ch{Ami}{one} \Ch{E}{}
+And <Ami>God I <E>know I'm <Ami>one <E>
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/Beatles____A_hard_days_night.tex
+++ b/tp-songs/03_zahranicni/Beatles____A_hard_days_night.tex
@@ -2,17 +2,17 @@
 
 \zp{A hard day's night}{Beatles}
 
-\Ch{Fadd9}{}
+<Fadd9>
 
 \zs
 
-It's been a \Ch{G}{hard} \Ch{C}{day's} \Ch{G}{night}, and I've been \Ch{F}{working} like a \Ch{G}{dog}
+It's been a <G>hard <C>day's <G>night, and I've been <F>working like a <G>dog
 
-It's been a hard \Ch{C}{day}'s n\Ch{G}{ight}, I should be s\Ch{F}{leeping} like a\Ch{G}{ log}
+It's been a hard <C>day's n<G>ight, I should be s<F>leeping like a<G> log
 
-But when I \Ch{C}{get} home to you, I find the t\Ch{D7}{hings} that you do
+But when I <C>get home to you, I find the t<D7>hings that you do
 
-Will make me \Ch{G}{feel} \Ch{C}{al}\Ch{G}{right}
+Will make me <G>feel <C>al<G>right
 \ks
 \zs
 
@@ -25,9 +25,9 @@ So why on earth should I moan, 'cause when I get you alone
 You know I'll be okay
 \ks
 \zr
-When I'm \Ch{Hmi}{home}, \Ch{Emi}{everything} seems to be \Ch{Hmi}{right}
+When I'm <Hmi>home, <Emi>everything seems to be <Hmi>right
 
-When I'm \Ch{G}{home}, \Ch{Emi}{feeling} you holding me \Ch{C}{tight}, \Ch{D}{tight}, yeah
+When I'm <G>home, <Emi>feeling you holding me <C>tight, <D>tight, yeah
 \kr
 \zs
 It's been a hard day's night, and I've been working like a dog
@@ -38,9 +38,9 @@ But when I get home to you, I find the things that you do
 
 Will make me feel alright
 
-You know I fee\Ch{C}{l} al\Ch{G}{right}
+You know I fee<C>l al<G>right
 
-You kno\Ch{G}{w} I f\Ch{C}{eel} \Ch{F}{al}right \Ch{G}{ }
+You kno<G>w I f<C>eel <F>alright <G> 
 \ks
 \kp
 

--- a/tp-songs/03_zahranicni/Beatles____All_my_loving.tex
+++ b/tp-songs/03_zahranicni/Beatles____All_my_loving.tex
@@ -3,17 +3,17 @@
 \zp{All my loving}{Beatles}
 
 \zs
-Close your \Ch{F#mi}{eyes} and I'll \Ch{H7}{kiss} you
+Close your <F#mi>eyes and I'll <H7>kiss you
 
-To\Ch{E}{morrow} I'll \Ch{C#mi}{miss} you
+To<E>morrow I'll <C#mi>miss you
 
-Re\Ch{A}{member} I'll \Ch{F#mi}{always} be \Ch{D}{true}\Ch{H7}{}
+Re<A>member I'll <F#mi>always be <D>true<H7>
 
-And then \Ch{F#mi}{while} I'm \Ch{H7}{away}
+And then <F#mi>while I'm <H7>away
 
-I'll write \Ch{E}{home} every \Ch{C#mi}{day}
+I'll write <E>home every <C#mi>day
 
-And I'll \Ch{A}{send} all my \Ch{H7}{loving} to \Ch{E}{you} \Ch{A}{} \Ch{E}{} \Ch{H}{} \Ch{E}{}
+And I'll <A>send all my <H7>loving to <E>you <A> <E> <H> <E>
 \ks
 
 \zs
@@ -31,9 +31,9 @@ And I'll send all my loving to you
 \ks
 
 \zr
-All my \Ch{C#mi}{loving} \Ch{C+}{I will} send to \Ch{E}{you}
+All my <C#mi>loving <C+>I will send to <E>you
 
-All my \Ch{C#mi}{loving,} \Ch{C+}{darling,} I'll be \Ch{E}{true}.
+All my <C#mi>loving, <C+>darling, I'll be <E>true.
 \kr
 
 \zs
@@ -45,9 +45,9 @@ All my \Ch{C#mi}{loving,} \Ch{C+}{darling,} I'll be \Ch{E}{true}.
 \ks
 
 \zr
-All my \Ch{C#mi}{loving}, all my \Ch{E}{loving}
+All my <C#mi>loving, all my <E>loving
 
-All my \Ch{C#mi}{loving} I will send to \Ch{E}{you}
+All my <C#mi>loving I will send to <E>you
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Beatles____Help.tex
+++ b/tp-songs/03_zahranicni/Beatles____Help.tex
@@ -2,28 +2,28 @@
 
 \zp{Help!}{Beatles}
 
-\Ch{Hmi}{Help!} I need somebo\Ch{Hmi/A}{dy!} \Ch{G}{Help!} Not just anybo\Ch{G/F#}{dy!}
+<Hmi>Help! I need somebo<Hmi/A>dy! <G>Help! Not just anybo<G/F#>dy!
 
-\Ch{E}{Help!} You know I need someone! \Ch{A}{Help!}
+<E>Help! You know I need someone! <A>Help!
 
 \zs
-\Ch{A}{When} I was younger so much \Ch{C#mi}{younger} than today
+<A>When I was younger so much <C#mi>younger than today
 
-\Ch{F#mi}{I nev}er needed anybody's \Ch{D}{help} in \Ch{G}{any} \Ch{A}{way}
+<F#mi>I never needed anybody's <D>help in <G>any <A>way
 
-But now these days are gone I'm \Ch{C#mi}{not so} self assured
+But now these days are gone I'm <C#mi>not so self assured
 
-\Ch{F#mi}{Now I} find I've changed my mind I've \Ch{D}{opened} \Ch{G}{up} the \Ch{A}{doors}
+<F#mi>Now I find I've changed my mind I've <D>opened <G>up the <A>doors
 \ks
 
 \zr
-\Ch{Hmi}{Help} me if you can I'm feeling down \Ch{Hmi/A}{}
+<Hmi>Help me if you can I'm feeling down <Hmi/A>
 
-And I \Ch{G}{do} appreciate you being 'round \Ch{G/F#}{}
+And I <G>do appreciate you being 'round <G/F#>
 
-\Ch{E}{Help} me get my feet back on the ground
+<E>Help me get my feet back on the ground
 
-Won't you \Ch{A}{please} please help me?
+Won't you <A>please please help me?
 \kr
 
 \zs
@@ -36,14 +36,14 @@ But every now and then I feel so insecure
 I know that I just need you like I've never done before
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 = 1.
 \ks
 
 \zr
-\Ch{F#mi}{Help} me! Help \Ch{A}{me}! \Ch{A6}{Oh}...
+<F#mi>Help me! Help <A>me! <A6>Oh...
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Beatles____Hey_Jude.tex
+++ b/tp-songs/03_zahranicni/Beatles____Hey_Jude.tex
@@ -3,13 +3,13 @@
 \zp{Hey Jude}{Beatles}
 
 \zs
-Hey \Ch{F}{Jude,} don't make it \Ch{C}{bad}
+Hey <F>Jude, don't make it <C>bad
 
-take a \Ch{C7}{sad song} and make it \Ch{F}{better}
+take a <C7>sad song and make it <F>better
 
-Re\Ch{B}{member} to let her into your \Ch{F}{heart}
+Re<B>member to let her into your <F>heart
 
-Then you can \Ch{C7}{start} to make it \Ch{F}{better}
+Then you can <C7>start to make it <F>better
 \ks
 
 \zs
@@ -21,15 +21,15 @@ then you begin to make it better
 \ks
 
 \zr
-\Ch{F7}{And} any time you feel the \Ch{B}{pain,} hey {Jude} re\Ch{Gmi7}{frain,}
+<F7>And any time you feel the <B>pain, hey {Jude} re<Gmi7>frain,
 
-Don't {carry} the \Ch{C7}{world} {upon} your \Ch{F}{shoulders}
+Don't {carry} the <C7>world {upon} your <F>shoulders
 
-\Ch{F7}{For} well you know that it's a \Ch{B}{fool} who {plays} it \Ch{Gmi7}{cool}
+<F7>For well you know that it's a <B>fool who {plays} it <Gmi7>cool
 
-By {making} his \Ch{C7}{world} a {little} \Ch{F}{colder}
+By {making} his <C7>world a {little} <F>colder
 
-Da da da \Ch{F7}{da} da da da \Ch{C7}{da} da
+Da da da <F7>da da da da <C7>da da
 \kr
 
 \zs
@@ -62,7 +62,7 @@ then you'll begin to make it better
 Better better better better better oh.
 \ks
 
-\Ch{F}{Da} da da \Ch{Eb}{da} da da da \Ch{B}{da} da da da hey \Ch{F}{Jude} ...
+<F>Da da da <Eb>da da da da <B>da da da da hey <F>Jude ...
 
 \kp
 

--- a/tp-songs/03_zahranicni/Beatles____Let_it_be.tex
+++ b/tp-songs/03_zahranicni/Beatles____Let_it_be.tex
@@ -3,10 +3,10 @@
 \zp{Let it be}{Beatles}
 
 \zs
-\Ch{G}{When} I find myself in \Ch{D}{times} of trouble,
-\Ch{Emi}{Mother} Mary \Ch{C}{comes} to me
+<G>When I find myself in <D>times of trouble,
+<Emi>Mother Mary <C>comes to me
 
-\Ch{G}{Speaking} words of \Ch{D}{wisdom:} ``Let it \Ch{C}{be.}'' \Ch{G}{}
+<G>Speaking words of <D>wisdom: ``Let it <C>be.'' <G>
 \ks
 \zs
 And in my hour of darkness,
@@ -15,9 +15,9 @@ she is standing right in front of me
 Speaking words of wisdom: ``Let it be.''
 \ks
 \zr
-Let it \Ch{Emi}{be, let} it \Ch{D}{be,} let it \Ch{C}{be,} yeah, let it \Ch{G}{be}
+Let it <Emi>be, let it <D>be, let it <C>be, yeah, let it <G>be
 
-\Ch{G}{Whisper} words of \Ch{D}{wisdom:} ``Let it \Ch{C}{be.}'' \Ch{G}{}
+<G>Whisper words of <D>wisdom: ``Let it <C>be.'' <G>
 \kr
 \zs
 And when the broken hearted people

--- a/tp-songs/03_zahranicni/Beatles____Love_me_do.tex
+++ b/tp-songs/03_zahranicni/Beatles____Love_me_do.tex
@@ -3,13 +3,13 @@
 \zp{Love me do}{Beatles}
 \zs
 
-\Ch{G}{Love}, love me \Ch{C}{do},
-you \Ch{G}{know} I love \Ch{C}{you}
+<G>Love, love me <C>do,
+you <G>know I love <C>you
 
-I'll \Ch{G}{always} be \Ch{C}{true,}
-so \Ch{C}{pleeeeee}\Ch{C/G}{ase}...
+I'll <G>always be <C>true,
+so <C>pleeeeee<C/G>ase...
 
-Love me \Ch{G}{do}
+Love me <G>do
 \ks
 
 \zs
@@ -23,9 +23,9 @@ Love me do
 \ks
 \zr
 
-\Ch{D}{Someone} to love, \Ch{C}{some}\Ch{F}{body} \Ch{G}{new}
+<D>Someone to love, <C>some<F>body <G>new
 
-\Ch{D}{Someone} to love, \Ch{C}{some}\Ch{F}{one} like \Ch{G}{you}
+<D>Someone to love, <C>some<F>one like <G>you
 \kr
 \zs
 Love, love me do,
@@ -47,8 +47,8 @@ Love me do
 \ks
 
 
-\Ch{G}{Love} me \Ch{C}{do}, yeah, \Ch{G}{love} me \Ch{C}{do,}
-yeah, \Ch{G}{love} me \Ch{C}{do}...
+<G>Love me <C>do, yeah, <G>love me <C>do,
+yeah, <G>love me <C>do...
 
 \kp
 

--- a/tp-songs/03_zahranicni/Beatles____Norwegian_wood.tex
+++ b/tp-songs/03_zahranicni/Beatles____Norwegian_wood.tex
@@ -2,13 +2,13 @@
 
 \zp{Norwegian wood}{Beatles}
 \zs
-\Ch{D}{I on}ce had a girl or should I say, \Ch{C}{she o}nce \Ch{G}{had} \Ch{D}{me}
+<D>I once had a girl or should I say, <C>she once <G>had <D>me
 
-She showed me her room, isn't it good, \Ch{C}{Norwe}\Ch{G}{gian} \Ch{D}{wood}
+She showed me her room, isn't it good, <C>Norwe<G>gian <D>wood
 
-She \Ch{Dmi}{asked} me to stay and she told me to sit any\Ch{G}{where}
+She <Dmi>asked me to stay and she told me to sit any<G>where
 
-But \Ch{Dmi}{I look}ed around and I noticed there wasn't a \Ch{Emi}{chair} \Ch{A7}{}
+But <Dmi>I looked around and I noticed there wasn't a <Emi>chair <A7>
 \ks
 
 \zs
@@ -22,9 +22,9 @@ I told her I didn't and crawled off to sleep in the bath
 \ks
 
 \zr
-\Ch{D}{And} when I awoke I was alone, \Ch{C}{this bird} \Ch{G}{had} \Ch{D}{flown}
+<D>And when I awoke I was alone, <C>this bird <G>had <D>flown
 
-So I lit a fire, isn't it good, \Ch{C}{Norwe}\Ch{G}{gian} \Ch{D}{wood?}
+So I lit a fire, isn't it good, <C>Norwe<G>gian <D>wood?
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Beatles____Oh_darling.tex
+++ b/tp-songs/03_zahranicni/Beatles____Oh_darling.tex
@@ -3,13 +3,13 @@
 \zp{Oh darling}{Beatles}
 
 \zs
-\Ch{F}{Oh} \Ch{A}{darling, please, be}\Ch{E}{lieve me} 
+<F>Oh <A>darling, please, be<E>lieve me 
 
-\Ch{F#mi}{I'll never do you no} \Ch{D}{harm} 
+<F#mi>I'll never do you no <D>harm 
 
-Be\Ch{Hmi7}{lieve me when I} \Ch{E7}{tell you} 
+Be<Hmi7>lieve me when I <E7>tell you 
 
-\Ch{Hmi7}{I'll never} \Ch{E7}{do you no} \Ch{A}{harm} \Ch{D}{} \Ch{A}{} \Ch{E7}{}
+<Hmi7>I'll never <E7>do you no <A>harm <D> <A> <E7>
 \ks
 
 \zs
@@ -19,17 +19,17 @@ I'll never make it alone
 
 Believe me when I beg you 
 
-Don't ever leave me alone \Ch{D7}{} 
+Don't ever leave me alone <D7> 
 \ks
 
 \zr
-(Be\Ch{A}{live me} \Ch{A7}{darling)} When you \Ch{D}{told me you} didn't \Ch{F}{need me anymore} 
+(Be<A>live me <A7>darling) When you <D>told me you didn't <F>need me anymore 
 
-Well you \Ch{A}{know I nearly broke down and cried} 
+Well you <A>know I nearly broke down and cried 
 
-\Ch{A7}{When you} \Ch{H7}{told me you didn't} \Ch{E7}{need me anymore} 
+<A7>When you <H7>told me you didn't <E7>need me anymore 
 
-Well you know I nearly \Ch{F}{broke down and} \Ch{E7}{died} \Ch{E7+}{} 
+Well you know I nearly <F>broke down and <E7>died <E7+> 
 \kr
 
 \zs
@@ -52,7 +52,7 @@ I'll never let you down
 
 Believe me when I tell you 
 
-I'll never do you no harm \Ch{D}{} \Ch{A}{} \Ch{B9}{} \Ch{A}{}
+I'll never do you no harm <D> <A> <B9> <A>
 \ks
 
 \kp

--- a/tp-songs/03_zahranicni/Beatles____Yellow_submarine.tex
+++ b/tp-songs/03_zahranicni/Beatles____Yellow_submarine.tex
@@ -3,13 +3,13 @@
 \zp{Yellow submarine}{Beatles}
 
 \zs
-\Ch{G}{In} the \Ch{D}{town} where \Ch{C}{I was} \Ch{G}{born}
+<G>In the <D>town where <C>I was <G>born
 
-\Ch{Emi}{Lived} a \Ch{Ami}{man} who \Ch{C}{sailed} the \Ch{D}{sea}
+<Emi>Lived a <Ami>man who <C>sailed the <D>sea
 
-\Ch{G}{And} he \Ch{D}{told} us \Ch{C}{of} his \Ch{G}{life}
+<G>And he <D>told us <C>of his <G>life
 
-\Ch{Emi}{In the} \Ch{Ami}{land} of \Ch{C}{subma}\Ch{D}{rines}
+<Emi>In the <Ami>land of <C>subma<D>rines
 \ks
 
 \zs
@@ -23,9 +23,9 @@ In our Yellow Submarine
 \ks
 
 \zr
-/: \Ch{G}{We} all live in a \Ch{D}{Yellow} Submarine
+/: <G>We all live in a <D>Yellow Submarine
 
-Yellow Submarine, \Ch{G}{Yellow} Submarine :/
+Yellow Submarine, <G>Yellow Submarine :/
 \kr
 
 \zs
@@ -36,7 +36,7 @@ Many more of them live next door
 And the band begins to play
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 As we live a life of ease
@@ -48,7 +48,7 @@ Sky of blue and sea of green
 In our Yellow Submarine
 \ks
 
-\zr  \kr   \zr  \kr
+\zr \kr \zr \kr
 
 \kp
 

--- a/tp-songs/03_zahranicni/Beatles____Yesterday.tex
+++ b/tp-songs/03_zahranicni/Beatles____Yesterday.tex
@@ -3,11 +3,11 @@
 \zp{Yesterday}{Beatles}
 
 \zs
-\Ch{G}{Yesterday}, \Ch{F#mi7}{all my} \Ch{H7}{troubles} seemed so \Ch{Emi}{far away} \Ch{D}{}
+<G>Yesterday, <F#mi7>all my <H7>troubles seemed so <Emi>far away <D>
 
-\Ch{C}{Now} it \Ch{D7}{seems} as though they're \Ch{G}{here} to stay \Ch{D}{}
+<C>Now it <D7>seems as though they're <G>here to stay <D>
 
-Oh, \Ch{Emi}{I be}\Ch{A7}{lieve} in \Ch{C}{yes}\Ch{G}{terday}
+Oh, <Emi>I be<A7>lieve in <C>yes<G>terday
 \ks
 
 \zs
@@ -19,13 +19,13 @@ Oh, yesterday came suddenly
 \ks
 
 \zr
-\Ch{F#mi7}{Why} \Ch{H7}{she} \Ch{Emi}{had} \Ch{D}{to} \Ch{C}{go}
+<F#mi7>Why <H7>she <Emi>had <D>to <C>go
 
-I don't \Ch{D}{know}, she \Ch{D7}{wouldn't} \Ch{G}{say}
+I don't <D>know, she <D7>wouldn't <G>say
 
-\Ch{F#mi7}{I} \Ch{H7}{said} \Ch{Emi}{some} \Ch{D}{thing} \Ch{C}{wrong}
+<F#mi7>I <H7>said <Emi>some <D>thing <C>wrong
 
-Now I \Ch{D}{long} for \Ch{D7}{yes}ter\Ch{G}{day}
+Now I <D>long for <D7>yester<G>day
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Beautiful_South____Dont_Marry_Her.tex
+++ b/tp-songs/03_zahranicni/Beautiful_South____Dont_Marry_Her.tex
@@ -2,13 +2,13 @@
 
 \zs
 
-\Ch{C}{Think} of you with \Ch{G}{pipe} and slippers, \Ch{Fmaj7}{think} of her in \Ch{G}{bed}
+<C>Think of you with <G>pipe and slippers, <Fmaj7>think of her in <G>bed
 
-\Ch{Fmaj7}{Laying} there just \Ch{C}{watching} telly, then \Ch{D}{think} of me \Ch{G}{instead}
+<Fmaj7>Laying there just <C>watching telly, then <D>think of me <G>instead
 
-I'll \Ch{C}{never} grow so \Ch{G}{old} and flabby, \Ch{Fmaj7}{that could} never \Ch{G}{be}
+I'll <C>never grow so <G>old and flabby, <Fmaj7>that could never <G>be
 
-\Ch{Fmaj7}{Don't} marry \Ch{G}{her}, have \Ch{C}{me}
+<Fmaj7>Don't marry <G>her, have <C>me
 \ks
 
 \zs
@@ -23,13 +23,13 @@ Don't marry her, have me
 
 \zr
 
-And the \Ch{C}{Sunday} sun shines down on San Fran\Ch{Fmaj7}{cisco Bay}
+And the <C>Sunday sun shines down on San Fran<Fmaj7>cisco Bay
 
-And you \Ch{Fmaj7}{realise} you can't make it \Ch{C}{anyway}
+And you <Fmaj7>realise you can't make it <C>anyway
 
-You have to wash the car, take the \Ch{Fmaj7}{kiddies} to the \Ch{C}{park}
+You have to wash the car, take the <Fmaj7>kiddies to the <C>park
 
-\Ch{Fmaj7}{Don't} marry \Ch{G}{her}, have \Ch{C}{me}
+<Fmaj7>Don't marry <G>her, have <C>me
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Ben_E_King____Stand_By_Me.tex
+++ b/tp-songs/03_zahranicni/Ben_E_King____Stand_By_Me.tex
@@ -3,15 +3,15 @@
 \zp{Stand by me}{Ben E King}
 
 \ifdefined\TPBAND
-  | \Ch{A}{} |  |  \Ch{F#mi}{} |  |  \Ch{D}{} |  \Ch{E}{} |  \Ch{A}{} |  |
+ | <A> | | <F#mi> | | <D> | <E> | <A> | |
 \fi
 
 \zs
-When the \Ch{A}{night} has come
+When the <A>night has come
 
-And the \Ch{F#mi}{land} is dark
+And the <F#mi>land is dark
 
-And the \Ch{D}{moon} is the \Ch{E}{only light} we'll \Ch{A}{see}
+And the <D>moon is the <E>only light we'll <A>see
 
 No, I won't be afraid
 

--- a/tp-songs/03_zahranicni/Bill_Haley____Rock_Around_the_Clock.tex
+++ b/tp-songs/03_zahranicni/Bill_Haley____Rock_Around_the_Clock.tex
@@ -3,26 +3,26 @@
 \zp{Rock around the clock}{Bill Haley and the Comets}
 
 \zs 
-\Ch{E}{One, two, three o'clock, four o'clock, rock}
+<E>One, two, three o'clock, four o'clock, rock
 
-\Ch{E}{Five, six, seven o'clock, eight o'clock, rock}
+<E>Five, six, seven o'clock, eight o'clock, rock
 
-\Ch{E}{Nine, ten, eleven o'clock, twelve o'clock, rock}
+<E>Nine, ten, eleven o'clock, twelve o'clock, rock
 
-We're gonna \Ch{H7}{rock around the clock tonight}
+We're gonna <H7>rock around the clock tonight
 \ks
 
 \zs
 
-Put your \Ch{E}{glad rags on and join me, hon}
+Put your <E>glad rags on and join me, hon
 
-We'll have some fun when the \Ch{E7}{clock strikes one}
+We'll have some fun when the <E7>clock strikes one
 
-We're gonna \Ch{A7}{rock around the clock tonight}
+We're gonna <A7>rock around the clock tonight
 
-We're gonna \Ch{E}{rock, rock, rock, 'til broad daylight}
+We're gonna <E>rock, rock, rock, 'til broad daylight
 
-We're gonna \Ch{H7}{rock, gonna rock,} a\Ch{A7}{round the clock} to\Ch{E}{night}
+We're gonna <H7>rock, gonna rock, a<A7>round the clock to<E>night
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/Bob_Dylan____Knockin_on_heavens_door.tex
+++ b/tp-songs/03_zahranicni/Bob_Dylan____Knockin_on_heavens_door.tex
@@ -3,9 +3,9 @@
 \zp{Knockin' on heaven's door}{Bob Dylan}
 
 \zs
-\Ch{G}{Ma}ma, \Ch{D}{take} this badge off of \Ch{Ami}{me} \Ch{Ami7}
+<G>Mama, <D>take this badge off of <Ami>me <Ami7>
 
-\Ch{G}{I can't} \Ch{D}{use} it any \Ch{C}{more}
+<G>I can't <D>use it any <C>more
 
 It's getting dark, too dark to see
 

--- a/tp-songs/03_zahranicni/Bobby_McFerrin____Dont_Worry_Be_Happy.tex
+++ b/tp-songs/03_zahranicni/Bobby_McFerrin____Dont_Worry_Be_Happy.tex
@@ -3,11 +3,11 @@
 \zp{Don't worry, be happy}{Bobby McFerrin}
 
 \zs
-\Ch{G}{Here's} a little song I wrote 
+<G>Here's a little song I wrote 
 
-You \Ch{Ami}{might} want to sing it note for note 
+You <Ami>might want to sing it note for note 
 
-Don't \Ch{C}{worry} be \Ch{G}{happy}
+Don't <C>worry be <G>happy
 
 In every life we have some trouble
 

--- a/tp-songs/03_zahranicni/Cat_Stevens____Father_and_Son.tex
+++ b/tp-songs/03_zahranicni/Cat_Stevens____Father_and_Son.tex
@@ -3,36 +3,36 @@
 
 Father
 \zs
-It's not \Ch{G}{time} to make a \Ch{D}{change}, just \Ch{C}{relax}, take it \Ch{Ami7}{easy}
+It's not <G>time to make a <D>change, just <C>relax, take it <Ami7>easy
 
-You're still \Ch{G}{young}, that's your \Ch{Emi}{fault}, there's so \Ch{Ami}{much} you have to \Ch{D}{know}
+You're still <G>young, that's your <Emi>fault, there's so <Ami>much you have to <D>know
 
-Find a \Ch{G}{girl}, settle \Ch{D}{down}, if you \Ch{C}{want} you can \Ch{Ami7}{marry}
+Find a <G>girl, settle <D>down, if you <C>want you can <Ami7>marry
 
-Look at \Ch{G}{me,} I am \Ch{Emi}{old but} I'm \Ch{Ami}{happy}\Ch{C}{} \Ch{D}{}
+Look at <G>me, I am <Emi>old but I'm <Ami>happy<C> <D>
 \ks
 
 \zs
-I was \Ch{G}{once} like you are \Ch{Bmi7}{now,} and I \Ch{C}{know} that it's not \Ch{Ami7}{easy}
+I was <G>once like you are <Bmi7>now, and I <C>know that it's not <Ami7>easy
 
-To be \Ch{G}{calm} when you've \Ch{Emi}{found} something going \Ch{Ami}{on} \Ch{C}{} \Ch{D}{}
+To be <G>calm when you've <Emi>found something going <Ami>on <C> <D>
 
-But take your \Ch{G}{time}, think a \Ch{Bmi7}{lot, think} \Ch{C}{of} everything you'\Ch{Ami7}{ve got}
+But take your <G>time, think a <Bmi7>lot, think <C>of everything you'<Ami7>ve got
 
-For you will \Ch{G}{still} be here to\Ch{Emi}{morrow}, but your \Ch{D}{dreams} may \Ch{G}{not} \Ch{G/C}{} \Ch{G/C}{}
+For you will <G>still be here to<Emi>morrow, but your <D>dreams may <G>not <G/C> <G/C>
 \ks
 
 Son
 \zs
-How can \Ch{G}{I try} to \Ch{Bmi}{explain}, when I \Ch{C}{do} he turns away a\Ch{Ami7}{gain}
+How can <G>I try to <Bmi>explain, when I <C>do he turns away a<Ami7>gain
 
-It's \Ch{G}{always} been the \Ch{Emi}{same}, same old \Ch{Ami}{story} \Ch{C}{} \Ch{D}{}
+It's <G>always been the <Emi>same, same old <Ami>story <C> <D>
 
-From the \Ch{G}{moment} I could \Ch{Bmi}{talk} I was \Ch{C}{ordered} to \Ch{Ami7}{listen}
+From the <G>moment I could <Bmi>talk I was <C>ordered to <Ami7>listen
 
-Now there's a \Ch{G}{way} and I \Ch{Emi}{know} that I \Ch{D}{have} to \Ch{G}{go} away
+Now there's a <G>way and I <Emi>know that I <D>have to <G>go away
 
-I \Ch{D}{know} I \Ch{C}{have} to \Ch{G}{go} \Ch{G/C}{} \Ch{G/C}{}\\
+I <D>know I <C>have to <G>go <G/C> <G/C>\\
 \ks
 
 Father

--- a/tp-songs/03_zahranicni/Chantal_Kreviazuk____Leaving_On_a_Jet_Plane.tex
+++ b/tp-songs/03_zahranicni/Chantal_Kreviazuk____Leaving_On_a_Jet_Plane.tex
@@ -3,17 +3,17 @@
 \zp{Leaving on a jet plane}{Chantal Kreviazuk}
 
 \zs
-All my \Ch{D}{bags} are packed, I'm \Ch{G}{ready} to go
+All my <D>bags are packed, I'm <G>ready to go
 
-I'm \Ch{D}{standing} here out\Ch{G}{side} your door
+I'm <D>standing here out<G>side your door
 
-I \Ch{D}{hate} to wake you \Ch{G}{up to} say good\Ch{A}{bye}
+I <D>hate to wake you <G>up to say good<A>bye
 
-But the \Ch{D}{dawn} is breakin', it's \Ch{G}{early} morn'
+But the <D>dawn is breakin', it's <G>early morn'
 
-The \Ch{D}{taxi's} waitin', he's \Ch{G}{blowin'} his horn
+The <D>taxi's waitin', he's <G>blowin' his horn
 
-Al\Ch{D}{ready} I'm so \Ch{G}{lonesome} I could \Ch{A}{cry}
+Al<D>ready I'm so <G>lonesome I could <A>cry
 \ks
 
 \zr

--- a/tp-songs/03_zahranicni/Chuck_Berry____Johnny_B_Goode.tex
+++ b/tp-songs/03_zahranicni/Chuck_Berry____Johnny_B_Goode.tex
@@ -1,25 +1,25 @@
 \zp{Johnny B Goode}{Chuck Berry}
 
 \zs
-\Ch{G}{Deep} down Louisiana close to New   Orleans
+<G>Deep down Louisiana close to New Orleans
 
-Way back up in the woods among the ever  greens
+Way back up in the woods among the ever greens
 
-There \Ch{C}{stood} a log cabin made of earth and wood
+There <C>stood a log cabin made of earth and wood
 
-Where \Ch{G}{lived} a country boy named Johnny B Goode
+Where <G>lived a country boy named Johnny B Goode
 
-Who \Ch{D}{never} ever learned to read or write so well
+Who <D>never ever learned to read or write so well
 
-But he could \Ch{G}{play} the guitar just like a ringing a bell
+But he could <G>play the guitar just like a ringing a bell
 \ks
 
 \zr
-\Ch{G}{Go, go}! Go, Johnny, go, go!
+<G>Go, go! Go, Johnny, go, go!
 
-Go, Johnny, go, \Ch{C}{go!} Go, Johnny, go, \Ch{G}{go!}
+Go, Johnny, go, <C>go! Go, Johnny, go, <G>go!
 
-Go, Johnny, go, \Ch{D}{go!} Johnny B \Ch{G}{Goode}
+Go, Johnny, go, <D>go! Johnny B <G>Goode
 \kr
 
 \zs
@@ -41,7 +41,7 @@ Oh my that little country boy could play
 \zs (solo) \ks 
 
 \zs
-His mother told him: ``Someday you will be a  man
+His mother told him: ``Someday you will be a man
 
 And you will be the leader of a big old band
 

--- a/tp-songs/03_zahranicni/Cornershop____Brimful_of_Asha.tex
+++ b/tp-songs/03_zahranicni/Cornershop____Brimful_of_Asha.tex
@@ -1,21 +1,21 @@
 \zp{Brimful of Asha}{Cornershop}
 
 \zs
-There's \Ch{A}{dancing} \Ch{E}{behind} \Ch{D}{movie} scenes
+There's <A>dancing <E>behind <D>movie scenes
 
-Behind the \Ch{A}{movie} scenes -- \Ch{E}{Sadi} \Ch{D}{Rani}
+Behind the <A>movie scenes -- <E>Sadi <D>Rani
 
-\Ch{A}{She's} the one that keeps the \Ch{E}{dream} \Ch{D}{alive}
+<A>She's the one that keeps the <E>dream <D>alive
 
-From the \Ch{A}{morning}, \Ch{E}{past} the \Ch{D}{evening}
+From the <A>morning, <E>past the <D>evening
 
-Till the end of the \Ch{A}{light}
+Till the end of the <A>light
 \ks
 
 \zr
-/: \Ch{A}{Brimful} of Asha on the \Ch{E}{forty}-\Ch{D}{five}
+/: <A>Brimful of Asha on the <E>forty-<D>five
 
-Well, \Ch{A}{it}'s a brimful of Asha on the \Ch{E}{forty}-\Ch{D}{five} :/
+Well, <A>it's a brimful of Asha on the <E>forty-<D>five :/
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Cranberries____Zombie.tex
+++ b/tp-songs/03_zahranicni/Cranberries____Zombie.tex
@@ -3,7 +3,7 @@
 \zp{Zombie}{Cranberries}
 
 
-\Ch{Emi}{}   \Ch{C}{}  \Ch{G}{}  \Ch{D}{}
+<Emi> <C> <G> <D>
 \zs
 Another head hangs lowly
 
@@ -31,7 +31,7 @@ What's in your head, in your head
 
 Zombie, Zombie, Zombie - ie - ie - ie - Emioh
 
-\Ch{C}{}  \Ch{G}{}  \Ch{D}{}  \Ch{Emi}{}  \Ch{C}{}  \Ch{G}{} \Ch{D}{} 
+<C> <G> <D> <Emi> <C> <G> <D> 
 
 tu tu tu...
 \kr
@@ -51,7 +51,7 @@ In your head, in your head they're still fightin'
 \ks
 
 \zr
-..... ie - ie - ie - oh. oh oh oh oh oh oh  ie-ah ah   
+..... ie - ie - ie - oh. oh oh oh oh oh oh ie-ah ah 
 \kr 
 
 \kp

--- a/tp-songs/03_zahranicni/Creedence_Clearwater_Revival____Proud_Mary.tex
+++ b/tp-songs/03_zahranicni/Creedence_Clearwater_Revival____Proud_Mary.tex
@@ -2,20 +2,20 @@
 
 \zp{Proud Mary}{Creedence Clearwater Revival}
 
-\Ch{C}{}
-\Ch{A}{}
-\Ch{C}{}
-\Ch{A}{}
-\Ch{C}{}
-\Ch{A}{}
-\Ch{G}{}
-\Ch{F}{}
-\Ch{D}{}
-\Ch{F}{}
-\Ch{D}{}
+<C>
+<A>
+<C>
+<A>
+<C>
+<A>
+<G>
+<F>
+<D>
+<F>
+<D>
 
 \zs
-\Ch{D}{Left} a good job in the city,
+<D>Left a good job in the city,
 
 Workin for the man every night and day
 
@@ -25,11 +25,11 @@ Worryin' 'bout the way things might have been
 \ks
 
 \zr
-\Ch{A}{Big} wheels keep on turnin'
+<A>Big wheels keep on turnin'
 
-\Ch{Hmi}{Pro}ud  Mary keep on \Ch{G}{burnin'}
+<Hmi>Proud Mary keep on <G>burnin'
 
-/: \Ch{D}{Roll}in', rollin', rollin' on the river :/
+/: <D>Rollin', rollin', rollin' on the river :/
 \kr
 
 \zs
@@ -39,20 +39,20 @@ Pumped a lot of pain down in New Orleans
 
 But I never saw the good side of the city
 
-Till I hitched a ride \Ch{A}{on} a river boat queen
+Till I hitched a ride <A>on a river boat queen
 \ks
 
 \zr
 \kr
 
 \zs
-\Ch{D}{If} you come down to the river
+<D>If you come down to the river
 
 Bet you're gonna find some people who live
 
 You don't have to worry, 'cause you have no money
 
-People on the river are \Ch{A}{happy} to give
+People on the river are <A>happy to give
 \ks
 
 \zr\kr

--- a/tp-songs/03_zahranicni/Deep_Purple____Smoke_on_the_water.tex
+++ b/tp-songs/03_zahranicni/Deep_Purple____Smoke_on_the_water.tex
@@ -3,14 +3,14 @@
 \zp{Smoke on the water}{Deep Purple}
 
 \zr
-8× /: \Ch{G}{} \Ch{B}{} \Ch{C}{} \Ch{G}{} \Ch{B}{} \Ch{C#}{} \Ch{C}{} \Ch{G}{} 
-\Ch{B}{} \Ch{C}{} \Ch{B}{} \Ch{G}{} :/
+8× /: <G> <B> <C> <G> <B> <C#> <C> <G> 
+<B> <C> <B> <G> :/
 \kr
 
 \zs
-\Ch{G}{We} all came out to Montreux
+<G>We all came out to Montreux
 
-On the Lake Ge\Ch{F}{neva} \Ch{G}{shoreline}
+On the Lake Ge<F>neva <G>shoreline
 
 To make records with a mobile
 
@@ -26,9 +26,9 @@ Burned the place to the ground
 \ks
 
 \zr
-\Ch{C}{Smoke} on the \Ch{G#}{water}, \Ch{G}{fire} in the sky! \Ch{C}{Smoke} on the \Ch{G#}{water}
+<C>Smoke on the <G#>water, <G>fire in the sky! <C>Smoke on the <G#>water
 
-/: \Ch{G}{} \Ch{B}{} \Ch{C}{} \Ch{G}{} \Ch{B}{} \Ch{C#}{} \Ch{C}{} \Ch{G}{} \Ch{B}{} \Ch{C}{} \Ch{B}{} \Ch{G}{} :/
+/: <G> <B> <C> <G> <B> <C#> <C> <G> <B> <C> <B> <G> :/
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Doors____People_Are_Strange.tex
+++ b/tp-songs/03_zahranicni/Doors____People_Are_Strange.tex
@@ -3,13 +3,13 @@
 \zp{People are strange}{Doors}
 
 \zs
-\Ch{Emi}{People are strange}
+<Emi>People are strange
 
-\Ch{Ami}{When you're a} \Ch{Emi}{stranger}
+<Ami>When you're a <Emi>stranger
 
-\Ch{Ami}{Faces look} \Ch{Emi}{ugly}
+<Ami>Faces look <Emi>ugly
 
-\Ch{H7}{When you're} a\Ch{Emi}{lone}
+<H7>When you're a<Emi>lone
 
 \bigskip
 
@@ -23,13 +23,13 @@ When you're down.
 \ks
 
 \zr
-When you're \Ch{H7}{strange}
+When you're <H7>strange
 
-\Ch{G}{Faces come} out of the \Ch{H7}{rain}
+<G>Faces come out of the <H7>rain
 
 When you're strange
 
-\Ch{G}{No one remembers} your \Ch{H7}{name}
+<G>No one remembers your <H7>name
 
 When you're strange
 

--- a/tp-songs/03_zahranicni/Eagles____Hotel_California.tex
+++ b/tp-songs/03_zahranicni/Eagles____Hotel_California.tex
@@ -2,20 +2,20 @@
 
 \zp{Hotel California}{Eagles}
 
-\Ch{Hmi}{} \Ch{F#}{} \Ch{A}{} \Ch{E}{} \Ch{G}{} \Ch{D}{} \Ch{Emi}{} \Ch{F#}{}
+<Hmi> <F#> <A> <E> <G> <D> <Emi> <F#>
 
 \zs
-\Ch{Hmi}{On a} dark desert highway,
-\Ch{F#}{cool} wind in my hair
+<Hmi>On a dark desert highway,
+<F#>cool wind in my hair
 
-\Ch{A}{Warm} smell of colitas
-\Ch{E}{rising} up through the air
+<A>Warm smell of colitas
+<E>rising up through the air
 
-\Ch{G}{Up} a head in the distance,
-I \Ch{D}{saw} a shimmering light
+<G>Up a head in the distance,
+I <D>saw a shimmering light
 
-My \Ch{Emi}{head} grew heavy and my sight grew dim,
-I \Ch{F#}{had} to stop for the night
+My <Emi>head grew heavy and my sight grew dim,
+I <F#>had to stop for the night
 \ks
 
 \zs
@@ -33,15 +33,15 @@ I thought I heard them say:
 \ks
 
 \zr
-\Ch{G}{Welcome} to the Hotel Cali\Ch{D}{fornia}
+<G>Welcome to the Hotel Cali<D>fornia
 
-Such a \Ch{Emi}{lovely} place (such a lovely place),
-such a \Ch{Hmi7}{lovely} face
+Such a <Emi>lovely place (such a lovely place),
+such a <Hmi7>lovely face
 
-\Ch{G}{Plenty} of room at the Hotel Cali\Ch{D}{fornia}
+<G>Plenty of room at the Hotel Cali<D>fornia
 
-Any \Ch{Emi}{time} of year (any time of year),
-you can \Ch{F#}{find} it here
+Any <Emi>time of year (any time of year),
+you can <F#>find it here
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Elvis_Presley____Blue_Suede_Shoes.tex
+++ b/tp-songs/03_zahranicni/Elvis_Presley____Blue_Suede_Shoes.tex
@@ -1,7 +1,7 @@
 \zp{Blue suede shoes}{Elvis Presley}
 
 \zs
-Well it's one for the money,  two for the show
+Well it's one for the money, two for the show
 
 Three to get ready now go cat go
 

--- a/tp-songs/03_zahranicni/Elvis_Presley____Hound_Dog.tex
+++ b/tp-songs/03_zahranicni/Elvis_Presley____Hound_Dog.tex
@@ -17,7 +17,7 @@ And you ain't no friend of mine
 
 \zs
 Well they said you was high-classed
-                    
+ 
 Well, that was just a lie
 
 Yeah, they said you was high-classed

--- a/tp-songs/03_zahranicni/Eric_Clapton____Layla.tex
+++ b/tp-songs/03_zahranicni/Eric_Clapton____Layla.tex
@@ -2,24 +2,24 @@
 
 \zp{Layla}{Eric Clapton}
 
-/: \Ch{Dmi}{} \Ch{B}{} \Ch{C}{} \Ch{Dmi}{} :/
+/: <Dmi> <B> <C> <Dmi> :/
 
 \zs
-\Ch{C#mi}{What} will you do when you get \Ch{G#mi}{lonely}
+<C#mi>What will you do when you get <G#mi>lonely
 
-\Ch{C#mi}{With} no-one \Ch{C}{wai}ting \Ch{D}{by} your \Ch{E}{side} \Ch{E7}{}
+<C#mi>With no-one <C>waiting <D>by your <E>side <E7>
 
-\Ch{F#mi}{You've} been \Ch{H}{runni}ng and \Ch{E}{hidi}ng much too \Ch{A}{long}
+<F#mi>You've been <H>running and <E>hiding much too <A>long
 
-\Ch{F#mi}{You} know it's \Ch{H}{just} your foolish \Ch{E}{pride} \Ch{A}{}
+<F#mi>You know it's <H>just your foolish <E>pride <A>
 \ks
 
 \zr
-La\Ch{Dmi}{yla,} \Ch{B}{you} got \Ch{C}{me} on my \Ch{Dmi}{knees}
+La<Dmi>yla, <B>you got <C>me on my <Dmi>knees
 
-Lay\Ch{B}{la,} I'm \Ch{C}{begg}ing darling \Ch{Dmi}{please}
+Lay<B>la, I'm <C>begging darling <Dmi>please
 
-Lay\Ch{B}{la,} \Ch{C}{darli}ng won't you \Ch{Dmi}{ease} my worried \Ch{B}{mind} \Ch{C}{}
+Lay<B>la, <C>darling won't you <Dmi>ease my worried <B>mind <C>
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Fools_Garden____Lemon_Tree.tex
+++ b/tp-songs/03_zahranicni/Fools_Garden____Lemon_Tree.tex
@@ -3,15 +3,15 @@
 \zp{Lemon tree}{Fool's Garden}
 
 \zs
-I'm \Ch{Dmi}{sitting here} in a \Ch{Ami}{boring room}
+I'm <Dmi>sitting here in a <Ami>boring room
 
-It's \Ch{Dmi}{just another} rainy Sunday \Ch{A7}{afternoon}
+It's <Dmi>just another rainy Sunday <A7>afternoon
 
-I'm \Ch{Dmi}{wasting my time} I got \Ch{Ami}{nothing to do}
+I'm <Dmi>wasting my time I got <Ami>nothing to do
 
-I'm \Ch{Gmi}{hanging around} and I'm \Ch{A7}{waiting for you}
+I'm <Gmi>hanging around and I'm <A7>waiting for you
 
-But \Ch{Gmi}{nothing ever happens} -- \Ch{A7}{} and I \Ch{Dmi}{wonder} \Ch{Ami}{} \Ch{Dmi}{}
+But <Gmi>nothing ever happens -- <A7> and I <Dmi>wonder <Ami> <Dmi>
 \ks
 
 \zs
@@ -23,22 +23,22 @@ But nothing ever happens -- and I wonder
 \ks
 
 \zr
-I \Ch{F}{wonder} how, I \Ch{C}{wonder} why
+I <F>wonder how, I <C>wonder why
 
-\Ch{Dmi}{Yesterday you} told me 'bout the \Ch{Ami}{blue blue sky}
+<Dmi>Yesterday you told me 'bout the <Ami>blue blue sky
 
-And \Ch{B}{all that} I can \Ch{C}{see is} just a yellow \Ch{F}{lemon tree} \Ch{C}{}
+And <B>all that I can <C>see is just a yellow <F>lemon tree <C>
 
-I'm \Ch{F}{turning} my head \Ch{C}{up and down}
+I'm <F>turning my head <C>up and down
 
-I'm \Ch{Dmi}{turning turning} turning turning \Ch{Ami}{turning around}
+I'm <Dmi>turning turning turning turning <Ami>turning around
 
-And \Ch{B}{all that} I can \Ch{C}{see is} just a yellow \Ch{F}{lemon tree}
+And <B>all that I can <C>see is just a yellow <F>lemon tree
 \kr
 
 \zs
-\Ch{Dmi}{Tap} \Ch{Ami}{ta-da dee da} \Ch{Dmi}{tee-dap tap...} \Ch{Ami}{} \Ch{Gmi}{}
-\Ch{A7}{} \Ch{Dmi}{} \Ch{Ami}{} \Ch{Dmi}{}
+<Dmi>Tap <Ami>ta-da dee da <Dmi>tee-dap tap... <Ami> <Gmi>
+<A7> <Dmi> <Ami> <Dmi>
 \ks
 
 \zs
@@ -49,9 +49,9 @@ But there's a heavy cloud inside my head, I feel so tired, put myself into bed
 Where nothing ever happens -- and I wonder
 \ks
 
-\Ch{A7}{Isolation} -- \Ch{Dmi}{it's not} good for me
+<A7>Isolation -- <Dmi>it's not good for me
 
-\Ch{C}{Isolation} -- \Ch{F}{I don't} \Ch{B}{want to} \Ch{A7}{sit on} a lemon tree
+<C>Isolation -- <F>I don't <B>want to <A7>sit on a lemon tree
 
 \zs
 I'm steppin' around in a desert of joy, baby anyhow I'll get another toy
@@ -61,7 +61,7 @@ And everything will happen -- and you'll wonder
 
 \zr\kr
 
-...3× /: And \Ch{B}{all that} I can \Ch{C}{see} :/
-is just a yellow \Ch{F}{lemon tree}
+...3× /: And <B>all that I can <C>see :/
+is just a yellow <F>lemon tree
 
 \kp

--- a/tp-songs/03_zahranicni/George_Gershwin____Summertime.tex
+++ b/tp-songs/03_zahranicni/George_Gershwin____Summertime.tex
@@ -3,17 +3,17 @@
 \zp{Summertime}{George Gershwin}
 
 \zs
-Summer\Ch{Ami}{time,} \Ch{E7}{} \Ch{Ami}{and the} \Ch{E7}{livin' is} 
-\Ch{Ami}{easy} \Ch{E7}{} \Ch{Ami}{} \Ch{E7}{}
+Summer<Ami>time, <E7> <Ami>and the <E7>livin' is 
+<Ami>easy <E7> <Ami> <E7>
 
-\Ch{Ami}{Fish are} \Ch{Dmi}{jumpin'} \Ch{Dmi7}{} and the \Ch{D#dim}{cotton is} 
-\Ch{E}{high} \Ch{E7}{}
+<Ami>Fish are <Dmi>jumpin' <Dmi7> and the <D#dim>cotton is 
+<E>high <E7>
  
-Your daddy's \Ch{Ami}{rich,} \Ch{E7}{} \Ch{Ami}{and your} \Ch{E7}{momma's 
-good} \Ch{Ami}{lookin'} \Ch{E7}{} \Ch{Ami}{} \Ch{E7}{}
+Your daddy's <Ami>rich, <E7> <Ami>and your <E7>momma's 
+good <Ami>lookin' <E7> <Ami> <E7>
 
-\Ch{Ami}{So} \Ch{C}{hush little} \Ch{Dmi}{baby,} \Ch{E7}{don't} you 
-\Ch{Ami}{cry} \Ch{E7}{} \Ch{Ami}{} \Ch{E7}{}
+<Ami>So <C>hush little <Dmi>baby, <E7>don't you 
+<Ami>cry <E7> <Ami> <E7>
 \ks
 
 \zs
@@ -21,7 +21,7 @@ One of these mornings, you're gonna rise up singing
 
 Then you'll spread your wings and you'll take to the sky
 
-But till that morning,  there's nothin' can harm you
+But till that morning, there's nothin' can harm you
 
 With daddy and mammy standing by
 \ks
@@ -31,30 +31,30 @@ With daddy and mammy standing by
 	A-moll
 	\begin{table}[h]
 	\begin{tabular}{|ll|ll|ll|ll|}
-\Ch{Ami}{~} & \Ch{E7}{~}   & \Ch{Ami}{~}   & \Ch{E7}{~}          & \Ch{Ami}{~} 
-& \Ch{E7}{~} & \Ch{Ami}{~} & \Ch{E7}{~}  \Ch{Ami}{~}	\\
-\Ch{Dmi}{~} &                   & \Ch{Dmi7}{~} & \Ch{D#dim}{~} & \Ch{E}{~}     
-&                 & \Ch{E}{~}     & \Ch{E7}{~}  	\\
-\Ch{Ami}{~} & \Ch{E7}{~}   & \Ch{Ami}{~}   & \Ch{E7}{~}          & \Ch{Ami}{~} 
-& \Ch{E7}{~} & \Ch{Ami}{~} & \Ch{E7}{~} \Ch{Ami}{~} 	\\
-  \Ch{C}{~}    & \Ch{Dmi}{~} & \Ch{E7}{~}     
-  &                          & \Ch{Ami}{~} & \Ch{E7}{~} & \Ch{Ami}{~} 
-  & \Ch{E7}{~}  \\
+<Ami>~ & <E7>~ & <Ami>~ & <E7>~ & <Ami>~ 
+& <E7>~ & <Ami>~ & <E7>~ <Ami>~	\\
+<Dmi>~ & & <Dmi7>~ & <D#dim>~ & <E>~ 
+& & <E>~ & <E7>~ 	\\
+<Ami>~ & <E7>~ & <Ami>~ & <E7>~ & <Ami>~ 
+& <E7>~ & <Ami>~ & <E7>~ <Ami>~ 	\\
+ <C>~ & <Dmi>~ & <E7>~ 
+ & & <Ami>~ & <E7>~ & <Ami>~ 
+ & <E7>~ \\
 	\end{tabular}
 	\end{table}
 	
-  H-moll
+ H-moll
 	\begin{table}[h]
 	\begin{tabular}{|ll|ll|ll|ll|}
-\Ch{Hmi}{~} & \Ch{F#7}{~}   & \Ch{Hmi}{~}   & \Ch{F#7}{~}          & \Ch{Hmi}{~} 
-& \Ch{F#7}{~} & \Ch{Hmi}{~} & \Ch{F#7}{~}  \Ch{Hmi	}{~}\\
-\Ch{Emi}{~} &                      & \Ch{Emi7}{~} & \Ch{Fdim}{~}       
-& \Ch{F#}{~}   &                   & \Ch{F#}{~}   & \Ch{	F#7}{~}  \\
-\Ch{Hmi}{~} & \Ch{F#7}{~}   & \Ch{Hmi}{~}   & \Ch{F#7}{~}          
-& \Ch{Hmi}{~} & \Ch{F#7}{~} & \Ch{Hmi}{~} & \Ch{F#7}{~} \Ch{Hmi}	{~} \\
-\Ch{D}{~}    & \Ch{Emi}{~}    & \Ch{F#7}{~}     
-&                          & \Ch{Hmi}{~} & \Ch{F#7}{~} & \Ch{Hmi}{~} 
-& \Ch{F#7}{~	}  \\
+<Hmi>~ & <F#7>~ & <Hmi>~ & <F#7>~ & <Hmi>~ 
+& <F#7>~ & <Hmi>~ & <F#7>~ <Hmi	>~\\
+<Emi>~ & & <Emi7>~ & <Fdim>~ 
+& <F#>~ & & <F#>~ & <	F#7>~ \\
+<Hmi>~ & <F#7>~ & <Hmi>~ & <F#7>~ 
+& <Hmi>~ & <F#7>~ & <Hmi>~ & <F#7>~ <Hmi>~ \\
+<D>~ & <Emi>~ & <F#7>~ 
+& & <Hmi>~ & <F#7>~ & <Hmi>~ 
+& <F#7>~	 \\
 	\end{tabular}
 	\end{table}
 \fi

--- a/tp-songs/03_zahranicni/Georges_Brassens____Fernande.tex
+++ b/tp-songs/03_zahranicni/Georges_Brassens____Fernande.tex
@@ -3,28 +3,28 @@
 \zp{Fernande}{Georges Brassens}
 
 \zs
-\Ch{C}{Une manie} de vieux garçon,
-moi \Ch{F}{j'ai pris} l'habi\Ch{E}{tude}
+<C>Une manie de vieux garçon,
+moi <F>j'ai pris l'habi<E>tude
 
-\Ch{G}{D'agré}\Ch{A7}{menter} ma\Ch{Dmi}{ soli}\Ch{E}{tude,}
-aux \Ch{D7}{accents} \Ch{G7}{de cette} chan\Ch{C}{son} \Ch{D7}{}
+<G>D'agré<A7>menter ma<Dmi> soli<E>tude,
+aux <D7>accents <G7>de cette chan<C>son <D7>
 \ks
 
 \zr 
-Quand \Ch{G}{je pense} à Fer\Ch{Ami}{nande,}
-je \Ch{D7}{bande,} je \Ch{G}{bande}
+Quand <G>je pense à Fer<Ami>nande,
+je <D7>bande, je <G>bande
 
-Quand j'pense à Féli\Ch{C}{cie,}
-je bande \Ch{G}{aussi}
+Quand j'pense à Féli<C>cie,
+je bande <G>aussi
 
-Quand j'pense à Lé\Ch{C}{onore,}
-mon \Ch{D7}{dieu} je bande en\Ch{G}{core}
+Quand j'pense à Lé<C>onore,
+mon <D7>dieu je bande en<G>core
 
-Mais \Ch{H7}{quand j'pense} à Lu\Ch{Emi}{lu,}
-\Ch{Ami}{là} \Ch{D7}{je ne} bande \Ch{E}{plus}
+Mais <H7>quand j'pense à Lu<Emi>lu,
+<Ami>là <D7>je ne bande <E>plus
 
-La \Ch{H7}{bandaison} pa\Ch{Emi}{pa,
-ça} n'se com\Ch{H7}{man}\Ch{D7}{de} \Ch{G}{pas.} ~~~ \Ch{C}{}
+La <H7>bandaison pa<Emi>pa,
+ça n'se com<H7>man<D7>de <G>pas. ~~~ <C>
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Gerard_Lenorman____La_Ballade.tex
+++ b/tp-songs/03_zahranicni/Gerard_Lenorman____La_Ballade.tex
@@ -5,9 +5,9 @@
 Pátý pražec
 
 \zs
-\Ch{A}{Notre vieille terre} est une étoile, où toi aussi tu \Ch{Hmi}{brilles un} \Ch{E7}{peu}
+<A>Notre vieille terre est une étoile, où toi aussi tu <Hmi>brilles un <E7>peu
 
-Je viens te \Ch{Hmi}{chanter} \Ch{E7}{la} \Ch{A}{ballade,} \Ch{F#mi}{la ballade des} \Ch{E7}{gens} heu\Ch{A}{reux} 
+Je viens te <Hmi>chanter <E7>la <A>ballade, <F#mi>la ballade des <E7>gens heu<A>reux 
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/Israel_Kamakawiwoole____Somewhere_over_the_rainbow.tex
+++ b/tp-songs/03_zahranicni/Israel_Kamakawiwoole____Somewhere_over_the_rainbow.tex
@@ -4,9 +4,9 @@
 
 \zs
 
-\Ch{C}{Somewhere} \Ch{Emi}{over} the rainbow, \Ch{F}{way} up \Ch{C}{high}
+<C>Somewhere <Emi>over the rainbow, <F>way up <C>high
 
-\Ch{F}{And} the \Ch{C}{dreams} that you dream of \Ch{G}{once} in a lulla\Ch{Ami}{by}  \Ch{F}{ }
+<F>And the <C>dreams that you dream of <G>once in a lulla<Ami>by <F> 
 \ks
 \zs
 Somewhere over the rainbow blue birds fly
@@ -15,12 +15,12 @@ And the dreams that you dream of, dreams really do come true
 \ks
 \zr
 
-Some\Ch{C}{day} I'll wish upon a star,
-\Ch{G}{wake} up where the clouds are far be\Ch{Ami}{hind} \Ch{F}{me}
+Some<C>day I'll wish upon a star,
+<G>wake up where the clouds are far be<Ami>hind <F>me
 
-Where\Ch{C}{ trouble} melts like lemon drops
+Where<C> trouble melts like lemon drops
 
-\Ch{G}{High} above the chimney tops is \Ch{Ami}{where} you'll \Ch{F}{find} me
+<G>High above the chimney tops is <Ami>where you'll <F>find me
 \kr
 \zs
 Somewhere over the rainbow bluebirds fly

--- a/tp-songs/03_zahranicni/Joan_Jett____I_Love_Rock_n_Roll.tex
+++ b/tp-songs/03_zahranicni/Joan_Jett____I_Love_Rock_n_Roll.tex
@@ -2,28 +2,28 @@
 
 \zp{I love rock'n'roll}{Joan Jett}
 
-/: \Ch{E}{} \Ch{G}{} \Ch{A}{} \Ch{H}{} \Ch{G}{} :/ \Ch{E}{}
+/: <E> <G> <A> <H> <G> :/ <E>
 
 \zs
-I \Ch{E}{saw} him dancin' there by the record machine
+I <E>saw him dancin' there by the record machine
 
-I knew he must have been about seven\Ch{H}{teen}
+I knew he must have been about seven<H>teen
 
-The \Ch{A}{beat} was goin' \Ch{H}{strong,} \Ch{E}{playin'} my favourite \Ch{A}{song}
+The <A>beat was goin' <H>strong, <E>playin' my favourite <A>song
 
-/: And I could \Ch{H}{tell} it wouldn't be \Ch{A}{long}
+/: And I could <H>tell it wouldn't be <A>long
 
-Till he was with \Ch{H}{me, yeah, me} :/ singin'
+Till he was with <H>me, yeah, me :/ singin'
 \ks
 
 \zr
-\Ch{E}{I love} rock'n'roll \Ch{G}{}
+<E>I love rock'n'roll <G>
 
-So \Ch{A}{put} another dime in the \Ch{H}{jukebox,} baby
+So <A>put another dime in the <H>jukebox, baby
 
-\Ch{E}{I love} rock'n'roll \Ch{G}{}
+<E>I love rock'n'roll <G>
 
-So \Ch{A}{come} an' take your time and \Ch{H}{dance} \Ch{A}{with} \Ch{E}{me}
+So <A>come an' take your time and <H>dance <A>with <E>me
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Las_Ketchup____Aserejé.tex
+++ b/tp-songs/03_zahranicni/Las_Ketchup____Aserejé.tex
@@ -3,34 +3,34 @@
 \zp{Aserejé}{Las Ketchup}
 
 \zs
-\Ch{Dmi}{Mira} lo que se avecina a la vuelta de la esquina viene Diego rumbeando.
+<Dmi>Mira lo que se avecina a la vuelta de la esquina viene Diego rumbeando.
 
 Con la luna en las pupilas y su traje agua marina parece de contrabando.
 
 
-Y donde \Ch{B}{mas no} cabe un alma alli se \Ch{C}{mete} a darse caña
+Y donde <B>mas no cabe un alma alli se <C>mete a darse caña
 
-poseido \Ch{Ami}{por el} ritmo raga\Ch{Dmi}{tanga.}
+poseido <Ami>por el ritmo raga<Dmi>tanga.
 
-Y el \Ch{B}{DJ} que lo conoce toca el \Ch{C}{himno} de las doce
+Y el <B>DJ que lo conoce toca el <C>himno de las doce
 
-para \Ch{Ami}{Diego} la cancion mas de\Ch{Dmi}{seada}
+para <Ami>Diego la cancion mas de<Dmi>seada
 
-y la baila, y la goza, y la \Ch{Bmi}{canta...}
+y la baila, y la goza, y la <Bmi>canta...
 \ks
 
 \zr
-Asere\Ch{Dmi}{jé, ja} deje tejebe tude jebere
+Asere<Dmi>jé, ja deje tejebe tude jebere
 
-sebiunouba majabi an de bugui an de buididi\Ch{C}{pí.}
-
-Aserejé, ja deje tejebe tude jebere
-
-sebiunouba majabi an de bugui an de buididi\Ch{B}{pí.}
+sebiunouba majabi an de bugui an de buididi<C>pí.
 
 Aserejé, ja deje tejebe tude jebere
 
-sebiunouba majabi an de bugui an de buididi\Ch{A}{pí.}
+sebiunouba majabi an de bugui an de buididi<B>pí.
+
+Aserejé, ja deje tejebe tude jebere
+
+sebiunouba majabi an de bugui an de buididi<A>pí.
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Leonard_Cohen____Hallelujah.tex
+++ b/tp-songs/03_zahranicni/Leonard_Cohen____Hallelujah.tex
@@ -2,26 +2,26 @@
 
 \zp{Hallelujah}{Leonard Cohen}
 
-\Ch{C}{}  \Ch{Ami}{}  \Ch{C}{}  \Ch{Ami}{}
+<C> <Ami> <C> <Ami>
 
 \zs
-Now I've \Ch{C}{heard} there was a \Ch{Ami}{secret} chord
+Now I've <C>heard there was a <Ami>secret chord
 
-That \Ch{C}{David} played to \Ch{Ami}{please} the Lord
+That <C>David played to <Ami>please the Lord
 
-But \Ch{F}{you} don't really \Ch{G}{care} for music, \Ch{C}{do} you? \Ch{G}{}
+But <F>you don't really <G>care for music, <C>do you? <G>
 
-It \Ch{C}{goes} like this, the \Ch{F}{fourth}, the \Ch{G}{fifth}
+It <C>goes like this, the <F>fourth, the <G>fifth
 
-The \Ch{Ami}{minor} fall, the \Ch{F}{major} lift
+The <Ami>minor fall, the <F>major lift
 
-The \Ch{G}{baffled} king com\Ch{E}{posing}, Halle\Ch{Dmi}{lujah}
+The <G>baffled king com<E>posing, Halle<Dmi>lujah
 \ks
 
 \zr
-Halle\Ch{F}{lujah}, Halle\Ch{Ami}{lujah}, Halle\Ch{F}{lujah}
+Halle<F>lujah, Halle<Ami>lujah, Halle<F>lujah
 
-Halle\Ch{C}{lu} \Ch{G}{--} \Ch{C}{jah}  \Ch{G}{}
+Halle<C>lu <G>-- <C>jah <G>
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Leonard_Cohen____Suzanne.tex
+++ b/tp-songs/03_zahranicni/Leonard_Cohen____Suzanne.tex
@@ -2,24 +2,24 @@
 
 \zp{Suzanne}{Leonard Cohen}
 \zs
-\Ch{E}{Suzanne takes you down to her place near the river}
+<E>Suzanne takes you down to her place near the river
 
-You can \Ch{A}{hear the boats go by, you can spend the night beside her}
+You can <A>hear the boats go by, you can spend the night beside her
 
-And you \Ch{E}{know that she's half crazy but that's why you want to be there}
+And you <E>know that she's half crazy but that's why you want to be there
 
-And she \Ch{G#mi}{feeds you tea and oranges} \Ch{A}{that come all the way from China}
+And she <G#mi>feeds you tea and oranges <A>that come all the way from China
 
-And just \Ch{E}{when you mean to tell her} \Ch{A}{that you have no love to give her}
+And just <E>when you mean to tell her <A>that you have no love to give her
 
-She gets \Ch{E}{you on her wavelength} and she \Ch{F#mi}{lets her river answer} that you've \Ch{E}{always} been her lover
+She gets <E>you on her wavelength and she <F#mi>lets her river answer that you've <E>always been her lover
 \ks
 \zr
-And you \Ch{G#mi}{want to travel with her,} you \Ch{A}{want to travel blind}
+And you <G#mi>want to travel with her, you <A>want to travel blind
 
-And you \Ch{E}{know that she can trust you} 
+And you <E>know that she can trust you 
 
-For you've \Ch{A}{touched her perfect body} with you \Ch{E}{mind}
+For you've <A>touched her perfect body with you <E>mind
 \kr
 \zs
 And Jesus was a sailor when he walked upon the water

--- a/tp-songs/03_zahranicni/Limp_Bizkit____Behind_blue_eyes.tex
+++ b/tp-songs/03_zahranicni/Limp_Bizkit____Behind_blue_eyes.tex
@@ -3,11 +3,11 @@
 \zp{Behind blue eyes}{Limp Bizkit}
 
 \zs
-\Ch{Emi}{No one} knows what it's \Ch{G}{like}
-to be the \Ch{D}{bad} man
+<Emi>No one knows what it's <G>like
+to be the <D>bad man
 
-To be the \Ch{C}{sad} man
-be\Ch{A}{hind} blue eyes
+To be the <C>sad man
+be<A>hind blue eyes
 
 And no one knows
 what it's like to be hated
@@ -16,15 +16,15 @@ To be fated to telling only lies
 \ks
 
 \zr
-But my \Ch{C}{dre}\Ch{D}{ams} they aren't as \Ch{G}{empty}
+But my <C>dre<D>ams they aren't as <G>empty
 
-As my \Ch{C}{con}science \Ch{D}{seems} to \Ch{E4}{be} \Ch{Emi}{}
+As my <C>conscience <D>seems to <E4>be <Emi>
 
-I have \Ch{Hmi}{hours,} only \Ch{C}{lonely}
+I have <Hmi>hours, only <C>lonely
 
-My love is \Ch{D}{vengeance}
+My love is <D>vengeance
 
-That's never \Ch{A}{free}
+That's never <A>free
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Liquido____Narcotic.tex
+++ b/tp-songs/03_zahranicni/Liquido____Narcotic.tex
@@ -4,11 +4,11 @@
 
 \zs
 
-\Ch{C}{So you face it} with a \Ch{Dmi}{smile}                                
+<C>So you face it with a <Dmi>smile 
 
-There is no need to \Ch{F}{cry}
+There is no need to <F>cry
 
-For a trifle's more than \Ch{C}{this}
+For a trifle's more than <C>this
 \ks
 
 \zs
@@ -28,15 +28,15 @@ Did I fear the consequence?
 \ks
 
 \zr
-\Ch{C}{Dazed by} careless \Ch{Dmi}{words}         
+<C>Dazed by careless <Dmi>words 
 
-Cosy in my \Ch{F}{mi}\Ch{Dmi}{nd} \Ch{C}{} 
+Cosy in my <F>mi<Dmi>nd <C> 
 
-\Ch{C}{I don't} \Ch{Dmi}{mind}            
+<C>I don't <Dmi>mind 
 
-I think \Ch{F}{so}         
+I think <F>so 
 
-I will \Ch{C}{let you go}
+I will <C>let you go
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Lou_Reed____Perfect_day.tex
+++ b/tp-songs/03_zahranicni/Lou_Reed____Perfect_day.tex
@@ -4,31 +4,31 @@
 
 
 
-\Ch{E}{}  \Ch{Ami}{}  \Ch{E}{}  \Ch{Ami}{}
+<E> <Ami> <E> <Ami>
 
 \zs
 
-\Ch{Ami}{Just a} \Ch{D}{perfect} day,
-\Ch{G}{drink} Sangria \Ch{C}{in the park}
+<Ami>Just a <D>perfect day,
+<G>drink Sangria <C>in the park
 
-\Ch{F}{And} then later, when \Ch{Dmi}{it gets} dark,
-we go \Ch{E}{home}
+<F>And then later, when <Dmi>it gets dark,
+we go <E>home
 
-\Ch{Ami}{Just} a \Ch{D}{perfect} day,
-\Ch{G}{feed} animals \Ch{C}{in the} zoo
+<Ami>Just a <D>perfect day,
+<G>feed animals <C>in the zoo
 
-\Ch{F}{Then} later a \Ch{Dmi}{movie,} too,
-and then \Ch{E}{home}
+<F>Then later a <Dmi>movie, too,
+and then <E>home
 
 \bigskip
 
-Oh \Ch{A}{it's such} a \Ch{D}{perfect} day
+Oh <A>it's such a <D>perfect day
 
-\Ch{C#mi}{I'm glad I} spent it with \Ch{D}{you}
+<C#mi>I'm glad I spent it with <D>you
 
-\Ch{A}{Oh such} a \Ch{E}{perfect} day
+<A>Oh such a <E>perfect day
 
-/: You just \Ch{F#mi}{keep me} \Ch{E}{hanging} \Ch{D}{on} :/
+/: You just <F#mi>keep me <E>hanging <D>on :/
 \ks
 
 
@@ -58,7 +58,7 @@ Oh such a perfect day
 
 
 4× /:
-\Ch{C#mi}{You're} going to \Ch{G}{reap} just what you \Ch{D}{sow}  \Ch{A}{}
+<C#mi>You're going to <G>reap just what you <D>sow <A>
 :/
 
 

--- a/tp-songs/03_zahranicni/Lynyrd_Skynyrd____Sweet_home_Alabama.tex
+++ b/tp-songs/03_zahranicni/Lynyrd_Skynyrd____Sweet_home_Alabama.tex
@@ -3,7 +3,7 @@
 \zp{Sweet home Alabama}{Lynyrd Skynyrd}
 
 \zs
-\Ch{D}{Big} whee\Ch{Cmaj7}{ls keep} on tu\Ch{G}{rning}.
+<D>Big whee<Cmaj7>ls keep on tu<G>rning.
 Carry me home to see my kin!
 
 Singing songs about the Southland,
@@ -41,7 +41,7 @@ Does your conscience bother you?
 Tell the truth
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 Now Muscle Shoals has got the Swampers
@@ -54,7 +54,7 @@ They pick me up when I'm feeling blue.
 Now how about you?
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zr
 Sweet home Alabama,

--- a/tp-songs/03_zahranicni/Mamas__Papas____California_dreaming.tex
+++ b/tp-songs/03_zahranicni/Mamas__Papas____California_dreaming.tex
@@ -2,24 +2,24 @@
 
 \zp{California dreaming}{Mamas \& Papas}
 \zs
-All {the} leaves are \Ch{Ami}{brown} (all the \Ch{G}{leaves} are \Ch{F}{brown})
+All {the} leaves are <Ami>brown (all the <G>leaves are <F>brown)
 
-And the \Ch{G}{sky} is \Ch{E}{gray} (and the sky is \Ch{E7}{gray})
+And the <G>sky is <E>gray (and the sky is <E7>gray)
 
-I've \Ch{F}{been} for a \Ch{C}{walk} (I've been \Ch{E7}{for a} \Ch{Ami}{walk)}
+I've <F>been for a <C>walk (I've been <E7>for a <Ami>walk)
 
-On a \Ch{F}{winter's} \Ch{E}{day}  (on a winter's \Ch{E7}{day)}
+On a <F>winter's <E>day (on a winter's <E7>day)
 
-I'd {be} safe and \Ch{Ami}{warm} (I'd be \Ch{G}{safe} and \Ch{F}{warm)}
+I'd {be} safe and <Ami>warm (I'd be <G>safe and <F>warm)
 
-If I \Ch{G}{was in} \Ch{E}{L.A.}  (if I was in L.\Ch{E7}{A.)}
+If I <G>was in <E>L.A. (if I was in L.<E7>A.)
 
 \ks
 
 \zr
-Cali{fornia} \Ch{Ami}{dream}in' (Cali\Ch{G}{fornia} \Ch{F}{dreamin')}
+Cali{fornia} <Ami>dreamin' (Cali<G>fornia <F>dreamin')
 
-On \Ch{G}{such a} winter's \Ch{E}{day} \Ch{E7}{}
+On <G>such a winter's <E>day <E7>
 \kr
 
 \zs
@@ -43,13 +43,13 @@ He knows I'm gonna stay (knows I'm gonna stay)
 
 All the leaves are brown (all the leaves are brown)
 
-And the sky is gray   (and the sky is gray)
+And the sky is gray (and the sky is gray)
 
 I've been for a walk (I've been for a walk)
 
-On a winter's day  (on a winter's day)
+On a winter's day (on a winter's day)
 
-If I didn't tell her   (if I didn't tell her)
+If I didn't tell her (if I didn't tell her)
 
 I could leave today (I could leave today)
 

--- a/tp-songs/03_zahranicni/Mary_Hopkin____Those_Were_the_Days.tex
+++ b/tp-songs/03_zahranicni/Mary_Hopkin____Those_Were_the_Days.tex
@@ -3,27 +3,27 @@
 \zp{Those were the days}{Mary Hopkin}
 
 \zs
-\Ch{Emi}{Once upon} a time there was a tavern
+<Emi>Once upon a time there was a tavern
 
-\Ch{E7}{Where} we used to raise a glass or \Ch{Ami}{two}
+<E7>Where we used to raise a glass or <Ami>two
 
-Remember how we laughed away the \Ch{Emi}{hours}
+Remember how we laughed away the <Emi>hours
 
-And \Ch{H7}{think} of all the great things we would do
+And <H7>think of all the great things we would do
 \ks
 
 \zr
-Those were the \Ch{Emi}{days, my friend}
+Those were the <Emi>days, my friend
 
-We thought they'd \Ch{Ami}{never end}
+We thought they'd <Ami>never end
 
-We'd sing and \Ch{D}{dance} for ever and a \Ch{G}{day}
+We'd sing and <D>dance for ever and a <G>day
 
-We'd live the \Ch{Ami}{life we choose}
+We'd live the <Ami>life we choose
 
-We'd fight and \Ch{Emi}{never lose}
+We'd fight and <Emi>never lose
 
-For we were \Ch{H7}{young} and sure to have our \Ch{Emi}{way}
+For we were <H7>young and sure to have our <Emi>way
 
 La la la la la la...
 \kr

--- a/tp-songs/03_zahranicni/Meredith_Brooks____Bitch.tex
+++ b/tp-songs/03_zahranicni/Meredith_Brooks____Bitch.tex
@@ -1,15 +1,15 @@
 \zp{Bitch}{Meredith Brooks} 
 
-/: \Ch{A}{~~~~~~~~~} \Ch{E}{} \Ch{D}{} :/
+/: <A>~~~~~~~~~ <E> <D> :/
 
 \zs
-I \Ch{A}{hate the world today.} \Ch{E}{}\Ch{D}{}
+I <A>hate the world today. <E><D>
 You're so good to me I
-\Ch{A}{know but I can't change} \Ch{E}{}\Ch{D}{}
+<A>know but I can't change <E><D>
 
-Tried to tell you but you \Ch{F#mi}{look at me like maybe}
+Tried to tell you but you <F#mi>look at me like maybe
 
-I'm and \Ch{H7}{angel} underneath \Ch{D}{innocent and sweet}
+I'm and <H7>angel underneath <D>innocent and sweet
  \ks
 
 \zs
@@ -21,13 +21,13 @@ I'm a little bit of everything all rolled into one
 \ks
 
 \zr
-I'm a \Ch{A}{bitch,} I'm a lover, I'm a \Ch{E}{child} I'm a mother
+I'm a <A>bitch, I'm a lover, I'm a <E>child I'm a mother
 
-I'm a \Ch{Hmi}{sinner,} I'm a saint, I \Ch{D}{do not feel ashamed}
+I'm a <Hmi>sinner, I'm a saint, I <D>do not feel ashamed
 
-I'm your \Ch{A}{hell,} I'm your dream, I'm \Ch{E}{nothing in between}
+I'm your <A>hell, I'm your dream, I'm <E>nothing in between
 
-You know you \Ch{F#mi}{wouldn't} want it any other \Ch{D}{way}
+You know you <F#mi>wouldn't want it any other <D>way
 \kr
 
 \zs
@@ -44,17 +44,17 @@ And I'm going to extreme tomorrow I will change and today won't mean a thing
 
 \zr (solo) \kr
 
-\Ch{E}{Just when you think you got me} figured out \Ch{F#mi}{the season's 
-already} \Ch{D}{changin'}
+<E>Just when you think you got me figured out <F#mi>the season's 
+already <D>changin'
 
-\Ch{E}{I think it's cool} you \Ch{F#mi}{do what ya do} and \Ch{D}{don't try 
-to} save me
+<E>I think it's cool you <F#mi>do what ya do and <D>don't try 
+to save me
 
 \zr
 \kr
 
 \zr
-I'm a bitch, I'm a tease  I'm a goddess on my knees
+I'm a bitch, I'm a tease I'm a goddess on my knees
 
 When you hurt, when you suffer, I'm your angel undercover
 
@@ -63,8 +63,8 @@ I've been numb, I'm revived, can't say I'm not alive
 You know I wouldn't want it any other way
 \kr
 
-\Ch{A}{}  \Ch{E}{}  \Ch{F#mi}{}  \Ch{D}{}  
-\Ch{A}{}  \Ch{E}{} \Ch{F#mi}{}  \Ch{D}{} 
-\Ch{A}{}
+<A> <E> <F#mi> <D> 
+<A> <E> <F#mi> <D> 
+<A>
 
 \kp

--- a/tp-songs/03_zahranicni/Michel_Teló____Ai_se_eu_te_pego.tex
+++ b/tp-songs/03_zahranicni/Michel_Teló____Ai_se_eu_te_pego.tex
@@ -3,8 +3,8 @@
 \zp{Ai se eu te pego}{Michel Teló}
 \zr
 
-\Ch{C}{Nossa,} \Ch{G}{nossa,}
-as\Ch{Ami}{sim você} me \Ch{F}{mata}
+<C>Nossa, <G>nossa,
+as<Ami>sim você me <F>mata
 
 Ai se eu te pego,
 ai ai se eu te pego
@@ -17,10 +17,10 @@ ai ai se eu te pego
 \kr
 
 
-\Ch{C}{} \Ch{G}{} \Ch{Ami}{} \Ch{F}{} ~ \Ch{C}{} \Ch{G}{} \Ch{F}{}
+<C> <G> <Ami> <F> ~ <C> <G> <F>
 
 \zs
-\Ch{C}{Sábado} \Ch{G}{na b}\Ch{Ami}{alad}\Ch{F}{a}
+<C>Sábado <G>na b<Ami>alad<F>a
 
 A galera começou a dançar
 

--- a/tp-songs/03_zahranicni/Morcheeba____Rome_Wasnt_Built_In_a_Day.tex
+++ b/tp-songs/03_zahranicni/Morcheeba____Rome_Wasnt_Built_In_a_Day.tex
@@ -3,25 +3,25 @@
 \zp{Rome wasn't built in a day}{Morcheeba}
 
 \zr
-You and \Ch{C}{me,} we're meant to be
+You and <C>me, we're meant to be
 
-Walking \Ch{B}{free} in harmo\Ch{F}{ny}
+Walking <B>free in harmo<F>ny
 
-One fine \Ch{C}{day} we'll fly away
+One fine <C>day we'll fly away
 
-Don't you know that \Ch{B}{Rome wasn't} built in a \Ch{F}{day}
+Don't you know that <B>Rome wasn't built in a <F>day
 
-Hey, hey, \Ch{C}{hey!}
+Hey, hey, <C>hey!
 \kr
 
 \zs
-In \Ch{C}{this} day and \Ch{B}{age it's so} easy to \Ch{C}{stress}
+In <C>this day and <B>age it's so easy to <C>stress
 
-'Cause people are \Ch{F}{strange} and you can never second \Ch{G}{guess}
+'Cause people are <F>strange and you can never second <G>guess
 
-In order to \Ch{B}{love, child,} we got to be \Ch{C}{strong}
+In order to <B>love, child, we got to be <C>strong
 
-I'm caught in the \Ch{F}{crossfire,} why can't we get a\Ch{G}{long?} \Ch{F}{}
+I'm caught in the <F>crossfire, why can't we get a<G>long? <F>
 \ks
 
 \zr\kr

--- a/tp-songs/03_zahranicni/Mungo_Jerry____Summertime.tex
+++ b/tp-songs/03_zahranicni/Mungo_Jerry____Summertime.tex
@@ -4,29 +4,29 @@
 
 \ifdefined\TPBAND
 
-	Intro:  
+	Intro: 
 	| E – E | E – E | A – A | E – E | B – A | E – E | 
 \fi
 
 \zs
-In the \Ch{E}{summertime} when the weather is high
-                              
+In the <E>summertime when the weather is high
+ 
 You can stretch right up and touch the sky
 
-When the \Ch{A}{weather} is fine, you got women, you got women on your \Ch{E}{mind}
+When the <A>weather is fine, you got women, you got women on your <E>mind
 
-Have a \Ch{B}{drink,} have a drive
+Have a <B>drink, have a drive
 
-\Ch{A}{Go out} and see what you can \Ch{E}{find}
+<A>Go out and see what you can <E>find
 \ks
 
 \zs
 If her daddy's rich, take her out for a meal
-                           
+ 
 If her daddy's poor, just do as you feel
 
 Speed along the lane, do a ton or a ton and twenty-five
-         
+ 
 When the sun goes down
 
 You can make it make it good in a lay-by
@@ -34,7 +34,7 @@ You can make it make it good in a lay-by
 
 \zs
 We're not grey people, we're not dirty, we're not mean
-                             
+ 
 We love everybody but we do as we please
 
 When the weather is fine, we go fishing or go swimming in the sea
@@ -46,7 +46,7 @@ Life's for living, yeah, that's our philosophy
 
 \zs
 Sing along with us, da da di di di 
-                       
+ 
 Da da da da, yeah, we're happy 
 
 Da da da da, di di di di di da da da 
@@ -63,11 +63,11 @@ Da da da da da da da da da da da da
 
 \zs
 When the winter's here, yeah, it's party-time,
-                                                       
+ 
 Bring a bottle, wear your bright clothes, it'll soon be summertime
 
 And we'll sing again, we'll go driving or maybe we'll settle down
-                
+ 
 If she's rich, if she's nice
 
 Bring your friend and we will all go into town

--- a/tp-songs/03_zahranicni/Nancy_Sinatra____These_Boots_Are_Made_For_Walking.tex
+++ b/tp-songs/03_zahranicni/Nancy_Sinatra____These_Boots_Are_Made_For_Walking.tex
@@ -3,21 +3,21 @@
 \zp{These boots are made for walking}{Nancy Sinatra}
 
 \zs
-\Ch{E7}{You keep} saying you've got something for me
+<E7>You keep saying you've got something for me
 
 Something you call love, but confess
 
-\Ch{A7}{You've} been messing where you shouldn't be messing
+<A7>You've been messing where you shouldn't be messing
 
-And now \Ch{E7}{someone} else is getting all your best
+And now <E7>someone else is getting all your best
 \ks
 
 \zr
-These \Ch{G}{boots} are made for \Ch{E}{walking}
+These <G>boots are made for <E>walking
 
-And \Ch{G}{that's} just what they'll \Ch{E}{do}
+And <G>that's just what they'll <E>do
 
-\Ch{G}{One of} these day these \Ch{E}{boots} are gonna
+<G>One of these day these <E>boots are gonna
 
 Walk all over you
 \kr

--- a/tp-songs/03_zahranicni/Natalie_Imbruglia____Torn.tex
+++ b/tp-songs/03_zahranicni/Natalie_Imbruglia____Torn.tex
@@ -1,41 +1,41 @@
 \zp{Torn}{Natalie Imbruglia} 
 
-\Ch{F}{}  \Ch{Bb}{} \Ch{F}{} \Ch{B}{}
+<F> <Bb> <F> <B>
 
 \zs
-\Ch{F}{I thought I saw a man brought to life}
+<F>I thought I saw a man brought to life
 
-\Ch{Ami}{He was warm,} he came around like he was \Ch{Bb}{dignified}
+<Ami>He was warm, he came around like he was <Bb>dignified
 
 He showed me what it was to cry
 
-\Ch{F}{Well you couldn't be that man I adored}               
+<F>Well you couldn't be that man I adored 
 
-\Ch{Ami}{You don't seem to know.} Don't seem to care what your \Ch{Bb}{heart is for}
+<Ami>You don't seem to know. Don't seem to care what your <Bb>heart is for
 
 But I don't know him anymore 
 
-There's \Ch{Dmi}{nothing where he used to lie}
+There's <Dmi>nothing where he used to lie
 
-\Ch{C}{My conversation has run dry}
+<C>My conversation has run dry
 
-\Ch{Ami}{That's what's going on}
+<Ami>That's what's going on
 
-\Ch{C}{Nothing's fine}
+<C>Nothing's fine
 
-I'm \Ch{F}{torn}
+I'm <F>torn
 \ks
 
 \zr
-I'm all out of \Ch{C}{faith, this is how I} \Ch{Dmi}{feel}
+I'm all out of <C>faith, this is how I <Dmi>feel
 
-I'm cold and I am \Ch{Bb}{shamed,} lying naked on the \Ch{F}{floor}
+I'm cold and I am <Bb>shamed, lying naked on the <F>floor
 
-Illusion never \Ch{C}{changed into} something \Ch{Dmi}{real}
+Illusion never <C>changed into something <Dmi>real
 
-I'm wide awake and \Ch{Bb}{I can see} the perfect sky is \Ch{F}{torn}
+I'm wide awake and <Bb>I can see the perfect sky is <F>torn
 
-You're a little \Ch{C}{late,} I'm already \Ch{Dmi}{torn} \Ch{Bb}{}
+You're a little <C>late, I'm already <Dmi>torn <Bb>
 \kr
 
 \zs
@@ -58,21 +58,21 @@ I'm torn
 
 \zr
 \kr
-...\Ch{Dmi}{Torn...}
+...<Dmi>Torn...
 
 Bridge: (bass only)
 
-\Ch{Dmi}{Ooooh}...  Hoo \Ch{F}{ooooh}...  \Ch{C}{Ooooh}
+<Dmi>Ooooh... Hoo <F>ooooh... <C>Ooooh
 \zs
-There's \Ch{Dmi}{nothing where he used to lie}
+There's <Dmi>nothing where he used to lie
 
-\Ch{C}{My conversation has run dry}
+<C>My conversation has run dry
 
-\Ch{Ami}{That's what's going on}
+<Ami>That's what's going on
 
-\Ch{C}{Nothing's fine}
+<C>Nothing's fine
 
-I'm \Ch{F}{torn}
+I'm <F>torn
 \ks
 
 \zr

--- a/tp-songs/03_zahranicni/Nick_Cave____Where_the_Wild_Roses_Grow.tex
+++ b/tp-songs/03_zahranicni/Nick_Cave____Where_the_Wild_Roses_Grow.tex
@@ -1,20 +1,20 @@
 \zp{Where the wild roses grow}{Leonard Cohen and Nick Cave}
 
 \zr
-They \Ch{Emi}{called} me The Wild \Ch{Ami}{Rose} \Ch{Emi}{but} my \Ch{G}{name} was Elisa \Ch{H}{Day}
+They <Emi>called me The Wild <Ami>Rose <Emi>but my <G>name was Elisa <H>Day
 
-Why they \Ch{Emi}{called} me it I do not \Ch{Ami}{know} \Ch{Emi}{for my} name was \Ch{D}{Elisa} \Ch{Emi}{Day}
+Why they <Emi>called me it I do not <Ami>know <Emi>for my name was <D>Elisa <Emi>Day
 \kr
 
 He:
 \zs
-From the \Ch{Emi}{first} day I saw her I knew \Ch{G}{she} was the one 
+From the <Emi>first day I saw her I knew <G>she was the one 
 
-She \Ch{Ami}{stared} in my eyes and \Ch{H}{smiled}
+She <Ami>stared in my eyes and <H>smiled
 
-For her \Ch{Emi}{lips} were the color of the \Ch{G}{roses} 
+For her <Emi>lips were the color of the <G>roses 
 
-That \Ch{Ami}{grew} down the river, all \Ch{H}{bloody} and wild
+That <Ami>grew down the river, all <H>bloody and wild
 \ks
 
 Elisa:
@@ -81,7 +81,7 @@ They called me The Wild Rose but my name was Elisa Day
 
 Why they called me it I do not know
 
-3× /: For my \Ch{Emi}{name} was \Ch{D}{Elisa} \Ch{Emi}{Day} :/
+3× /: For my <Emi>name was <D>Elisa <Emi>Day :/
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/No_Doubt____Dont_Speak.tex
+++ b/tp-songs/03_zahranicni/No_Doubt____Dont_Speak.tex
@@ -3,91 +3,91 @@
 \zp{Don't speak}{No Doubt}
 
 \zs
-\Ch{Hmi}{You and me,} we \Ch{F#mi}{used to be} to\Ch{Emi}{gether}
+<Hmi>You and me, we <F#mi>used to be to<Emi>gether
 
-\Ch{A}{Everyday to}\Ch{F#mi}{gether,} \Ch{Emi}{always} \Ch{A}{}
+<A>Everyday to<F#mi>gether, <Emi>always <A>
 
-I \Ch{Hmi}{really fe}\Ch{F#mi}{el that I'm} \Ch{Emi}{losing my} \Ch{A}{best friend}
+I <Hmi>really fe<F#mi>el that I'm <Emi>losing my <A>best friend
 
-I \Ch{F#mi}{can't believe} this \Ch{Hmi}{could be} \Ch{Emi}{the end} \Ch{A}{}
+I <F#mi>can't believe this <Hmi>could be <Emi>the end <A>
 
-It \Ch{Hmi}{looks as} \Ch{F#mi}{though you'}\Ch{Emi}{re letting} \Ch{A}{go}
+It <Hmi>looks as <F#mi>though you'<Emi>re letting <A>go
 
-And \Ch{D}{if it's real} -- well \Ch{A}{I don't want} to \Ch{H}{know}
+And <D>if it's real -- well <A>I don't want to <H>know
 \ks
 
 \zr
-\Ch{Emi}{Don't speak}
+<Emi>Don't speak
 
-\Ch{Ami}{I know} what you're \Ch{D}{saying}
+<Ami>I know what you're <D>saying
 
-\Ch{H}{So please} stop \Ch{Ami}{explaining}
+<H>So please stop <Ami>explaining
 
-Don't \Ch{H}{tell me} cause it \Ch{Emi}{hurts} \Ch{Ami}{} \Ch{H}{}
+Don't <H>tell me cause it <Emi>hurts <Ami> <H>
 
-\Ch{Emi}{Don't speak}
+<Emi>Don't speak
 
-\Ch{Ami}{I know what} you're \Ch{D}{thinking}
+<Ami>I know what you're <D>thinking
 
-And \Ch{H}{I don't} need your \Ch{Ami}{reasons}
+And <H>I don't need your <Ami>reasons
 
-Don't \Ch{H}{tell me} cause it \Ch{Emi}{hurts} \Ch{C}{} \Ch{D}{}
+Don't <H>tell me cause it <Emi>hurts <C> <D>
 \kr
 
 \zs
-Our \Ch{Hmi}{memories,} \Ch{F#mi}{} well, \Ch{Emi}{they can be} in\Ch{A}{viting}
+Our <Hmi>memories, <F#mi> well, <Emi>they can be in<A>viting
 
-But some are \Ch{F#mi}{altogether} \Ch{Hmi}{mighty} \Ch{Emi}{frightening} \Ch{A}{}
+But some are <F#mi>altogether <Hmi>mighty <Emi>frightening <A>
 
-\Ch{Hmi}{As we} \Ch{F#mi}{die, both} \Ch{Emi}{you and} \Ch{A}{I}
+<Hmi>As we <F#mi>die, both <Emi>you and <A>I
 
-\Ch{D}{With} my head in my \Ch{A}{hands} I sit and \Ch{H}{cry}
+<D>With my head in my <A>hands I sit and <H>cry
 \ks
 
 \zr\kr
 
-\Ch{Emi}{} \Ch{D}{} \Ch{H}{} \Ch{G}{}
+<Emi> <D> <H> <G>
 
 \zs
-\Ch{C}{It's all} \Ch{G}{ending}
+<C>It's all <G>ending
 
-I gotta \Ch{B}{stop pre}\Ch{F}{tending} who we \Ch{G#}{are...} \Ch{G6}{} \Ch{G}{}
+I gotta <B>stop pre<F>tending who we <G#>are... <G6> <G>
 
-3× /: \Ch{Hmi}{} \Ch{F#mi}{} \Ch{Emi}{} \Ch{A}{} :/ \Ch{F#mi}{} \Ch{Hmi}{} \Ch{F#}{}
+3× /: <Hmi> <F#mi> <Emi> <A> :/ <F#mi> <Hmi> <F#>
 
-\Ch{Hmi}{You and me} \Ch{F#mi}{} \Ch{Emi}{I can see us} \Ch{A}{dying...} \Ch{Emi}{are we?} \Ch{A}{}
+<Hmi>You and me <F#mi> <Emi>I can see us <A>dying... <Emi>are we? <A>
 \ks
 
 \zr
-\Ch{Emi}{Don't speak}
+<Emi>Don't speak
 
-I \Ch{Ami}{know just} what you're \Ch{D}{saying}
+I <Ami>know just what you're <D>saying
 
-\Ch{H}{So please} stop \Ch{Ami}{explaining}
+<H>So please stop <Ami>explaining
 
-Don't \Ch{H}{tell me} cause it \Ch{Emi}{hurts} \Ch{Ami}{} \Ch{H}{}
+Don't <H>tell me cause it <Emi>hurts <Ami> <H>
 
-\Ch{Emi}{Don't speak}
+<Emi>Don't speak
 
-\Ch{Ami}{I know what} you're \Ch{D}{thinking}
+<Ami>I know what you're <D>thinking
 
-\Ch{H}{I don't} need your \Ch{Ami}{reasons}
+<H>I don't need your <Ami>reasons
 
-Don't \Ch{H}{tell me} cause it \Ch{Emi}{hurts}
+Don't <H>tell me cause it <Emi>hurts
 
-Don't \Ch{Ami}{tell me} \Ch{H}{cause} it \Ch{Emi}{hurts!}
+Don't <Ami>tell me <H>cause it <Emi>hurts!
 
-\Ch{Ami}{I know what} you're \Ch{D}{saying}
+<Ami>I know what you're <D>saying
 
-\Ch{H}{So please} stop \Ch{Ami}{explaining}
+<H>So please stop <Ami>explaining
 
-\Ch{H}{Don't speak,} \Ch{Emi}{don't speak,} \Ch{Ami}{don't} \Ch{H}{speak,} \Ch{Emi}{oh}
+<H>Don't speak, <Emi>don't speak, <Ami>don't <H>speak, <Emi>oh
 
-\Ch{Ami}{I know what} you're \Ch{D}{thinking}
+<Ami>I know what you're <D>thinking
 
-And \Ch{H}{I don't} need your \Ch{Ami}{reasons}
+And <H>I don't need your <Ami>reasons
 
-I know you're \Ch{D}{good,} I know you're \Ch{Emi}{good, I know you're} \Ch{Ami}{real} \Ch{H}{good}
+I know you're <D>good, I know you're <Emi>good, I know you're <Ami>real <H>good
 
 Oh, la la la la la la...
 

--- a/tp-songs/03_zahranicni/Norah_Jones____Dont_Know_Why.tex
+++ b/tp-songs/03_zahranicni/Norah_Jones____Dont_Know_Why.tex
@@ -29,7 +29,7 @@ My <Gmi7>heart is <C7>drenched in <F>wine <F7>
 
 But <Gmi7>you'll be <C7>on my <F7>mind
  
-<F7/Eb>For-<Bb/D>ev-<F/C>er
+<F7/Eb>For<Bb/D>ev<F/C>er
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Norah_Jones____Dont_Know_Why.tex
+++ b/tp-songs/03_zahranicni/Norah_Jones____Dont_Know_Why.tex
@@ -1,11 +1,11 @@
 \zp{Don't know why}{Norah Jones} 
 
-\Ch{Bbmaj7}{}  \Ch{Bb7}{}  \Ch{Eb}{}  \Ch{D}{}  \Ch{Gmi7}{}  \Ch{C7}{}
+<Bbmaj7> <Bb7> <Eb> <D> <Gmi7> <C7>
 
 \zs
-\Ch{Bbmaj7}{I waited} \Ch{Bb7}{'til I saw} the \Ch{Ebmaj7}{sun} \Ch{D+}{}
+<Bbmaj7>I waited <Bb7>'til I saw the <Ebmaj7>sun <D+>
 
-\Ch{Gmi7}{I don't} know \Ch{C7}{why I didn't} \Ch{F7sus}{come} \Ch{Bb}{}
+<Gmi7>I don't know <C7>why I didn't <F7sus>come <Bb>
 
 I left you by the house of fun
 
@@ -25,11 +25,11 @@ Catching teardrops in my hand
 \ks
 
 \zr
-My \Ch{Gmi7}{heart} is \Ch{C7}{drenched in} \Ch{F}{wine} \Ch{F7}{}
+My <Gmi7>heart is <C7>drenched in <F>wine <F7>
 
-But \Ch{Gmi7}{you'l}l be \Ch{C7}{on my} \Ch{F7}{mind}
-        
-\Ch{F7/Eb}{For-}\Ch{Bb/D}{ev-}\Ch{F/C}{er}
+But <Gmi7>you'll be <C7>on my <F7>mind
+ 
+<F7/Eb>For-<Bb/D>ev-<F/C>er
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Peggy_Lee____Good_Day.tex
+++ b/tp-songs/03_zahranicni/Peggy_Lee____Good_Day.tex
@@ -2,13 +2,13 @@
 
 \zp{Good day}{Peggy Lee}
 \zs
-\Ch{G7}{Yes, it's} a \Ch{C}{good} day for singin' a song
+<G7>Yes, it's a <C>good day for singin' a song
 
-And it's a \Ch{G7}{good day} for \Ch{C}{movin' along} 
+And it's a <G7>good day for <C>movin' along 
 
 Yes, it's a good day, how could anything go wrong
 
-A \Ch{G7}{good day} from mornin' till \Ch{C}{night}
+A <G7>good day from mornin' till <C>night
 \ks
 
 \zs 
@@ -22,15 +22,15 @@ Ev'rything to gain and nothin' to lose
 \ks
 
 \zr
-I \Ch{C7}{said to the sun:} ``\Ch{F}{Good mornin',} \Ch{Fmi}{sun}
+I <C7>said to the sun: ``<F>Good mornin', <Fmi>sun
 
-\Ch{Dmi7}{Rise and shine} today \Ch{G7}{}
+<Dmi7>Rise and shine today <G7>
 
-You know \Ch{C6}{you'}\Ch{C}{ve} go\Ch{C6}{tta} \Ch{Cdim}{get goin'}  
+You know <C6>you'<C>ve go<C6>tta <Cdim>get goin' 
 
-\Ch{Cdim}{If you're gonna make a showin'} 
+<Cdim>If you're gonna make a showin' 
 
-\Ch{F}{And you know} you'\Ch{Dmi7}{ve got the right of} \Ch{G7}{way''}
+<F>And you know you'<Dmi7>ve got the right of <G7>way''
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Pink_Floyd____Another_brick_in_the_wall.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Another_brick_in_the_wall.tex
@@ -3,21 +3,21 @@
 \zp{Another brick in the wall}{Pink Floyd}
 
 \zs
-\Ch{Dmi}{We do}n’t need no education
+<Dmi>We don’t need no education
 
-\Ch{Dmi}{We do}n’t need no thought control
+<Dmi>We don’t need no thought control
 
-\Ch{Dmi}{No da}rk sarcasm in the classroom
+<Dmi>No dark sarcasm in the classroom
 
-\Ch{Dmi}{Teacher} leave them kids alone \Ch{G}{}
+<Dmi>Teacher leave them kids alone <G>
 \ks
 
 \zr
-\Ch{G}{Hey}, teacher! Leave them kids \Ch{Dmi}{alone} \Ch{C}{} \Ch{Dmi}{} \Ch{C}{}  \Ch{Dmi}{} \Ch{C}{} \Ch{Emi}{}  \Ch{Dmi}{} \Ch{F}{}
+<G>Hey, teacher! Leave them kids <Dmi>alone <C> <Dmi> <C> <Dmi> <C> <Emi> <Dmi> <F>
 
-\Ch{F}{All} in all it's just an-\Ch{C}{other} brick in the \Ch{Dmi}{wall}
+<F>All in all it's just an-<C>other brick in the <Dmi>wall
 
-\Ch{F}{All} in all it's just an-\Ch{C}{other} brick in the \Ch{Dmi}{wall}
+<F>All in all it's just an-<C>other brick in the <Dmi>wall
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Pink_Floyd____Comfortably_Numb.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Comfortably_Numb.tex
@@ -2,13 +2,13 @@
 
 \zp{Comfortably numb}{Pink Floyd}
 \zs
-\Ch{Hmi}{Hello}.
+<Hmi>Hello.
 
-\Ch{Hmi}{Is there} anybody \Ch{A}{in} there? 
+<Hmi>Is there anybody <A>in there? 
 
-Just nod if you can \Ch{G}{hear} me\Ch{Emi}{}
+Just nod if you can <G>hear me<Emi>
 
-Is there \Ch{Hmi}{anyone} home?
+Is there <Hmi>anyone home?
 \ks
 
 \zs
@@ -32,25 +32,25 @@ Can you show me where it hurts?
 \ks
 
 \zr
-\Ch{D}{There is} no pain, you are \Ch{A}{receding}
+<D>There is no pain, you are <A>receding
 
-\Ch{D}{A distant} ship’s smoke on the ho\Ch{A}{rizon}
+<D>A distant ship’s smoke on the ho<A>rizon
 
-\Ch{C}{You are only} coming through in \Ch{G}{waves}
+<C>You are only coming through in <G>waves
 
-\Ch{C}{Your lips} move but I can’t hear \Ch{G}{what} you’re sayin’
+<C>Your lips move but I can’t hear <G>what you’re sayin’
 
-\Ch{D}{When I was} a child I had \Ch{A}{a fever}
+<D>When I was a child I had <A>a fever
 
-\Ch{D}{My hands} felt just like two ball\Ch{A}{oons}
+<D>My hands felt just like two ball<A>oons
 
-\Ch{C}{Now I got} that feeling once a\Ch{G}{gain}
+<C>Now I got that feeling once a<G>gain
 
-I can’t explain, you would not under\Ch{C}{stand}
+I can’t explain, you would not under<C>stand
 
-This is not how I am\Ch{G}{}
+This is not how I am<G>
 
-\Ch{A}{I} \Ch{G}{have} beco\Ch{D}{me comfortably} \Ch{A}{numb}
+<A>I <G>have beco<D>me comfortably <A>numb
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Pink_Floyd____Money.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Money.tex
@@ -3,7 +3,7 @@
 \zp{Money}{Pink Floyd}
 \zs
 
-\Ch{Hmi7}{Money,} get away
+<Hmi7>Money, get away
 
 Get a good job with more pay and you're okay
 
@@ -13,9 +13,9 @@ Grab that cash with both hands and make a stash
 \ks
 
 \zr
-\Ch{F#mi7}{New car}, caviar, four star daydream
+<F#mi7>New car, caviar, four star daydream
 
-\Ch{Emi}{Think} I'll buy me a football \Ch{Hmi7}{team}
+<Emi>Think I'll buy me a football <Hmi7>team
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/Pink_Floyd____Mother.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Mother.tex
@@ -2,13 +2,13 @@
 
 \zp{Mother}{Pink Floyd}
 \zs
-\Ch{G}{Mother,} do you think they'll drop the \Ch{C}{bomb?} \Ch{D}{} \Ch{G}{}
+<G>Mother, do you think they'll drop the <C>bomb? <D> <G>
 
-\Ch{G}{Mother,} do you think they'll like this \Ch{C}{song?} \Ch{D}{} \Ch{G}{} 
+<G>Mother, do you think they'll like this <C>song? <D> <G> 
 
-\Ch{C}{Mother,}  do you think they'll try to break my \Ch{G}{balls?}
+<C>Mother, do you think they'll try to break my <G>balls?
 
-\Ch{D}{Ohhhh}..   \Ch{C}{Ahhhh}.. Mother, should I build a \Ch{G}{wall?}
+<D>Ohhhh.. <C>Ahhhh.. Mother, should I build a <G>wall?
 \ks
 
 \zs
@@ -18,27 +18,27 @@ Mother, should I trust the government?
 
 Mother, will they put me in the firing line?
 
-Ohhhh...  Ahhhhh.. Is it just a waste of time?
+Ohhhh... Ahhhhh.. Is it just a waste of time?
 \ks
 
 \zr
-\Ch{G}{Hush} now, baby, don't you \Ch{C}{cry}
+<G>Hush now, baby, don't you <C>cry
 
-\Ch{F}{Mama}'s gonna make all of your \Ch{C}{nightmares} come true
+<F>Mama's gonna make all of your <C>nightmares come true
 
-\Ch{F}{Mama}'s gonna put all of her \Ch{C}{fears} into you
+<F>Mama's gonna put all of her <C>fears into you
 
-\Ch{F}{Mama}'s gonna keep you right here, \Ch{C}{under} her wing
+<F>Mama's gonna keep you right here, <C>under her wing
 
-\Ch{F}{She} won't let you fly, but she \Ch{C}{might} let you sing
+<F>She won't let you fly, but she <C>might let you sing
 
-\Ch{F}{Mama}'s gonna keep baby \Ch{C}{cozy} and \Ch{G}{warm}
+<F>Mama's gonna keep baby <C>cozy and <G>warm
 
-\Ch{D}{Ohhhh}...  \Ch{C}{Babe}
+<D>Ohhhh... <C>Babe
 
-\Ch{D}{Ohhhh}...  \Ch{C}{Babe}
+<D>Ohhhh... <C>Babe
 
-\Ch{D}{Ohh}... Babe, \Ch{C}{of} course mama's gonna help build the \Ch{G}{wall}
+<D>Ohh... Babe, <C>of course mama's gonna help build the <G>wall
 \kr
 
 \zs
@@ -64,13 +64,13 @@ Mama will always find out just where you've been
 
 Mama's gonna keep baby healthy and clean
 
-Ooohhhh...  Baby
+Ooohhhh... Baby
 
-Ooohhhh...  Baby
+Ooohhhh... Baby
 
 Ooohhhh baby, you'll always be baby to me
 
-\Ch{G}{Mother,} did it need to be so \Ch{C}{high}?
+<G>Mother, did it need to be so <C>high?
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Pink_Floyd____Shine_on_your_crazy_diamond.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Shine_on_your_crazy_diamond.tex
@@ -6,12 +6,12 @@
 <Gmi>Remember when you were young,
 <F#>you shone like the <B>sun
 
-<Es>Shine <Es/D>on you <Cmi>cra-<Cmi/Bb>zy <F>diamond
+<Es>Shine <Es/D>on you <Cmi>cra<Cmi/Bb>zy <F>diamond
 
 <Gmi>Now there's a look in your eyes
 <F#>like black holes in the <B>sky
 
-<Es>Shine <Es/D>on you <Cmi>cra-<Cmi/Bb>zy <F>diamond
+<Es>Shine <Es/D>on you <Cmi>cra<Cmi/Bb>zy <F>diamond
 
 You were <Gmi>caught in the crossfire
 <Gmmaj7/F#>of childhood and stardom

--- a/tp-songs/03_zahranicni/Pink_Floyd____Shine_on_your_crazy_diamond.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Shine_on_your_crazy_diamond.tex
@@ -3,27 +3,27 @@
 \zp{Shine on you crazy diamond}{Pink Floyd}
 
 \zs
-\Ch{Gmi}{Remember} when you were young,
-\Ch{F#}{you} shone like the \Ch{B}{sun}
+<Gmi>Remember when you were young,
+<F#>you shone like the <B>sun
 
-\Ch{Es}{Shine} \Ch{Es/D}{on you} \Ch{Cmi}{cra-}\Ch{Cmi/Bb}{zy} \Ch{F}{diamond}
+<Es>Shine <Es/D>on you <Cmi>cra-<Cmi/Bb>zy <F>diamond
 
-\Ch{Gmi}{Now} there's a look in your eyes
-\Ch{F#}{like} black holes in the \Ch{B}{sky}
+<Gmi>Now there's a look in your eyes
+<F#>like black holes in the <B>sky
 
-\Ch{Es}{Shine} \Ch{Es/D}{on you} \Ch{Cmi}{cra-}\Ch{Cmi/Bb}{zy} \Ch{F}{diamond}
+<Es>Shine <Es/D>on you <Cmi>cra-<Cmi/Bb>zy <F>diamond
 
-You were \Ch{Gmi}{caught} in the crossfire
-\Ch{Gmmaj7/F#}{of childhood} and stardom
+You were <Gmi>caught in the crossfire
+<Gmmaj7/F#>of childhood and stardom
 
-\Ch{Gmi7/F}{Blown} on the steel \Ch{C9}{breeze}
+<Gmi7/F>Blown on the steel <C9>breeze
 
-\Ch{Es}{Come} on you target for \Ch{Edim}{faraway} laughter
+<Es>Come on you target for <Edim>faraway laughter
 
-\Ch{B/F}{Come} on you stranger, you \Ch{Dmi}{legend}, you \Ch{D7}{martyr}, and \Ch{Gmi}{shine}!
+<B/F>Come on you stranger, you <Dmi>legend, you <D7>martyr, and <Gmi>shine!
 \ks
 
-\Ch{F#}{} \Ch{Bb}{} \Ch{E}{} \Ch{Eb/D}{} \Ch{Cmi}{} \Ch{Cmi/Bb}{} \Ch{F}{}
+<F#> <Bb> <E> <Eb/D> <Cmi> <Cmi/Bb> <F>
 
 \zs
 You reached for the secret too soon,

--- a/tp-songs/03_zahranicni/Pink_Floyd____Time.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Time.tex
@@ -3,23 +3,23 @@
 \zp{Time}{Pink Floyd}
 
 \zs
-\Ch{F#mi}{Ticking} away the moments that make up a \Ch{A}{dull} day
+<F#mi>Ticking away the moments that make up a <A>dull day
 
-You \Ch{E}{fritter} and waste the hours in an off hand \Ch{F#mi}{way}
+You <E>fritter and waste the hours in an off hand <F#mi>way
 
-\Ch{F#mi}{Kicking} around on a piece of ground in your \Ch{A}{home} town
+<F#mi>Kicking around on a piece of ground in your <A>home town
 
-\Ch{E}{Waiting} for someone or something to show you the \Ch{F#mi}{way}
+<E>Waiting for someone or something to show you the <F#mi>way
 \ks
 
 \zs
-\Ch{Dmaj7}{Tired of} lying in the sunshine \Ch{Amaj7}{staying} home to watch the rain
+<Dmaj7>Tired of lying in the sunshine <Amaj7>staying home to watch the rain
 
-\Ch{Dmaj7}{You are} young and life is long and \Ch{Amaj7}{there is} time to kill today
+<Dmaj7>You are young and life is long and <Amaj7>there is time to kill today
 
-\Ch{Dmaj7}{And then} one day you find \Ch{C#mi7}{ten years} have got behind you
+<Dmaj7>And then one day you find <C#mi7>ten years have got behind you
 
-\Ch{Hmi7}{No one} told you when to run, \Ch{E}{you} missed the \Ch{E7}{starting} gun
+<Hmi7>No one told you when to run, <E>you missed the <E7>starting gun
 \ks
 
 \zs
@@ -39,7 +39,7 @@ Plans that either come to naught or half a page of scribbled lines
 
 Hanging on in quiet desperation is the English way
 
-The time is gone, the song is over, \Ch{Hmi7}{thought} I'd something \Ch{F}{more} to \Ch{Emi}{say}
+The time is gone, the song is over, <Hmi7>thought I'd something <F>more to <Emi>say
 \ks
 
 \kp

--- a/tp-songs/03_zahranicni/Pink_Floyd____Wish_you_were_here.tex
+++ b/tp-songs/03_zahranicni/Pink_Floyd____Wish_you_were_here.tex
@@ -1,18 +1,18 @@
 % -*-coding: utf-8 -*-
 
 \zp{Wish you were here}{Pink Floyd}
-/: \Ch{G}{} \Ch{Emi7}{} \Ch{G}{} :/  \Ch{Emi7}{} \Ch{A}{} \Ch{Emi7}{} \Ch{A}{}  \Ch{G}{}
+/: <G> <Emi7> <G> :/ <Emi7> <A> <Emi7> <A> <G>
 
 \zs
-\Ch{C}{So}, so you think you can \Ch{D}{tell}
+<C>So, so you think you can <D>tell
 
-Heaven from \Ch{Ami}{hell}, blue sky from \Ch{G}{pain}
+Heaven from <Ami>hell, blue sky from <G>pain
 
-Can you tell a green \Ch{D}{field} from a cold steel \Ch{C}{rail}
+Can you tell a green <D>field from a cold steel <C>rail
 
-A smile from a \Ch{Ami}{veil}
+A smile from a <Ami>veil
 
-Do you think you can \Ch{G}{tell}?
+Do you think you can <G>tell?
 \ks
 
 \zs
@@ -28,7 +28,7 @@ A walk on part in the {war}
 For a lead role in a cage?
 \ks
 
-/: \Ch{G}{} \Ch{Emi7}{} \Ch{G}{} :/  \Ch{Emi7}{} \Ch{A}{} \Ch{Emi7}{} \Ch{A}{}  \Ch{G}{}
+/: <G> <Emi7> <G> :/ <Emi7> <A> <Emi7> <A> <G>
 
 \zs
 {How} I wish, how I wish you were {here}
@@ -42,7 +42,7 @@ The same old {fears}
 Wish you were {here}!
 \ks
 
-/: \Ch{G}{} \Ch{Emi7}{} \Ch{G}{} :/  \Ch{Emi7}{} \Ch{A}{} \Ch{Emi7}{} \Ch{A}{}  \Ch{G}{}
+/: <G> <Emi7> <G> :/ <Emi7> <A> <Emi7> <A> <G>
 
 
 \kp

--- a/tp-songs/03_zahranicni/Pink____Fucking_Perfect.tex
+++ b/tp-songs/03_zahranicni/Pink____Fucking_Perfect.tex
@@ -3,8 +3,8 @@
 \zp{Fucking perfect}{Pink}
 
 \zs
-Made a \Ch{G}{wrong} turn, once \Ch{Dsus}{or twice}.
-Dug my \Ch{Emi7}{way out,} blood and \Ch{Cadd9}{fire}
+Made a <G>wrong turn, once <Dsus>or twice.
+Dug my <Emi7>way out, blood and <Cadd9>fire
 
 Bad decisions. That's alright, welcome to my silly life
 

--- a/tp-songs/03_zahranicni/Proclaimers____500_miles.tex
+++ b/tp-songs/03_zahranicni/Proclaimers____500_miles.tex
@@ -3,13 +3,13 @@
 \zp{500 miles}{Proclaimers}
 
 \zs
-When I \Ch{E}{wake} up, well I know I'm gonna be
+When I <E>wake up, well I know I'm gonna be
 
-I'm gonna \Ch{A}{be} the man who \Ch{H}{wakes} up next \Ch{E}{you}
+I'm gonna <A>be the man who <H>wakes up next <E>you
 
-When I \Ch{E}{go} out, yeah I know I'm gonna be
+When I <E>go out, yeah I know I'm gonna be
 
-I'm gonna \Ch{A}{be} the man who \Ch{H}{goes} along with \Ch{E}{you}
+I'm gonna <A>be the man who <H>goes along with <E>you
 
 \ks
 
@@ -75,9 +75,9 @@ I'm gonna be the man who goes along with you
 
 And when I come home, yes I know I'm gonna be
 
-I'm gonna be the man who comes back home with \Ch{C#mi}{you}
+I'm gonna be the man who comes back home with <C#mi>you
 
-I'm gonna \Ch{A}{be} the man who's \Ch{H}{coming} home with \Ch{E}{you}
+I'm gonna <A>be the man who's <H>coming home with <E>you
 \ks
 
 \zr \kr

--- a/tp-songs/03_zahranicni/Queen____We_are_the_champions.tex
+++ b/tp-songs/03_zahranicni/Queen____We_are_the_champions.tex
@@ -3,31 +3,31 @@
 \zp{We are the champions}{Queen}
 
 \zs
-I've paid my \Ch{Ami}{dues}
+I've paid my <Ami>dues
 
-\Ch{Emi}{time} after \Ch{Ami}{time}\Ch{Emi}{}
+<Emi>time after <Ami>time<Emi>
 
-I've done my \Ch{Ami}{sentence}
+I've done my <Ami>sentence
 
-\Ch{Emi}{but} committed no \Ch{Ami}{crime} \Ch{G}{}
+<Emi>but committed no <Ami>crime <G>
 
-And bad mis\Ch{C}{takes}
+And bad mis<C>takes
 
-\Ch{F}{I've} made a \Ch{C}{few} \Ch{F}{}
+<F>I've made a <C>few <F>
 
-I've had my \Ch{C}{share} of sand \Ch{G}{kicked} in my \Ch{Ami}{face}
+I've had my <C>share of sand <G>kicked in my <Ami>face
 
-but \Ch{D}{I've} come \Ch{G}{through} \Ch{A}{}
+but <D>I've come <G>through <A>
 \ks
 
 \zr
-\Ch{D}{We} are the \Ch{F#mi}{champions}, my \Ch{Hmi}{friend} \Ch{G}{} \Ch{A}{}
+<D>We are the <F#mi>champions, my <Hmi>friend <G> <A>
 
-And \Ch{D}{we'll} keep on \Ch{F#mi}{fighting} till the \Ch{G}{end} \Ch{H}{}
+And <D>we'll keep on <F#mi>fighting till the <G>end <H>
 
-\Ch{Emi}{We are} the \Ch{A}{champions}, \Ch{Gmi}{we are} the \Ch{F#}{cham}\Ch{E}{pions}!
+<Emi>We are the <A>champions, <Gmi>we are the <F#>cham<E>pions!
 
-\Ch{D}{No} time for \Ch{Ami7}{losers} 'cause \Ch{F6}{we} are the \Ch{G7}{champions} of the \Ch{Ami}{world} \Ch{Emi}{}
+<D>No time for <Ami7>losers 'cause <F6>we are the <G7>champions of the <Ami>world <Emi>
 \kr
 
 \zs
@@ -52,7 +52,7 @@ Before the human race
 And I never lose
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/03_zahranicni/R.E.M.____Losing_my_religion.tex
+++ b/tp-songs/03_zahranicni/R.E.M.____Losing_my_religion.tex
@@ -3,16 +3,16 @@
 \zp{Losing my religion}{R.E.M.}
 
 \zs
-\Ch{Ami}{Life} is bigger,
-\Ch{Emi}{it's bigger} than you
+<Ami>Life is bigger,
+<Emi>it's bigger than you
 
-And you are \Ch{Ami}{not me}
+And you are <Ami>not me
 
-The lengths that I will \Ch{Emi}{go to,}
-the distance in your \Ch{Ami}{eyes}
+The lengths that I will <Emi>go to,
+the distance in your <Ami>eyes
 
-\Ch{Emi}{Oh no} I've said too \Ch{Dmi}{much,}
-I set it \Ch{G}{up}
+<Emi>Oh no I've said too <Dmi>much,
+I set it <G>up
 \ks
 
 \zs
@@ -29,10 +29,10 @@ I haven't said enough
 \ks
 
 \zr
-I thought that I heard you \Ch{F}{laughing},
-I thought that I \Ch{G}{heard} you \Ch{Ami}{sing}
+I thought that I heard you <F>laughing,
+I thought that I <G>heard you <Ami>sing
 
-I \Ch{F}{think} I thought I saw \Ch{G}{you} \Ch{Ami}{try} \Ch{G}{}
+I <F>think I thought I saw <G>you <Ami>try <G>
 \kr
 
 \zs
@@ -71,8 +71,8 @@ I think I thought I saw you try
 \kr
 
 \zr
-But \Ch{C}{that} was just a \Ch{Dmi}{dream},
-\Ch{C}{that} was just a \Ch{Dmi}{dream}
+But <C>that was just a <Dmi>dream,
+<C>that was just a <Dmi>dream
 \kr
 
 \zs
@@ -81,10 +81,10 @@ That's me in the spotlight ...
 \ks
 
 \zr
-But \Ch{C}{that} was just a dream,
-\Ch{Dmi}{that} was just a \Ch{C}{dream}
+But <C>that was just a dream,
+<Dmi>that was just a <C>dream
 
-Just a \Ch{G}{dream}, just a \Ch{C}{dream}, dream \Ch{Ami}{}
+Just a <G>dream, just a <C>dream, dream <Ami>
 \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Radiohead____Creep.tex
+++ b/tp-songs/03_zahranicni/Radiohead____Creep.tex
@@ -2,34 +2,34 @@
 
 \zp{Creep}{Radiohead}
 
-\zs                   
-When you were here \Ch{G}{before}
+\zs 
+When you were here <G>before
 
-Couldn't look you in the \Ch{B}{eyes}
+Couldn't look you in the <B>eyes
 
-You look like an \Ch{C}{angel}
+You look like an <C>angel
 
-Your skin makes me \Ch{Cmi}{cry}
+Your skin makes me <Cmi>cry
 \ks
 
 \zs
-You float like a \Ch{G}{feather}
+You float like a <G>feather
 
-In a beautiful \Ch{B}{weather}
+In a beautiful <B>weather
 
-I wish I was \Ch{C}{special}
+I wish I was <C>special
 
-You're so fucking \Ch{Cmi}{special}
+You're so fucking <Cmi>special
 \ks
 
 \zr
-But I'm a \Ch{G}{creep} 
+But I'm a <G>creep 
 
-I'm a \Ch{B}{wierdo}
+I'm a <B>wierdo
 
-What the hell am I doin' \Ch{C}{here}
+What the hell am I doin' <C>here
 
-I don't belong \Ch{Cmi}{here}
+I don't belong <Cmi>here
 \kr
 
 \zs
@@ -52,7 +52,7 @@ You're so fuckin' special
 I wish I was special...
 \ks
 
-\zr  
+\zr 
 
 
 Ooh... she's running away... she's running... run... run... run... ruuuuun
@@ -68,6 +68,6 @@ You're so fucking special
 Wish I was special...
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp

--- a/tp-songs/03_zahranicni/Ray_Charles____Hit_the_road_Jack.tex
+++ b/tp-songs/03_zahranicni/Ray_Charles____Hit_the_road_Jack.tex
@@ -2,7 +2,7 @@
 
 \zp{Hit the road, Jack}{Ray Charles}
 \zr
-Hit the \Ch{Ami}{road,} \Ch{G}{Jack,} \Ch{F}{don}'t you come \Ch{E7}{back}
+Hit the <Ami>road, <G>Jack, <F>don't you come <E7>back
 
 No more, no more, no more, no more
 

--- a/tp-songs/03_zahranicni/Ritchie_Valens____La_Bamba.tex
+++ b/tp-songs/03_zahranicni/Ritchie_Valens____La_Bamba.tex
@@ -2,16 +2,16 @@
 
 \zp{La bamba}{Ritchie Valens}
 \zs
-Para bailar la \Ch{C}{Bamba,}\Ch{F}{ } \Ch{G}{ }
+Para bailar la <C>Bamba,<F> <G> 
 
-para bailar la \Ch{C}{Bamba} se \Ch{F}{nece}\Ch{G}{sita}
-una poca de \Ch{C}{gracia,}\Ch{F}{ } \Ch{G}{ }
+para bailar la <C>Bamba se <F>nece<G>sita
+una poca de <C>gracia,<F> <G> 
 
-una poca de \Ch{C}{gracia} para \Ch{F}{mi, para} \Ch{G}{ti,}
-ay arriba ay ar\Ch{C}{riba,} \Ch{F}{} \Ch{G}{}
+una poca de <C>gracia para <F>mi, para <G>ti,
+ay arriba ay ar<C>riba, <F> <G>
 
-Ay arriba ay ar\Ch{C}{riba,} por \Ch{F}{ti se}\Ch{G}{re,}
-por ti se\Ch{C}{re, por} \Ch{F}{ti se}\Ch{G}{re.}
+Ay arriba ay ar<C>riba, por <F>ti se<G>re,
+por ti se<C>re, por <F>ti se<G>re.
 
 Yo no soy marinero,
 
@@ -20,7 +20,7 @@ soy capitan, soy capitan.
 \ks
 
 \zr
-3× /: \Ch{C}{Bam}\Ch{F}{ba,} \Ch{G}{Bamba.} :/
+3× /: <C>Bam<F>ba, <G>Bamba. :/
 \kr
 
 \zs
@@ -31,7 +31,7 @@ y arriba y arriba contigo ire.
 
 Yo no soy marinero...
 \ks
-\zr    \kr
+\zr \kr
 \zs
 Para ser secretaria,
 para ser secretaria se necesita una falda muy corta,

--- a/tp-songs/03_zahranicni/Rolling_Stones____Angie.tex
+++ b/tp-songs/03_zahranicni/Rolling_Stones____Angie.tex
@@ -3,17 +3,17 @@
 \zp{Angie}{Rolling Stones}
 
 \zs
-\Ch{Ami}{Angie}, \Ch{E7}{Angie,} \Ch{C2}{when} will \Ch{B2}{those} \Ch{F}{clouds} all disap\Ch{C4}{pe}\Ch{C}{ar}?
+<Ami>Angie, <E7>Angie, <C2>when will <B2>those <F>clouds all disap<C4>pe<C>ar?
 
 Angie, Angie, where were the ladies from here?
 \ks
 
 \zr
-With no \Ch{G}{loving} in our souls and no \Ch{Dmi}{money} in our \Ch{Ami}{coats}
+With no <G>loving in our souls and no <Dmi>money in our <Ami>coats
 
-\Ch{C}{You} can't \Ch{F}{say} we're satis\Ch{G}{fied}
+<C>You can't <F>say we're satis<G>fied
 
-\Ch{Ami}{Angie}, \Ch{E7}{Angie,} \Ch{C2}{you} can't \Ch{B2}{say} \Ch{F}{we} never \Ch{C4}{tri}\Ch{C}{ed}
+<Ami>Angie, <E7>Angie, <C2>you can't <B2>say <F>we never <C4>tri<C>ed
 \kr
 
 \zs
@@ -33,13 +33,13 @@ Seem to all go up in smoke let me whisper in your ear
 Solo.
 
 \zr
-Oh \Ch{G}{Angie} don't you weep
+Oh <G>Angie don't you weep
 
-All your \Ch{Dmi}{kisse}s still taste \Ch{Ami}{sweet}
+All your <Dmi>kisses still taste <Ami>sweet
 
-\Ch{C}{I} hate that \Ch{F}{sadness} in your \Ch{G}{eyes}
+<C>I hate that <F>sadness in your <G>eyes
 
-but \Ch{Ami}{Angie}, \Ch{E7}{Angie}, \Ch{C2}{ain't} it \Ch{B2}{ti-}\Ch{F}{me} we said good\Ch{C}{bye}... ya
+but <Ami>Angie, <E7>Angie, <C2>ain't it <B2>ti-<F>me we said good<C>bye... ya
 \kr
 
 Solo.

--- a/tp-songs/03_zahranicni/Rolling_Stones____Angie.tex
+++ b/tp-songs/03_zahranicni/Rolling_Stones____Angie.tex
@@ -39,7 +39,7 @@ All your <Dmi>kisses still taste <Ami>sweet
 
 <C>I hate that <F>sadness in your <G>eyes
 
-but <Ami>Angie, <E7>Angie, <C2>ain't it <B2>ti-<F>me we said good<C>bye... ya
+but <Ami>Angie, <E7>Angie, <C2>ain't it <B2>ti<F>me we said good<C>bye... ya
 \kr
 
 Solo.

--- a/tp-songs/03_zahranicni/Rolling_Stones____Ruby_Tuesday.tex
+++ b/tp-songs/03_zahranicni/Rolling_Stones____Ruby_Tuesday.tex
@@ -3,25 +3,25 @@
 \zp{Ruby Tuesday}{Rolling Stones}
 
 \zs
-\Ch{Ami}{She} would \Ch{G}{never} \Ch{F}{say} \Ch{G}{where} she came \Ch{C}{from} \Ch{F}{} \Ch{C}{}
+<Ami>She would <G>never <F>say <G>where she came <C>from <F> <C>
 
-\Ch{Ami}{Yesterday} \Ch{G}{don't} \Ch{F}{matter} \Ch{C}{if} it's \Ch{G}{gone} \Ch{C}{} \Ch{G}{}
+<Ami>Yesterday <G>don't <F>matter <C>if it's <G>gone <C> <G>
 
-\Ch{Ami}{While} the \Ch{D7}{sun} is \Ch{G}{bright}
+<Ami>While the <D7>sun is <G>bright
 
-Or \Ch{Ami}{in the} \Ch{D7}{darkest} \Ch{G}{night}
+Or <Ami>in the <D7>darkest <G>night
 
-No one \Ch{C}{knows} \Ch{F}{} \Ch{C}{} she comes and \Ch{G}{goes} \Ch{C}{} \Ch{G}{}
+No one <C>knows <F> <C> she comes and <G>goes <C> <G>
 \ks
 
 \zr
-\Ch{C}{Good}\Ch{G}{bye} \Ch{C}{Ruby} Tuesday
+<C>Good<G>bye <C>Ruby Tuesday
 
-Who could \Ch{G}{hang} a name \Ch{C}{on} you?
+Who could <G>hang a name <C>on you?
 
-\Ch{C}{When} you \Ch{G}{change} with \Ch{F}{ev'ry} new day
+<C>When you <G>change with <F>ev'ry new day
 
-\Ch{G}{Still} I'm gonna \Ch{C}{miss} you \Ch{G}{}
+<G>Still I'm gonna <C>miss you <G>
 \kr
 
 \zs
@@ -36,7 +36,7 @@ To a life where nothing's gained
 And nothing's lost at such a cost
 \ks
 
-\zr  \kr
+\zr \kr
 
 \zs
 There's no time to loose I heard her say

--- a/tp-songs/03_zahranicni/Rolling_Stones____Satisfaction.tex
+++ b/tp-songs/03_zahranicni/Rolling_Stones____Satisfaction.tex
@@ -2,40 +2,40 @@
 
 \zp{Satisfaction}{Rolling Stones}
 
-\Ch{E}{}
-\Ch{A}{}
-\Ch{D}{}
-\Ch{A}{}
+<E>
+<A>
+<D>
+<A>
 
 \zs
-\Ch{E}{I} can't get no \Ch{A}{satisfaction}
+<E>I can't get no <A>satisfaction
 
-\Ch{E}{I} can't get no \Ch{A}{satisfaction}
+<E>I can't get no <A>satisfaction
 
-Cause I \Ch{E}{try}, and I \Ch{H7}{try}, and I \Ch{E}{try}, and \Ch{A}{try}
+Cause I <E>try, and I <H7>try, and I <E>try, and <A>try
 \ks
 
 \zr
-/: {I} can't \Ch{E}{get} no \Ch{A}{} \Ch{D}{} \Ch{A}{} :/
+/: {I} can't <E>get no <A> <D> <A> :/
 \kr
 
 \zs
-\Ch{A}{When} I'm \Ch{E}{driving} in \Ch{A}{my} \Ch{D}{car}
+<A>When I'm <E>driving in <A>my <D>car
 
-\Ch{A}{And} the \Ch{E}{man} comes on \Ch{A}{the} \Ch{D}{radio}
+<A>And the <E>man comes on <A>the <D>radio
 
-\Ch{A}{He's} \Ch{E}{telling} me more \Ch{A}{and} \Ch{D}{more}
-\Ch{A}{about} some \Ch{E}{useless} info\Ch{A}{rma}\Ch{D}{tion}
+<A>He's <E>telling me more <A>and <D>more
+<A>about some <E>useless info<A>rma<D>tion
 
-\Ch{A}{Supposed} \Ch{E}{to} drive my \Ch{A}{imagi}\Ch{D}{nation}
+<A>Supposed <E>to drive my <A>imagi<D>nation
 \ks
 
 \zr
-/: \Ch{A}{I can't} \Ch{E}{get} no \Ch{A}{} \Ch{D}{} :/
+/: <A>I can't <E>get no <A> <D> :/
 
-Oh no \Ch{A}{no} \Ch{E}{no}, hey hey hey \Ch{A}{} \Ch{D}{}
+Oh no <A>no <E>no, hey hey hey <A> <D>
 
-\Ch{A}{That's} what I \Ch{E}{say} \Ch{A}{} \Ch{D}{}
+<A>That's what I <E>say <A> <D>
 \kr
 
 \zs
@@ -70,7 +70,7 @@ Baby better come back next week
 Cause you see I'm on a losin' streak
 \ks
 
-\zr  \kr
+\zr \kr
 
 \kp
 

--- a/tp-songs/03_zahranicni/Scorpions____Wind_of_Change.tex
+++ b/tp-songs/03_zahranicni/Scorpions____Wind_of_Change.tex
@@ -3,13 +3,13 @@
 \zp{Wind of change}{Scorpions}
 
 \zs
-\Ch{C}{I follow} the Mosk\Ch{Dmi}{va down} to Gorky \Ch{C}{Park}
+<C>I follow the Mosk<Dmi>va down to Gorky <C>Park
 
-Listening to the \Ch{Dmi}{wind of} \Ch{Ami}{chan}\Ch{G}{ge}
+Listening to the <Dmi>wind of <Ami>chan<G>ge
 
-\Ch{C}{An August} summer \Ch{Dmi}{night,} soldiers passing \Ch{C}{by}
+<C>An August summer <Dmi>night, soldiers passing <C>by
 
-Listening to the \Ch{Dmi}{wind of} \Ch{Ami}{chan}\Ch{G}{ge}
+Listening to the <Dmi>wind of <Ami>chan<G>ge
 \ks
 
 \zs
@@ -23,9 +23,9 @@ Blowing with the wind of change
 \ks
 
 \zr
-\Ch{C}{Take} \Ch{G}{me to} the \Ch{Dmi}{magic of the} \Ch{G7}{moment} on a \Ch{C}{glory} \Ch{G}{night}
+<C>Take <G>me to the <Dmi>magic of the <G7>moment on a <C>glory <G>night
 
-Where the \Ch{Dmi}{children of to}\Ch{G}{morrow} dream \Ch{Ami}{away} in the wind of \Ch{G}{change}
+Where the <Dmi>children of to<G>morrow dream <Ami>away in the wind of <G>change
 \kr
 
 \zs
@@ -49,11 +49,11 @@ Where the children of tomorrow dream away in the wind of change
 \kr
 
 \zs
-\Ch{Ami}{The wind of} change blows \Ch{G}{straight} into the face of \Ch{Ami}{time}
+<Ami>The wind of change blows <G>straight into the face of <Ami>time
 
-Like a stormwind that will \Ch{G}{ring} the freedom bell for peace of \Ch{C}{mind}
+Like a stormwind that will <G>ring the freedom bell for peace of <C>mind
 
-Let your balalaika \Ch{Dmi}{sing} what my guitar wants to \Ch{E}{say}
+Let your balalaika <Dmi>sing what my guitar wants to <E>say
 \ks
 
 \zr

--- a/tp-songs/03_zahranicni/Scott_Mckenzie____San_Francisco.tex
+++ b/tp-songs/03_zahranicni/Scott_Mckenzie____San_Francisco.tex
@@ -2,16 +2,16 @@
 
 \zp{San Francisco}{Scott Mckenzie}
 
-\Ch{G}{}
+<G>
 
 \zs
-\Ch{Emi}{If you}'re \Ch{C}{going} to \Ch{G}{San} Fran\Ch{D}{cisco}
+<Emi>If you're <C>going to <G>San Fran<D>cisco
 
-\Ch{Emi}{Be sure} to \Ch{C}{wear} some \Ch{G}{flowers} in your \Ch{D}{hair}
+<Emi>Be sure to <C>wear some <G>flowers in your <D>hair
 
-\Ch{Emi}{If you}'re \Ch{G}{going} to \Ch{C}{San} Fran\Ch{G}{cisco}
+<Emi>If you're <G>going to <C>San Fran<G>cisco
 
-\Ch{G}{You}'re gonna \Ch{Hmi}{meet} some \Ch{Emi}{gentle} people \Ch{D}{there}
+<G>You're gonna <Hmi>meet some <Emi>gentle people <D>there
 \ks
 \zs
 For those who come to San Francisco
@@ -24,13 +24,13 @@ Gentle people with flowers in their hair
 \ks
 
 \zr
-\Ch{F}{All} across the nation
+<F>All across the nation
 
-Such a strange vibration, \Ch{G}{people} in motion
+Such a strange vibration, <G>people in motion
 
-\Ch{F}{There}'s a whole generation
+<F>There's a whole generation
 
-With a new explanation, \Ch{G}{people} in motion, \Ch{D}{people} in motion
+With a new explanation, <G>people in motion, <D>people in motion
 \kr
 \zs
 For those who come to San Francisco
@@ -43,9 +43,9 @@ Summer time will be a-lovin' there
 \ks
 
 \zs
-\Ch{Emi}{} \Ch{F#mi}{If you} \Ch{A}{come} to \Ch{D}{San} Fran\Ch{A}{cisco}
+<Emi> <F#mi>If you <A>come to <D>San Fran<A>cisco
 
-\Ch{A}{Summer}\Ch{C#mi}{time will} \Ch{F#mi}{be a-lovin'} \Ch{A}{there}
+<A>Summer<C#mi>time will <F#mi>be a-lovin' <A>there
 \ks
 \kp
 

--- a/tp-songs/03_zahranicni/Slade____My_Oh_My.tex
+++ b/tp-songs/03_zahranicni/Slade____My_Oh_My.tex
@@ -3,15 +3,15 @@
 \zp{My oh my}{Slade}
 
 \zs
-I be\Ch{C}{lieve in} \Ch{Fmaj7}{woman, my oh} \Ch{C}{my}
+I be<C>lieve in <Fmaj7>woman, my oh <C>my
 
-I be\Ch{Emi}{lieve in} \Ch{Ami}{lovin', my oh} \Ch{G}{my}
+I be<Emi>lieve in <Ami>lovin', my oh <G>my
 
-Don't a \Ch{Fmaj7}{woman need a} \Ch{C}{man}
+Don't a <Fmaj7>woman need a <C>man
 
-Try and \Ch{Dmi}{catch one} if you \Ch{F}{can}
+Try and <Dmi>catch one if you <F>can
 
-I be\Ch{C}{lieve in} \Ch{Fmaj7}{woman, my oh} \Ch{C}{my}
+I be<C>lieve in <Fmaj7>woman, my oh <C>my
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/Steve_Miller_Band____Joker.tex
+++ b/tp-songs/03_zahranicni/Steve_Miller_Band____Joker.tex
@@ -1,9 +1,9 @@
 \zp{The joker}{Steve Miller Band}
 
-/: \Ch{F}{} ~ \Ch{B}{} ~ \Ch{C}{} ~ \Ch{B}{} :/
+/: <F> ~ <B> ~ <C> ~ <B> :/
 
 \zs
-\Ch{F}{Some} \Ch{B}{people} call me the space \Ch{C}{cowboy}, yeah~\Ch{B}{} ~ \Ch{F}{}
+<F>Some <B>people call me the space <C>cowboy, yeah~<B> ~ <F>
 
 Some call me the gangster of love
 

--- a/tp-songs/03_zahranicni/Suzanne_Vega____Caramel.tex
+++ b/tp-songs/03_zahranicni/Suzanne_Vega____Caramel.tex
@@ -6,43 +6,43 @@
 CHORDS
 
 \begin{tabular}{ l r }
-  Gmi7     &  353333\\
-  C\#7     &  x4342x\\
-  D7sus4/A &  x0553x\\
-  D7       &  x5453x\\
-  G7       &  353433\\
-  Cm7      &  x35343\\
-  Dm7      &  x57565\\
-  D\#maj7  &  x68786\\
-  G        &  355433\\
-  Gmi      &  355333\\
+ Gmi7 & 353333\\
+ C\#7 & x4342x\\
+ D7sus4/A & x0553x\\
+ D7 & x5453x\\
+ G7 & 353433\\
+ Cm7 & x35343\\
+ Dm7 & x57565\\
+ D\#maj7 & x68786\\
+ G & 355433\\
+ Gmi & 355333\\
 \end{tabular}
 \fi
 
-4× /: \Ch{Gmi7}{} \Ch{Eb5}{} \Ch{D7}{} :/
+4× /: <Gmi7> <Eb5> <D7> :/
 
 \zs
-It won't \Ch{Gmi7}{do} \Ch{C#7}{} to \Ch{D7sus4/A}{dream of} cara\Ch{D7}{mel}
+It won't <Gmi7>do <C#7> to <D7sus4/A>dream of cara<D7>mel
 
-To \Ch{D7sus4/A}{think of cinnamon} \Ch{D7}{} and long for \Ch{Gmi7}{you}  \Ch{Eb7}{}  \Ch{D7}{}
+To <D7sus4/A>think of cinnamon <D7> and long for <Gmi7>you <Eb7> <D7>
 \ks
 
 \zs
-It won't do  to stir a deep desire
+It won't do to stir a deep desire
 
 To fan a hidden fire that can never burn true
 \ks
 
 \zr
-\Ch{Cmi7}{}I \Ch{Dmi7}{know} your \Ch{D#maj7}{name, I} \Ch{Dmi7}{know your} \Ch{D7}{skin}
+<Cmi7>I <Dmi7>know your <D#maj7>name, I <Dmi7>know your <D7>skin
 
-I \Ch{Dmi7}{know the} way \Ch{D#maj7}{these things} \Ch{D7}{begin}
+I <Dmi7>know the way <D#maj7>these things <D7>begin
 
-But I don't \Ch{G}{know} \Ch{Gmi}{} how I would \Ch{D7sus4/A}{live with} my\Ch{D7}{self}
+But I don't <G>know <Gmi> how I would <D7sus4/A>live with my<D7>self
 
-What I'd for\Ch{D7sus4/A}{give of myself} \Ch{D7}{}
+What I'd for<D7sus4/A>give of myself <D7>
 
-If you don't \Ch{Gmi7}{go} \Ch{D7}{}
+If you don't <Gmi7>go <D7>
 \kr
 
 \ifdefined\TPBAND
@@ -58,9 +58,9 @@ no single bite could satisfy...
 \zr\kr
 
 \ifdefined\TPBAND
-(\Ch{Gmi7}{B}R\Ch{Eb5}{I}D\Ch{D7}{GE})
+(<Gmi7>BR<Eb5>ID<D7>GE)
 \else
-\Ch{Gmi7}{} \Ch{Eb5}{} \Ch{D7}{}
+<Gmi7> <Eb5> <D7>
 \fi
 
 \zs

--- a/tp-songs/03_zahranicni/Tokens____Lion_Sleeps_Tonight.tex
+++ b/tp-songs/03_zahranicni/Tokens____Lion_Sleeps_Tonight.tex
@@ -6,12 +6,12 @@ Wee wee ooh wimoweh,
 wee wee ooh wimoweh.
 \ks
 \zr
-/: O\Ch{C}{wimoweh,} owimoweh, o\Ch{F}{wimoweh,} owimoweh,
+/: O<C>wimoweh, owimoweh, o<F>wimoweh, owimoweh,
 
-o\Ch{C}{wimoweh,} owimoweh, o\Ch{G}{wimoweh,} owimoweh :/
+o<C>wimoweh, owimoweh, o<G>wimoweh, owimoweh :/
 \kr
 \zs
-\Ch{C}{In the} jungle, the \Ch{F}{mighty} jungle, the \Ch{C}{lion} sleeps \Ch{G}{tonight}
+<C>In the jungle, the <F>mighty jungle, the <C>lion sleeps <G>tonight
 
 In the jungle, the quiet jungle, the lion sleeps tonight
 \ks

--- a/tp-songs/03_zahranicni/neznámý____Bella_Ciao.tex
+++ b/tp-songs/03_zahranicni/neznámý____Bella_Ciao.tex
@@ -3,13 +3,13 @@
 \zp{Bella ciao}{(neznámý)}
 
 \zs
-\Ch{Ami}{Una mattina} mi sono svegliato,
+<Ami>Una mattina mi sono svegliato,
 
 o bella, ciao! Bella, ciao! Bella, ciao, ciao, ciao!
 
-Una mat\Ch{Dmi}{tina mi} sono sve\Ch{Ami}{gliato,}
+Una mat<Dmi>tina mi sono sve<Ami>gliato,
 
-e ho tro\Ch{E}{vato l'inva}\Ch{Ami}{sor.}
+e ho tro<E>vato l'inva<Ami>sor.
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/neznámý____El_Condor_Pasa.tex
+++ b/tp-songs/03_zahranicni/neznámý____El_Condor_Pasa.tex
@@ -3,25 +3,25 @@
 \zp{El condor pasa}{(neznámý)}
 
 \zs
-I'd \Ch{Ami}{rather be} a sparrow than a \Ch{C}{snail}
+I'd <Ami>rather be a sparrow than a <C>snail
 
-Yes I would, if I could, I surely \Ch{Ami}{would}
+Yes I would, if I could, I surely <Ami>would
 
-I'd rather be a hammer than a \Ch{C}{nail}
+I'd rather be a hammer than a <C>nail
 
-Yes I would, if I only could, I surely \Ch{Ami}{would}
+Yes I would, if I only could, I surely <Ami>would
 \ks
 
 \zr
-A\Ch{F}{way,} I'd rather sail away
+A<F>way, I'd rather sail away
 
-Like a \Ch{C}{swan} that's here and gone
+Like a <C>swan that's here and gone
 
-A \Ch{F}{man} gets tied up to the ground
+A <F>man gets tied up to the ground
 
-He gives the \Ch{C}{world} its saddest sound
+He gives the <C>world its saddest sound
 
-Its saddest \Ch{Ami}{sound}
+Its saddest <Ami>sound
 \kr
 
 \zs

--- a/tp-songs/03_zahranicni/neznámý____Scarborough_Fair.tex
+++ b/tp-songs/03_zahranicni/neznámý____Scarborough_Fair.tex
@@ -3,13 +3,13 @@
 \zp{Scarborough fair}{(neznámý)}
 
 \zs
-\Ch{Dmi}{Are you going} to \Ch{C}{Scarborough} \Ch{Dmi}{Fair?}
+<Dmi>Are you going to <C>Scarborough <Dmi>Fair?
 
-\Ch{F}{Parsley,} \Ch{Dmi}{sage, rose}\Ch{F}{ma}\Ch{G}{ry and} \Ch{Dmi}{thyme}
+<F>Parsley, <Dmi>sage, rose<F>ma<G>ry and <Dmi>thyme
 
-Remember \Ch{F}{me to} one \Ch{C}{who} \Ch{Dmi}{lives} \Ch{C}{there}
+Remember <F>me to one <C>who <Dmi>lives <C>there
 
-\Ch{Dmi}{She once} \Ch{C}{was} \Ch{Dmi}{a} \Ch{C}{true} \Ch{Dmi}{love} \Ch{C}{of} \Ch{Dmi}{mine}
+<Dmi>She once <C>was <Dmi>a <C>true <Dmi>love <C>of <Dmi>mine
 \ks
 
 \zs

--- a/tp-songs/03_zahranicni/neznámý____What_Shall_We_Do_With_a_Drunken_Sailor.tex
+++ b/tp-songs/03_zahranicni/neznámý____What_Shall_We_Do_With_a_Drunken_Sailor.tex
@@ -3,13 +3,13 @@
 \zp{What shall we do with a drunken sailor}{(neznámý)}
 
 \zs
-\Ch{Dmi}{What shall we do with a drunken sailor}
+<Dmi>What shall we do with a drunken sailor
 
-\Ch{C}{What shall we do with a drunken sailor}
+<C>What shall we do with a drunken sailor
 
-\Ch{Dmi}{What shall we do with a drunken sailor}
+<Dmi>What shall we do with a drunken sailor
 
-\Ch{F}{Early} \Ch{A}{in the} \Ch{Dmi}{morning}
+<F>Early <A>in the <Dmi>morning
 \ks
 
 \zr

--- a/tp-songs/04_tp/Eso____Hymna_TP.tex
+++ b/tp-songs/04_tp/Eso____Hymna_TP.tex
@@ -3,11 +3,11 @@
 \zp{Hymna TP}{Mirek \uv{Eso} Řehoř}
 
 \zs
-Na \Ch{C}{TP} vždycky \Ch{G}{jedu} rád,
-na \Ch{Ami}{TP,} tam si \Ch{Emi}{můžu} hrát,
+Na <C>TP vždycky <G>jedu rád,
+na <Ami>TP, tam si <Emi>můžu hrát,
 
-na \Ch{F}{TP,} kde jsou \Ch{C}{lidi} cool,
-na \Ch{Dmi}{TP je} jen \Ch{G}{zřídka} vůl.
+na <F>TP, kde jsou <C>lidi cool,
+na <Dmi>TP je jen <G>zřídka vůl.
 \ks
 
 \zs

--- a/tp-songs/04_tp/Johnny____On_hledá_ji.tex
+++ b/tp-songs/04_tp/Johnny____On_hledá_ji.tex
@@ -3,7 +3,7 @@
 \zp{On hledá ji}{Jan \uv{Johnny} Dočkal}
 
 \zs
-\Ch{C}{Jmenuji se Jan,} \Ch{F}{je mi dvacet pět,} \Ch{G}{jsem celkem pohled}\Ch{C}{ný,} \Ch{F}{} \Ch{G}{}
+<C>Jmenuji se Jan, <F>je mi dvacet pět, <G>jsem celkem pohled<C>ný, <F> <G>
 
 jsem zrovna sám, jsem však společenský, charakterní, důsledný.
 
@@ -24,13 +24,13 @@ tak hledám slečnu, co je schopná napsat inzerát bez gramatických chyb.
 \ks
  
 \zr
-\Ch{F}{A tak inzeruji,} \Ch{G}{hledám,} \Ch{Cmaj7}{pátrám,} \Ch{Ami7}{sítí se prodírám,}
+<F>A tak inzeruji, <G>hledám, <Cmaj7>pátrám, <Ami7>sítí se prodírám,
 
-z \Ch{F}{tisíce} \Ch{G}{nabízených možností} \Ch{Cmaj7}{pečlivě} \Ch{Ami7}{vybírám,}
+z <F>tisíce <G>nabízených možností <Cmaj7>pečlivě <Ami7>vybírám,
 
-\Ch{F}{stále inzeruji,} \Ch{G}{hledám,} \Ch{G}{pátrám} \Ch{Emi}{a lásku poptá}\Ch{Ami7}{vám,}
+<F>stále inzeruji, <G>hledám, <G>pátrám <Emi>a lásku poptá<Ami7>vám,
 
-\Ch{F}{snad najdu ženu,} \Ch{G}{co vyhovuje veškerým} \Ch{C}{představám.}
+<F>snad najdu ženu, <G>co vyhovuje veškerým <C>představám.
 \kr
  
 \zs

--- a/tp-songs/04_tp/Johnny____Píseň_Technické_přestávky.tex
+++ b/tp-songs/04_tp/Johnny____Píseň_Technické_přestávky.tex
@@ -4,29 +4,29 @@
 
 \zs
 
-Možná \Ch{C}{že} se nad tím lidé
-s pous\Ch{Emi}{máním} zastaví,
+Možná <C>že se nad tím lidé
+s pous<Emi>máním zastaví,
 
-že mi \Ch{G}{lezem'} ven, když vracíme se
-\Ch{C}{zmrz}lí, proch\Ch{G}{caní.}
+že mi <G>lezem' ven, když vracíme se
+<C>zmrzlí, proch<G>caní.
 \ks
 
 \zs
 
-Je to \Ch{C}{jedno,} to se spraví,
-hlavně \Ch{Emi}{když} se bavíme,
+Je to <C>jedno, to se spraví,
+hlavně <Emi>když se bavíme,
 
-večer \Ch{G}{na} to láhev dáme,
-navrá\Ch{C}{cení} \Ch{F7}{slaví}\Ch{C}{me.}
+večer <G>na to láhev dáme,
+navrá<C>cení <F7>slaví<C>me.
 \ks
 
 \zr
 
-\Ch{C9}{Tak al}espoň na těch pár dnů
-\Ch{F}{vyr}azíme z města ven,
+<C9>Tak alespoň na těch pár dnů
+<F>vyrazíme z města ven,
 
-\Ch{D7}{fyzičku} si potrápíme,
-\Ch{G}{až kl}esne\Ch{G#}{me do} \Ch{G}{kol}en.
+<D7>fyzičku si potrápíme,
+<G>až klesne<G#>me do <G>kolen.
 \kr
 
 \zs

--- a/tpcb/songbook.sty
+++ b/tpcb/songbook.sty
@@ -544,7 +544,7 @@
     \setbox1=\hbox{\ChFont\sbChord#1\relax\strut}%
     \setbox0=\hbox{#2}%
     \ifdim\wd1<\wd0%
-      \strut\raise\SBChordRaise\copy1\kern-\wd1\copy0%
+      \strut\raise\SBChordRaise\copy1\kern-\wd1{#2}%
     \else%
       \strut\copy0\kern-\wd0\strut\raise\SBChordRaise\copy1%
     \fi%

--- a/tpcb/songbook.sty
+++ b/tpcb/songbook.sty
@@ -539,7 +539,25 @@
 }
 
 %%%
-\newcommand{\Ch}[2]{{%
+\makeatletter
+\def\Ch{\@ifstar\@Ch\@@Ch}
+
+\def\@Ch#1#2{{%
+  \ifChordBk%
+    \setbox1=\hbox{\ChFont\sbChord#1\relax\strut}%
+    \setbox0=\hbox{#2}%
+    \ifdim\wd1<\wd0%
+      \strut\raise\SBChordRaise\copy1\kern-\wd1{#2}%
+    \else\ifdim\wd0=0pt%
+      \strut\copy0\kern-\wd0\strut\raise\SBChordRaise\copy1%
+    \else%
+      \strut\raise\SBChordRaise\copy1\kern-\wd1\strut\hbox to \wd1{#2\cleaders\hbox{\kern-.5pt-\kern-.5pt}\hfill}%
+    \fi\fi%
+  \else%
+    #2%
+  \fi}}
+
+\def\@@Ch#1#2{{%
   \ifChordBk%
     \setbox1=\hbox{\ChFont\sbChord#1\relax\strut}%
     \setbox0=\hbox{#2}%
@@ -551,6 +569,8 @@
   \else%
     #2%
   \fi}}
+
+\makeatother
 
 \newcommand{\ChX}[2]{%
   \ifWordsOnly%


### PR DESCRIPTION
Akordy se dají psát `<C>takhle`. Původní formát `\Ch{C}{takhle}` je pořád podporovaný a ve skutečnosti se na něj nový v rámci `chords.py` (kde probíhá i transpozice) převádí.

Je k dispozici skript pro sed, který na nový formát převádí. Volá se následovně:

``` bash
    sed -f konverze.sed < vstup > výstup
```

Všechny písničky jsem automaticky převedl a zkontroloval správnost při překladu. Další opravy (ve větvi `vasek-pisnicky`) už budu dělat v novém formátu.

Další novinkou je automatické přidávání rozdělovníků. `songbook.sty` je teď trochu chytřejší a poradí si sám, když je akord delší, než slova pod ním. Místo dřívějšího

```
<C>do-<Cdim>bro-<Gmi7>druž-<C#7>ství
```

stačí napsat

```
<C>do<Cdim>bro<Gmi7>druž<C#7>ství
```

a rozdělovníky se automaticky přidají tam, kde
1. akord dělí slovo,
2. je delší než odpovídající část slova pod ním
3. a toto vytvoří mezeru delší než jeden rozdělovník.

To má výhody, že:
1. se nemusí na tu možnost při psaní myslet a předvídat a nanečisto zkoušet, jak to vyjde,
2. chování se přizpůsobí prodloužení/zkrácení akordové značky při transpozici,
3. vypadá to pěkněji i ve zdrojáku i vysázené (rozdělovník se udělá kratší nebo delší podle potřeby a je vycentrovaný mezi rozdělenými slabikami).
