### PR TITLE
Geometry

### DIFF
--- a/tpcb/songbook.sty
+++ b/tpcb/songbook.sty
@@ -81,12 +81,6 @@
 \newif\ifPrintAllSongs  \PrintAllSongsfalse
 \newif\ifSamepageMode   \SamepageModefalse
 \newif\ifSongEject      \SongEjecttrue
-\newif\ifSBpaperAfour   \SBpaperAfourfalse
-\newif\ifSBpaperAfive   \SBpaperAfivefalse
-\newif\ifSBpaperBfive   \SBpaperBfivefalse
-\newif\ifSBpaperLtr     \SBpaperLtrfalse
-\newif\ifSBpaperLgl     \SBpaperLglfalse
-\newif\ifSBpaperExc     \SBpaperExcfalse
 %%========================================================
 %%                      F O N T S                        %
 %%========================================================
@@ -155,19 +149,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%=======================================================%
-%%          P A P E R S I Z E   O P T I O N S            %
-%%=======================================================%
-\DeclareOption{a4paper}{% Paper size: 210mm x 297mm
-  \SBpaperAfourtrue
-  \SBpaperAfivefalse
-  \SBpaperBfivefalse
-  \SBpaperLtrfalse
-  \SBpaperLglfalse
-  \SBpaperExcfalse
-}
-
-
-%%=======================================================%
 %%         C O M P A C T S O N G   O P T I O N           %
 %%=======================================================%
 %\DeclareOption{compactsong}{%
@@ -196,21 +177,6 @@
   \NotWordsOnlytrue
   \SongEjecttrue
 
-  \voffset=-1.00in
-  \hoffset=-1.00in
-
-    \topmargin=0.5in
-    \headheight=0.21in
-    \headsep=0.2in
-    \textheight=10.0in
-    \footskip=0.19in
-    %
-    \oddsidemargin=0.618in
-    \evensidemargin=1.4in
-    \textwidth=6.25in
-    \marginparsep=0.2in
-    \marginparwidth=0.8in
-
   \raggedbottom
 
 }
@@ -223,7 +189,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\ExecuteOptions{a4paper}
 \ProcessOptions
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -6,6 +6,9 @@
 \documentclass[11pt,a4paper%
   \ifdefined\ONESIDE,oneside\fi%
 ]{book}
+\usepackage[textwidth=6.25in,textheight=10in,
+  outer=1.4in,top=0.91in,
+  headheight=0.51in,headsep=0.2in]{geometry}
 
 \usepackage{fontspec}
 \usepackage{index}
@@ -81,7 +84,7 @@
 % Makra pro vkládání celých PDF (přední a zadní obálka)
 \newcounter{insertCur}
 \newcounter{insertTotal}
-\newcommand\insertPage[2]{\shipout\vbox to 29.7cm{\vss\hbox to 21cm{\hss{\XeTeXpdffile #1 page #2 }\hss}\vss}\stepcounter{page}}
+\newcommand\insertPage[2]{{\hoffset=-1in\voffset=-1in\shipout\vbox to 29.7cm{\vss\hbox to 21cm{\hss{\XeTeXpdffile #1 page #2 }\hss}\vss}\stepcounter{page}}}
 \newcommand\countPages[1]{\setcounter{insertTotal}{\XeTeXpdfpagecount #1 }}
 \newcommand\insertPDF[1]{\countPages{#1}\stepcounter{insertTotal}
   \forloop{insertCur}{1}{\value{insertCur} < \value{insertTotal}}{%

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -7,7 +7,7 @@
   \ifdefined\ONESIDE,oneside\fi%
 ]{book}
 \usepackage[textwidth=6.25in,textheight=10in,
-  outer=1.4in,top=0.91in,
+  inner=1.4in,top=0.91in,
   headheight=0.51in,headsep=0.2in]{geometry}
 
 \usepackage{fontspec}
@@ -35,10 +35,10 @@
   \pagestyle{empty}
 \else
   \pagestyle{fancy}
-  \fancyhead[RE]{\ifdefined\RHEAD\RHEAD\fi}
-  \fancyhead[LO]{\ifdefined\LHEAD\LHEAD\fi}
-  \fancyhead[RO]{}
-  \fancyhead[LE]{}
+  \fancyhead[RO]{\ifdefined\RHEAD\RHEAD\fi}
+  \fancyhead[LE]{\ifdefined\LHEAD\LHEAD\fi}
+  \fancyhead[RE]{}
+  \fancyhead[LO]{}
   \fancyfoot{}
 \fi
 
@@ -108,7 +108,7 @@
       \edef\nerrors{\the\errors^^J\space\space\the\lastsong}
       \global\errors\expandafter{\nerrors}
     \else\ifnum\value{numpages}>1
-      \unless\ifodd\value{page}
+      \ifodd\value{page}
         \message{^^J^^J\space\space Píseň "\the\lastsong" začala na pravé a skončila na levé.^^J^^J}
         \stepcounter{errorCount}
         \edef\nerrors{\the\errors^^J\space\space\the\lastsong}
@@ -130,9 +130,6 @@
   \twocolumn
 \fi
 
-% Stránky je potřeba počítat od sudé (pravé)
-\setcounter{page}{0}
-
 % Přední obálka
 \ifdefined\FRONTCOVER
   \insertPDF{\FRONTCOVER}
@@ -140,7 +137,7 @@
     % Pokud přední obálka existuje, vloží ji a jednu nebo dvě volné strany za 
     % ni (mimo ONESIDE), aby první stránka zpěvníku vyšla napravo
     \emptyPage
-    \ifodd\value{page}\emptyPage\fi
+    \unless\ifodd\value{page}\emptyPage\fi
     % Pro budoucí \twopagecheck v \zs první písničky
     \setcounter{lastpage}{\value{page}}
   \fi
@@ -178,7 +175,7 @@
     \emptyPage
     \countPages{\BACKCOVER}
     \addtocounter{insertTotal}{\value{page}}
-    \ifodd\value{insertTotal}\emptyPage\fi
+    \unless\ifodd\value{insertTotal}\emptyPage\fi
   \fi
   \insertPDF{\BACKCOVER}
 \fi


### PR DESCRIPTION
Geometrie stránky byla nastavovaná v `songbook.sty`, ale nějakým způsobem, ze kterého zbylo už jen torzo několika pevných příkazů pro A4 a spousta nepoužívaných `if`. Vyčistil jsem to a dal tu roli balíčku `geometry`, který to má v popisu práce.

Taky jsem vyhodil jeden ošklivý hack, který (nejspíš v důsledku předchozího) přehazoval význam levé a pravé stránky tím, že první očísloval 0.

Rozměry rozložení jsem použil identické a v obou případech zkontroloval, že dopad na výsledek překladu by měl být nulový.