### PR TITLE
Revize Snakemake závislostí

### DIFF
--- a/Snakefile.2pedro
+++ b/Snakefile.2pedro
@@ -286,5 +286,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.AllSongs
+++ b/Snakefile.AllSongs
@@ -22,5 +22,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.TP2011
+++ b/Snakefile.TP2011
@@ -210,5 +210,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.TP2012
+++ b/Snakefile.TP2012
@@ -223,5 +223,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.TP2013
+++ b/Snakefile.TP2013
@@ -227,5 +227,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.TP2015
+++ b/Snakefile.TP2015
@@ -275,5 +275,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.TPBAND
+++ b/Snakefile.TPBAND
@@ -57,5 +57,5 @@ include:"tpcb/snake_incl.py"
 
 rule all:
 	input:
-		cb_pdf()
+		run()
 

--- a/Snakefile.test
+++ b/Snakefile.test
@@ -6,6 +6,8 @@ chordbook="muj_novy_zpevnik"
 #cover_front="obalka_predni.pdf"
 #cover_back="obalka_zadni.pdf"
 
+options=["SINGLES"]
+
 songs=[
     ("./tp-songs/03_zahranicni/Beatles____Let_it_be.tex", 5), # 5 = transpozice o 5 půltónů nahoru
     "./tp-songs/03_zahranicni/Beatles____Love_me_do.tex",
@@ -15,5 +17,4 @@ include:"tpcb/snake_incl.py"
 
 rule all:
     input:
-        cb_pdf(),
-        singles
+        run()

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -184,8 +184,8 @@ rule copies:
 		os.path.join("tpcb","template.tex"),
 		os.path.join("tpcb","songbook.sty"),
 	output:
-		temp(os.path.join(cache_dir(),"template.tex")),
-		temp(os.path.join(cache_dir(),"songbook.sty")),
+		os.path.join(cache_dir(),"template.tex"),
+		os.path.join(cache_dir(),"songbook.sty"),
 	run:
 		shutil.copyfile(os.path.join("tpcb","template.tex"),os.path.join(cache_dir(),"template.tex"))
 		shutil.copyfile(os.path.join("tpcb","songbook.sty"),os.path.join(cache_dir(),"songbook.sty"))
@@ -214,7 +214,7 @@ rule song_pdf:
 		os.path.join(cache_dir(),"template.tex"),
 		os.path.join(cache_dir(),"songbook.sty"),
 	output:
-		temp(os.path.join(cache_dir(),"_single_{song}.tex")),
+		os.path.join(cache_dir(),"_single_{song}.tex"),
 		temp(os.path.join(cache_dir(),"_single_{song}.log")),
 		temp(os.path.join(cache_dir(),"_single_{song}.out")),
 		temp(os.path.join(cache_dir(),"_single_{song}.aux")),

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -68,6 +68,17 @@ def call_xelatex(xelatex_file):
 			)
 	shell(xelatex_command)
 
+def run():
+	if not "SINGLESONLY" in options:
+		outputs = [ cb_pdf() ]
+	else:
+		outputs = []
+
+	if "SINGLES" in options or "SINGLESONLY" in options:
+		outputs.extend([ sc_pdf(x) for x in songs_dict.keys() ])
+	
+	return outputs
+
 #####
 ##### SETTING ALL PARAMS
 #####
@@ -97,8 +108,6 @@ for x in songs:
 songs_dict = OrderedDict([ (x[2],x[0]) for x in songs_prop ])
 
 songs_dict_transp = OrderedDict([ (x[2],x[1]) for x in songs_prop ])
-
-singles = [ sc_pdf(x) for x in songs_dict.keys() ]
 
 # zpevnik.tex => zpevnik.pdf
 rule main_pdf:

--- a/tpcb/snake_incl.py
+++ b/tpcb/snake_incl.py
@@ -31,12 +31,14 @@ def cb_ind():
 def sc_tex(song):
 	return os.path.join(cache_dir(),"0_{}.tex".format(song))
 
