### PR TITLE
Index

### DIFF
--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -22,6 +22,22 @@
   \newindex[cisloPisne]{interpreti}{idx_interpreti}{ind_interpreti}{Rejstřík interpretů}
 \fi
 
+% https://tex.stackexchange.com/a/132415/16770
+\makeatletter
+\newif\iffirst@subitem
+\def\@idxitem{%
+  \par\hangindent40\p@
+  \first@subitemtrue
+}
+\def\subitem{%
+  \par\hangindent40\p@
+  \iffirst@subitem
+    \nobreak
+    \first@subitemfalse
+  \fi
+  \hspace*{20\p@}}
+\makeatother
+
 \selectlanguage{czech}
 
 \newcounter{cisloPisne}

--- a/tpcb/template.tex
+++ b/tpcb/template.tex
@@ -36,6 +36,15 @@
     \first@subitemfalse
   \fi
   \hspace*{20\p@}}
+
+\def\@makeschapterhead#1{%
+  \vspace*{20\p@}%
+  {\parindent \z@ \raggedright
+    \normalfont
+    \interlinepenalty\@M
+    \huge \bf\sf  #1\par\nobreak
+    \vskip 20\p@
+  }}
 \makeatother
 
 \selectlanguage{czech}


### PR DESCRIPTION
Záhlaví rejstříků mi už dlouho pilo krev. Computer Modern je už tak dost těžké písmo a v `\Huge\bfseries` by se snad vůbec nemělo používat. Navíc ty titulky zabíraly velké množství prostoru, nekonzistentní se stylem zbytku výtisku. Zmenšil jsem odstup před a za na 20pt (z 50, resp. 40) a písmo použil stejné bezpatkové, jakým jsou názvy písniček.

![](https://user-images.githubusercontent.com/11852447/80103387-7393fb80-8574-11ea-800a-390b98812fd8.png)

V prvním commitu řeším ještě poměrně běžnou situaci, kdy se v rejstříku interpretů rozdělil autor a jeho písničky zlomem sloupce / stránky. Vypadalo to nevzhledně a ubíralo z přehlednosti.

Obojí trochu ovlivní existující zpěvníky, ale snad jen pozitivně (možná o stránku méně). Rozhodně nepovede k přelámání nebo přečíslování.