-def sc_pdf(song):
-	try:
-		return os.path.join(singles_dir,"{}.pdf".format(song))
-	except NameError:
-		return "{}.pdf".format(song)
+#def sc_pdf(song):
+#	try:
+#		return os.path.join(singles_dir,"{}.pdf".format(song))
+#	except NameError:
+#		return "{}.pdf".format(song)
 
+def sc_pdf(song):
+	return os.path.join(cache_dir(),"_single_{}.pdf".format(song))
 
 def ind_pisne():
 	return cb_ind()+"_pisne"
@@ -71,15 +73,6 @@ def call_xelatex(xelatex_file):
 #####
 
 try:
-	LHEAD=left_page_head
-except NameError:
-	LHEAD=""
-try:
-	RHEAD=right_page_head
-except NameError:
-	RHEAD=""
-
-try:
 	options=options
 except NameError:
 	options=[]
@@ -101,17 +94,9 @@ for x in songs:
 			os.path.basename(x[0]).replace(".tex","")
 		))
 
-songs_dict = OrderedDict(
-				[
-					(x[2],x[0]) for x in songs_prop
-				]
-			)
+songs_dict = OrderedDict([ (x[2],x[0]) for x in songs_prop ])
 
-songs_dict_transp = OrderedDict(
-				[
-					(x[2],x[1]) for x in songs_prop
-				]
-			)
+songs_dict_transp = OrderedDict([ (x[2],x[1]) for x in songs_prop ])
 
 singles = [ sc_pdf(x) for x in songs_dict.keys() ]
 
@@ -119,15 +104,18 @@ singles = [ sc_pdf(x) for x in songs_dict.keys() ]
 rule main_pdf:
 	output:
 		cb_pdf(),
+		temp(cb_tex().replace(".tex",".pdf")),
+		temp(cb_tex().replace(".tex",".log")),
+		temp(cb_tex().replace(".tex",".out")),
+		temp(idx_pisne()),
+		temp(idx_interpreti()),
 		ind_pisne(),
-		idx_pisne(),
-		idx_pisne()+".old",
 		ind_interpreti(),
-		idx_interpreti(),
+		temp(ind_pisne()+".old"),
 	input:
 		cb_tex(),
 		[sc_tex(x) for x in songs_dict.keys()],
-		workflow.snakefile,
+		os.path.join(cache_dir(),"_list.tex"),
 		os.path.join(cache_dir(),"template.tex"),
 		os.path.join(cache_dir(),"songbook.sty"),
 	run:
@@ -135,28 +123,22 @@ rule main_pdf:
 			call_xelatex(input[0])
 			udelejRejstrik(idx_pisne(),ind_pisne()); 
 			udelejRejstrik(idx_interpreti(),ind_interpreti());
-			shutil.copyfile(idx_pisne(),idx_pisne()+".old")
-		else:
-			shutil.copyfile(idx_pisne(),idx_pisne()+".old")
-			udelejRejstrik(idx_pisne(),ind_pisne()); 
-			udelejRejstrik(idx_interpreti(),ind_interpreti());
 
 		call_xelatex(input[0])
 
-		if not filecmp.cmp(idx_pisne(),idx_pisne()+".old"):
-			udelejRejstrik(idx_pisne(),ind_pisne()); 
-			udelejRejstrik(idx_interpreti(),ind_interpreti());
+		shutil.copyfile(ind_pisne(),ind_pisne()+".old")
+		udelejRejstrik(idx_pisne(),ind_pisne()); 
+		udelejRejstrik(idx_interpreti(),ind_interpreti());
+
+		if not filecmp.cmp(ind_pisne(),ind_pisne()+".old"):
 			call_xelatex(input[0])
 
-		main_pdf=cb_tex().replace(".tex",".pdf")
-		shutil.copyfile(main_pdf,output[0])
+		shutil.copyfile(output[1],output[0])
 
-# cache/pisen.tex, cache/pisen2.tex => zpevnik.tex
+# seznam => zpevnik.tex
 rule main_tex:
 	input:
 		workflow.snakefile,
-		[sc_tex(x) for x in songs_dict.keys()],
-		os.path.join("tpcb","template.tex"),
 	output:
 		cb_tex(),
 		os.path.join(cache_dir(),"_list.tex"),
@@ -172,8 +154,14 @@ rule main_tex:
 		with open(output[0],"w+",encoding="utf-8") as f:
 			main_tex = "\\def\\thelist{_list.tex}\n"
 			main_tex += os.linesep.join(["\\def\\{}{{}}".format(x) for x in options])+"\n"
-			main_tex += "\\def\\RHEAD{{{}}}\n".format(RHEAD)
-			main_tex += "\\def\\LHEAD{{{}}}\n".format(LHEAD)
+			try:
+				main_tex += "\\def\\RHEAD{{{}}}\n".format(right_page_head)
+			except NameError:
+				pass
+			try:
+				main_tex += "\\def\\LHEAD{{{}}}\n".format(left_page_head)
+			except NameError:
+				pass
 			try:
 				main_tex += "\\def\\FRONTCOVER{{{}}}\n".format(os.path.basename(cover_front))
 			except NameError:
@@ -196,8 +184,8 @@ rule copies:
 		os.path.join("tpcb","template.tex"),
 		os.path.join("tpcb","songbook.sty"),
 	output:
-		os.path.join(cache_dir(),"template.tex"),
-		os.path.join(cache_dir(),"songbook.sty"),
+		temp(os.path.join(cache_dir(),"template.tex")),
+		temp(os.path.join(cache_dir(),"songbook.sty")),
 	run:
 		shutil.copyfile(os.path.join("tpcb","template.tex"),os.path.join(cache_dir(),"template.tex"))
 		shutil.copyfile(os.path.join("tpcb","songbook.sty"),os.path.join(cache_dir(),"songbook.sty"))
@@ -219,18 +207,23 @@ rule song_tex:
 		with open(output[0],"w+",encoding="utf-8") as f:
 			f.write(song2)
 
+# cache/pisen.tex => cache/_single_pisen.pdf
 rule song_pdf:
 	input:
 		sc_tex("{song}"),
 		os.path.join(cache_dir(),"template.tex"),
 		os.path.join(cache_dir(),"songbook.sty"),
 	output:
-		os.path.join(cache_dir(),"_single_{song}.tex"),
-		sc_pdf("{song,[^_].*}"),
+		temp(os.path.join(cache_dir(),"_single_{song}.tex")),
+		temp(os.path.join(cache_dir(),"_single_{song}.log")),
+		temp(os.path.join(cache_dir(),"_single_{song}.out")),
+		temp(os.path.join(cache_dir(),"_single_{song}.aux")),
+		#sc_pdf("{song,[^_].*}"),
+		sc_pdf("{song}")
 	run:
 		with open(output[0],"w+",encoding="utf-8") as f:
 			main_tex = "\\def\\thelist{{{}}}\n".format(os.path.basename(input[0]))
 			main_tex += "\\def\\SINGLE{}\n\\input{template.tex}\n"
 			f.write(main_tex)
 		call_xelatex(output[0])
-		shutil.copyfile(output[0].replace(".tex",".pdf"),output[1])
+		#shutil.copyfile(output[0].replace(".tex",".pdf"),output[1])

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -31,8 +31,8 @@
   \pagestyle{empty}
 \else
   \pagestyle{fancy}
-  \fancyhead[RE]{\RHEAD}
-  \fancyhead[LO]{\LHEAD}
+  \fancyhead[RE]{\ifdefined\RHEAD\RHEAD\fi}
+  \fancyhead[LO]{\ifdefined\LHEAD\LHEAD\fi}
   \fancyhead[RO]{}
   \fancyhead[LE]{}
   \fancyfoot{}


### PR DESCRIPTION
- označení souborů nepotřebných pro opětovný překlad jako `temp` (po úspěšném překladu se automaticky smažou, až už nejsou potřeba)
- totéž pro soubory, jejichž generace nic nestojí a zabírají zbytečně místo (jen kopie z `tpcb`)
- `_single_XXX.pdf` nechat v `cache_dir()` (fixes #28)
- odstranění závislostí, které se nepoužívají
- zjednodušení logiky kolem `.idx`, `.ind` a `.idx.old`, mezi překlady stačí zachovat `.ind`
- obecný cleanup
